### PR TITLE
Merge changes from internal repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.4
+
+* Unknown enum values are ignored when parsing JSON, instead of throwing an
+  exception.
+
 ## 0.5.3+2
 
 * Resolved a strong-mode error.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.5.3+2
+version: 0.5.4
 author: Dart Team <misc@dartlang.org>
 description: Runtime library for protocol buffers support.
 homepage: https://github.com/dart-lang/protobuf

--- a/test/mock_util.dart
+++ b/test/mock_util.dart
@@ -33,7 +33,7 @@ abstract class MockMessage extends GeneratedMessage {
 
   List<int> get int32s => $_get(3, 4, null);
 
-  Int64 get int64 => $_get(4, 5, 0);
+  Int64 get int64 => $_get(4, 5, new Int64(0));
   set int64(x) => setField(5, x);
 
   clone() {


### PR DESCRIPTION
Parsing protobuf from JSON now ignores unknown enum values instead of
throwing an exception.

The behavior is still different from parsing a message from a serialized
byte string, because we do not store the (tag, unknown enum value) pair
in the UnknownFieldSet. JSON parsing currently discards unknown field
tags, so it makes sense to also discard the unknown enum values.