### PR TITLE
Add type inference for _inRange

### DIFF
--- a/lib/src/protobuf/field_error.dart
+++ b/lib/src/protobuf/field_error.dart
@@ -181,12 +181,11 @@ ArgumentError _createFieldTypeError(val, String wantedType) =>
 RangeError _createFieldRangeError(val, String wantedType) =>
     new RangeError('Value ($val) is not ${wantedType}');
 
-bool _inRange<T extends num>(T min, T value, T max) =>
-    (min <= value) && (value <= max);
+bool _isSigned32(int value) => (-2147483648 <= value) && (value <= 2147483647);
 
-bool _isSigned32(int value) => _inRange(-2147483648, value, 2147483647);
-bool _isUnsigned32(int value) => _inRange(0, value, 4294967295);
+bool _isUnsigned32(int value) => (0 <= value) && (value <= 4294967295);
+
 bool _isFloat32(double value) =>
     value.isNaN ||
     value.isInfinite ||
-    _inRange(-3.4028234663852886E38, value, 3.4028234663852886E38);
+    (-3.4028234663852886E38 <= value) && (value <= 3.4028234663852886E38);

--- a/lib/src/protobuf/field_error.dart
+++ b/lib/src/protobuf/field_error.dart
@@ -181,8 +181,8 @@ ArgumentError _createFieldTypeError(val, String wantedType) =>
 RangeError _createFieldRangeError(val, String wantedType) =>
     new RangeError('Value ($val) is not ${wantedType}');
 
-bool _inRange<T extends num>(T min, T value, T max)
-  => (min <= value) && (value <= max);
+bool _inRange<T extends num>(T min, T value, T max) =>
+    (min <= value) && (value <= max);
 
 bool _isSigned32(int value) => _inRange(-2147483648, value, 2147483647);
 bool _isUnsigned32(int value) => _inRange(0, value, 4294967295);

--- a/lib/src/protobuf/field_error.dart
+++ b/lib/src/protobuf/field_error.dart
@@ -181,7 +181,8 @@ ArgumentError _createFieldTypeError(val, String wantedType) =>
 RangeError _createFieldRangeError(val, String wantedType) =>
     new RangeError('Value ($val) is not ${wantedType}');
 
-bool _inRange(min, value, max) => (min <= value) && (value <= max);
+bool _inRange<T extends num>(T min, T value, T max)
+  => (min <= value) && (value <= max);
 
 bool _isSigned32(int value) => _inRange(-2147483648, value, 2147483647);
 bool _isUnsigned32(int value) => _inRange(0, value, 4294967295);


### PR DESCRIPTION
For dart2js builds this doesn't (yet) affect them, but for DDC builds
this is important as _inRange is usually one of the most called methods
and the lack of type annotations make it so all these are dynamic
unnecessarily.

Since the only two usages of this are private and are either int or
double then <T extends num> is a correct restriction.

DDC with this infers either 'int' or 'double' depending on the case.