### PR TITLE
Prepare for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 0.9.0
+
+* Breaking change: Changed signature of `CodedBufferWriter.writeTo` to require
+  `Uint8List` for performance.
+* More Dart 2 fixes.
+
 ## 0.8.0
 
 * Breaking change: Added generics to RpcClient.invoke(). Proto files must be
   rebuilt using Dart protoc_plugin version 0.8.0 or newer to match.
 * Dart 2 fixes.
-* Breaking change: Changed signature of `CodedBufferWriter.writeTo` to require
-`Uint8List` for performance.
 
 ## 0.7.2+1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.8.1
+version: 0.9.0
 author: Dart Team <misc@dartlang.org>
 description: Runtime library for protocol buffers support.
 homepage: https://github.com/dart-lang/protobuf


### PR DESCRIPTION
Change to CodeBufferWriter.writeDo is a breaking change