### PR TITLE
Sync changes from internal repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.4
+
+* Added separate getter for `BuilderInfo.qualifiedMessageName`.
+
 ## 0.10.3
 
 * Added type argument to `ProtobufEnum.initByValue` which allows the return

--- a/lib/src/protobuf/coded_buffer_reader.dart
+++ b/lib/src/protobuf/coded_buffer_reader.dart
@@ -17,8 +17,8 @@ class CodedBufferReader {
   final int _sizeLimit;
 
   CodedBufferReader(List<int> buffer,
-      {int recursionLimit: DEFAULT_RECURSION_LIMIT,
-      int sizeLimit: DEFAULT_SIZE_LIMIT})
+      {int recursionLimit = DEFAULT_RECURSION_LIMIT,
+      int sizeLimit = DEFAULT_SIZE_LIMIT})
       : _buffer = buffer is Uint8List ? buffer : new Uint8List(buffer.length)
           ..setRange(0, buffer.length, buffer),
         _recursionLimit = recursionLimit,

--- a/lib/src/protobuf/field_set.dart
+++ b/lib/src/protobuf/field_set.dart
@@ -63,7 +63,7 @@ class _FieldSet {
 
   // Metadata about multiple fields
 
-  String get _messageName => _meta.messageName;
+  String get _messageName => _meta.qualifiedMessageName;
   bool get _hasRequiredFields => _meta.hasRequiredFields;
 
   /// The FieldInfo for each non-extension field.

--- a/lib/src/protobuf/mixins/map_mixin.dart
+++ b/lib/src/protobuf/mixins/map_mixin.dart
@@ -32,7 +32,7 @@ abstract class PbMapMixin {
     var tag = getTagNumber(key as String);
     if (tag == null) {
       throw new ArgumentError(
-          "field '${key}' not found in ${info_.messageName}");
+          "field '${key}' not found in ${info_.qualifiedMessageName}");
     }
     setField(tag, val);
   }
@@ -45,6 +45,6 @@ abstract class PbMapMixin {
 
   remove(key) {
     throw new UnsupportedError(
-        "remove() not supported by ${info_.messageName}");
+        "remove() not supported by ${info_.qualifiedMessageName}");
   }
 }

--- a/lib/src/protobuf/pb_list.dart
+++ b/lib/src/protobuf/pb_list.dart
@@ -154,9 +154,9 @@ abstract class PbListBase<E> extends ListBase<E> {
   final List<E> _wrappedList;
   final CheckFunc<E> check;
 
-  PbListBase._(this._wrappedList, {this.check: _checkNotNull}) {}
+  PbListBase._(this._wrappedList, {this.check = _checkNotNull}) {}
 
-  PbListBase._noList({this.check: _checkNotNull}) : _wrappedList = <E>[] {
+  PbListBase._noList({this.check = _checkNotNull}) : _wrappedList = <E>[] {
     assert(check != null);
   }
 
@@ -222,7 +222,7 @@ abstract class PbListBase<E> extends ListBase<E> {
   bool any(bool test(E element)) => _wrappedList.any(test);
 
   /// Creates a [List] containing the elements of this [Iterable].
-  List<E> toList({bool growable: true}) =>
+  List<E> toList({bool growable = true}) =>
       _wrappedList.toList(growable: growable);
 
   /// Creates a [Set] containing the same elements as this iterable.

--- a/lib/src/protobuf/readonly_message.dart
+++ b/lib/src/protobuf/readonly_message.dart
@@ -53,7 +53,7 @@ abstract class ReadonlyMessageMixin {
       _readonly("setField");
 
   void _readonly(String methodName) {
-    String messageType = info_.messageName;
+    String messageType = info_.qualifiedMessageName;
     frozenMessageModificationHandler(messageType, methodName);
   }
 }

--- a/lib/src/protobuf/unpack.dart
+++ b/lib/src/protobuf/unpack.dart
@@ -21,7 +21,7 @@ void unpackIntoHelper<T extends GeneratedMessage>(
   //   in the type URL, for example "foo.bar.com/x/y.z" will yield type
   //   name "y.z".
   if (!canUnpackIntoHelper(instance, typeUrl)) {
-    String typeName = instance.info_.messageName;
+    String typeName = instance.info_.qualifiedMessageName;
     throw new InvalidProtocolBufferException.wrongAnyMessage(
         _typeNameFromUrl(typeUrl), typeName);
   }
@@ -33,7 +33,7 @@ void unpackIntoHelper<T extends GeneratedMessage>(
 ///
 /// This is a helper method for `Any.canUnpackInto`.
 bool canUnpackIntoHelper(GeneratedMessage instance, String typeUrl) {
-  return instance.info_.messageName == _typeNameFromUrl(typeUrl);
+  return instance.info_.qualifiedMessageName == _typeNameFromUrl(typeUrl);
 }
 
 String _typeNameFromUrl(String typeUrl) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.10.3
+version: 0.10.4
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.

--- a/test/builder_info_test.dart
+++ b/test/builder_info_test.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:protobuf/protobuf.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('className', () {
+    final qualifiedmessageName = 'proto.test.TestMessage';
+    final expectedMessageName = 'TestMessage';
+    test('truncates qualifiedMessageName containing dots', () {
+      final info = new BuilderInfo(qualifiedmessageName);
+      expect(info.messageName, expectedMessageName);
+    });
+
+    test('uses qualifiedMessageName if it contains no dots', () {
+      final info = new BuilderInfo(expectedMessageName);
+      expect(info.messageName, expectedMessageName);
+    });
+  });
+}


### PR DESCRIPTION
Namely, the last major external change (support for Any proto) caused a large breakage internally because of the new behavior of `BuilderInfo.messageName`. This getter has been reverted back to its original behavior, and a new `BuilderInfo.qualifiedMessageName` has been introduced.