### PR TITLE
Rewrite CodedBufferWriter to speed it up.

### DIFF
--- a/benchmarks/compile-js.sh
+++ b/benchmarks/compile-js.sh
@@ -5,9 +5,12 @@
 
 # Compile benchmark_js to JavaScript using dart2js.
 
-mkdir -p temp
+SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+OUTPUT_DIR="${SCRIPT_DIR}/temp"
+
+mkdir -p "${OUTPUT_DIR}"
 
 dart2js --trust-type-annotations        \
         --trust-primitives              \
-        -o benchmarks/temp/benchmark.js \
-        benchmarks/benchmark_js.dart
+        -o "${OUTPUT_DIR}"/benchmark.js \
+        "${SCRIPT_DIR}"/benchmark_js.dart

--- a/benchmarks/compile-protos.sh
+++ b/benchmarks/compile-protos.sh
@@ -25,10 +25,13 @@ PROTOS=(
   "datasets/google_message4/benchmark_message4_3.proto"
 )
 
-mkdir -p benchmarks/temp
+SCRIPT_DIR=$(dirname "${BASH_SOURCE}")
+OUTPUT_DIR="${SCRIPT_DIR}/temp"
+
+mkdir -p ${OUTPUT_DIR}
 
 for proto in ${PROTOS[@]}
 do
   echo "PROTOC ${proto}"
-  protoc --dart_out=temp $proto
+  protoc -I"${SCRIPT_DIR}" --dart_out="${OUTPUT_DIR}" "${SCRIPT_DIR}/$proto"
 done

--- a/benchmarks/d8.dart
+++ b/benchmarks/d8.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// Wrapper over d8 specific helper methods.
-
+/// Wrapper over d8 specific helper methods.
 @JS()
 library d8;
 


### PR DESCRIPTION
The previous implementation was allocating two typed arrays per each written
varint and was using maps to lookup writer functions and wire types for
different field types.

After the rewrite we instead maintain two arrays:

* an array of Uint8List chunks, which serve as temporary output buffers for
small data (ints and floats);
* an array of splices which describes additional bytes to splice in-between
bytes written into chunks.

Note that it is impossible to serialize protobufs in a purely streaming fashion
(using a single continuous output buffer) because some values are serialized
in length-deliminted format - meaning that they are represented as a
varint encoded length followed by the specified number of bytes of data. This
in turn means that we sometimes have to write data before we know how
much space needs to be reseved for the length of the data.

Additionally in some cases value is a raw sequence of bytes that needs to be
written as-is into the output buffer - in this case it does not make sense to
first copy this data into temporary buffer and then copy it again.

These two considerations lead to the splice based design described above.