### PR TITLE
CodedBufferWriter: Support writing to preallocated buffer. (#69)

### DIFF
--- a/lib/src/protobuf/coded_buffer_writer.dart
+++ b/lib/src/protobuf/coded_buffer_writer.dart
@@ -8,9 +8,7 @@ class CodedBufferWriter {
 
   final List<TypedData> _output = <TypedData>[];
   int _runningSizeInBytes = 0;
-  int get lengthInBytes {
-    return _runningSizeInBytes;
-  }
+  int get lengthInBytes => _runningSizeInBytes;
 
   static final _WRITE_FUNCTION_MAP = _makeWriteFunctionMap();
 

--- a/lib/src/protobuf/coded_buffer_writer.dart
+++ b/lib/src/protobuf/coded_buffer_writer.dart
@@ -8,6 +8,9 @@ class CodedBufferWriter {
 
   final List<TypedData> _output = <TypedData>[];
   int _runningSizeInBytes = 0;
+  int get lengthInBytes {
+    return _runningSizeInBytes;
+  }
 
   static final _WRITE_FUNCTION_MAP = _makeWriteFunctionMap();
 
@@ -204,13 +207,23 @@ class CodedBufferWriter {
 
   Uint8List toBuffer() {
     Uint8List result = new Uint8List(_runningSizeInBytes);
-    int position = 0;
+    writeTo(result);
+    return result;
+  }
+
+  /// Serializes everything written to this writer so far to [buffer], starting
+  /// from [offset] in [buffer]. Returns `true` on success.
+  bool writeTo(List<int> buffer, [int offset=0]) {
+    if (buffer.length - offset < _runningSizeInBytes) {
+      return false;
+    }
+    int position = offset;
     for (var typedData in _output) {
       Uint8List asBytes = new Uint8List.view(
           typedData.buffer, typedData.offsetInBytes, typedData.lengthInBytes);
-      result.setRange(position, position + typedData.lengthInBytes, asBytes);
+      buffer.setRange(position, position + typedData.lengthInBytes, asBytes);
       position += typedData.lengthInBytes;
     }
-    return result;
+    return true;
   }
 }

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -5,6 +5,7 @@
 
 library pb_codec_tests;
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:protobuf/protobuf.dart';
@@ -750,5 +751,22 @@ void main() {
         expect64(0xffffffff, 0xffffffff));
     expect(readUint64([180, 222, 252, 255, 255, 255, 255, 255, 255, 1]),
         expect64(0xffff2f34, 0xffffffff));
+  });
+
+  test('testWriteTo', () {
+    var writer = new CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
+    expect(writer.lengthInBytes, 3);
+    var rng = new Random();
+    var a = rng.nextInt(256);
+    var b = rng.nextInt(256);
+    var buffer = new Uint8List(5);
+    buffer[0] = a;
+    buffer[4] = b;
+    var expected = writer.toBuffer();
+    expect(writer.writeTo(buffer, 1), isTrue);
+    expect(buffer[0], a);
+    expect(buffer[4], b);
+    expect(buffer.sublist(1, 4), expected);
+    expect(writer.writeTo(buffer, 3), isFalse);
   });
 }

--- a/test/codec_test.dart
+++ b/test/codec_test.dart
@@ -5,7 +5,6 @@
 
 library pb_codec_tests;
 
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:protobuf/protobuf.dart';
@@ -756,16 +755,13 @@ void main() {
   test('testWriteTo', () {
     var writer = new CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
     expect(writer.lengthInBytes, 3);
-    var rng = new Random();
-    var a = rng.nextInt(256);
-    var b = rng.nextInt(256);
     var buffer = new Uint8List(5);
-    buffer[0] = a;
-    buffer[4] = b;
+    buffer[0] = 0x55;
+    buffer[4] = 0xAA;
     var expected = writer.toBuffer();
     expect(writer.writeTo(buffer, 1), isTrue);
-    expect(buffer[0], a);
-    expect(buffer[4], b);
+    expect(buffer[0], 0x55);
+    expect(buffer[4], 0xAA);
     expect(buffer.sublist(1, 4), expected);
     expect(writer.writeTo(buffer, 3), isFalse);
   });


### PR DESCRIPTION
This will help reduce the number of allocation and copying when the
serialized message is just part of a bigger buffer.