### PR TITLE
Fix Dart 2 related issue for strong types and default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,13 @@
 language: dart
-sudo: false
 
 dart:
 - dev
-# - stable
 
 dart_task:
 - test: --platform vm
-- test: --platform firefox
-
-# Only run one instance of the formatter and the analyzer, rather than running
-# them against each Dart version.
-matrix:
-  include:
-  - dart: dev # TODO: stable
-    dart_task: dartfmt
-  - dart: dev
-    dart_task: dartanalyzer
+- test: --platform chrome
+- dartfmt
+- dartanalyzer
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/lib/src/protobuf/field_info.dart
+++ b/lib/src/protobuf/field_info.dart
@@ -69,7 +69,7 @@ class FieldInfo<T> {
   /// Returns a read-only default value for a field.
   /// (Unlike getField, doesn't create a repeated field.)
   get readonlyDefault {
-    if (isRepeated) return const [];
+    if (isRepeated) return new List<T>();
     return makeDefault();
   }
 

--- a/lib/src/protobuf/field_info.dart
+++ b/lib/src/protobuf/field_info.dart
@@ -69,7 +69,7 @@ class FieldInfo<T> {
   /// Returns a read-only default value for a field.
   /// (Unlike getField, doesn't create a repeated field.)
   get readonlyDefault {
-    if (isRepeated) return new List<T>();
+    if (isRepeated) return const <Null>[];
     return makeDefault();
   }
 

--- a/lib/src/protobuf/field_set.dart
+++ b/lib/src/protobuf/field_set.dart
@@ -117,7 +117,7 @@ class _FieldSet {
 
   _getDefault(FieldInfo fi) {
     if (!fi.isRepeated) return fi.makeDefault();
-    if (_isReadOnly) return const [];
+    if (_isReadOnly) return fi.readonlyDefault;
 
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:


### PR DESCRIPTION
When a proto field is not set this porobuf lib is attempting to get a
default value. If it happens to be a collection like a List the type
would be List<dynamic> so when using Dart 2, at runtime you might
get a casting exception:
"type 'List<dynamic>' is not a subtype of type 'List<int>

Related to this issue:
https://github.com/dart-lang/protobuf/issues/94