### PR TITLE
Fix problems in CodedBufferWriter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.1
+
+* Fix problem with encoding negative enum values.
+* Fix problem with encoding byte arrays.
+
 ## 0.9.0+1
 
 * Dart SDK upper constraint raised to declare compatability with Dart 2.0 stable.

--- a/lib/src/protobuf/coded_buffer_writer.dart
+++ b/lib/src/protobuf/coded_buffer_writer.dart
@@ -318,7 +318,7 @@ class CodedBufferWriter {
         break;
       case PbFieldType._BYTES_BIT:
         _writeBytesNoTag(
-            value is TypedData ? value : Uint8List.fromList(value));
+            value is TypedData ? value : new Uint8List.fromList(value));
         break;
       case PbFieldType._STRING_BIT:
         _writeBytesNoTag(_utf8.encode(value));

--- a/lib/src/protobuf/coded_buffer_writer.dart
+++ b/lib/src/protobuf/coded_buffer_writer.dart
@@ -317,7 +317,8 @@ class CodedBufferWriter {
         _writeVarint32(value ? 1 : 0);
         break;
       case PbFieldType._BYTES_BIT:
-        _writeBytesNoTag(value);
+        _writeBytesNoTag(
+            value is TypedData ? value : Uint8List.fromList(value));
         break;
       case PbFieldType._STRING_BIT:
         _writeBytesNoTag(_utf8.encode(value));
@@ -329,7 +330,7 @@ class CodedBufferWriter {
         _writeFloat(value);
         break;
       case PbFieldType._ENUM_BIT:
-        _writeVarint32(value.value);
+        _writeVarint32(value.value & 0xffffffff);
         break;
       case PbFieldType._GROUP_BIT:
         value.writeToCodedBufferWriter(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.9.0+1
+version: 0.9.1
 author: Dart Team <misc@dartlang.org>
 description: Runtime library for protocol buffers support.
 homepage: https://github.com/dart-lang/protobuf


### PR DESCRIPTION
These problems where revealed by the tests in dart-protoc-plugin when trying to update the dependency.

* Negative enum values where not encoded correctly.
* Fields with type "bytes" would crash the encoder.