### PR TITLE
Declare Dart 2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Dart SDK upper constraint raised to declare compatability with Dart 2.0 stable.
+
 ## 0.9.0
 
 * Breaking change: Changed signature of `CodedBufferWriter.writeTo` to require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.0
+## 0.9.0+1
 
 * Dart SDK upper constraint raised to declare compatability with Dart 2.0 stable.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: protobuf
-version: 0.9.0
+version: 0.10.0
 author: Dart Team <misc@dartlang.org>
 description: Runtime library for protocol buffers support.
 homepage: https://github.com/dart-lang/protobuf
 environment:
-  sdk: '>=2.0.0-dev.17.0 <2.0.0'
+  sdk: '>=2.0.0-dev.17.0 <3.0.0'
 dependencies:
   fixnum: '>=0.9.0 <0.11.0'
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.10.0
+version: 0.9.0+1
 author: Dart Team <misc@dartlang.org>
 description: Runtime library for protocol buffers support.
 homepage: https://github.com/dart-lang/protobuf


### PR DESCRIPTION
@kevmoo can you review if this is how we generally want to update these?

We tested that this works fine with a 2.0 stable build (with the grpc package; except that it still fails as the deps of this package are not updated: https://gist.github.com/sortie/3f1a42b921ee304ea12514076670d223)