### PR TITLE
Remove unnecessary check in GeneratedMessage.$_getN

### DIFF
--- a/lib/src/protobuf/generated_message.dart
+++ b/lib/src/protobuf/generated_message.dart
@@ -315,9 +315,6 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   T $_getN<T>(int index) {
-    if (_fieldSet == null) {
-      throw new StateError('Unable to access $index in the proto message');
-    }
     return _fieldSet._$getN<T>(index);
   }
 


### PR DESCRIPTION
This makes `$_getN` follow the same pattern as the other `$_get`X methods.
It also prevents the lengthy error string from being inlined in some cases.