### PR TITLE
Add type param to ProtobufEnum.initByValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.3
+
+* Added type argument to `ProtobufEnum.initByValue` which allows the return
+  value to be fully typed.
+
 ## 0.10.2
 
 * Added ProtobufEnum reserved names.

--- a/lib/src/protobuf/protobuf_enum.dart
+++ b/lib/src/protobuf/protobuf_enum.dart
@@ -37,12 +37,9 @@ class ProtobufEnum {
 
   /// Returns a Map for all of the [ProtobufEnum]s in [byIndex], mapping each
   /// [ProtobufEnum]'s [value] to the [ProtobufEnum].
-
-  // Cannot type return type as Map<int, ProtobufEnum> as it will be
-  // assigned to Map<int, subtype of ProtobufEnum>.
-  static Map<int, dynamic> initByValue(List<ProtobufEnum> byIndex) {
-    var byValue = new Map<int, dynamic>();
-    for (ProtobufEnum v in byIndex) {
+  static Map<int, T> initByValue<T extends ProtobufEnum>(List<T> byIndex) {
+    var byValue = new Map<int, T>();
+    for (T v in byIndex) {
       byValue[v.value] = v;
     }
     return byValue;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.10.3-dev
+version: 0.10.3
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.10.2
+version: 0.10.3-dev
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.


### PR DESCRIPTION
Will allow generated code to omit a runtime cast on `valueOf`