### PR TITLE
Ensure getExtension works after freeze.

### DIFF
--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -249,10 +249,9 @@ abstract class GeneratedMessage {
   /// Returns the value of [extension].
   ///
   /// If not set, returns the extension's default value.
-  getExtension(Extension extension) {
-    if (_fieldSet._isReadOnly) return extension.readonlyDefault;
-    return _fieldSet._ensureExtensions()._getFieldOrDefault(extension);
-  }
+  getExtension(Extension extension) =>
+      _fieldSet._extensions?._getFieldOrNull(extension) ??
+      extension.readonlyDefault;
 
   /// Returns the value of the field associated with [tagNumber], or the
   /// default value if it is not set.

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -40,6 +40,13 @@ void main() {
     assertExtensionsClear(new TestAllExtensions());
   });
 
+  test('can read after freeze', () {
+    TestAllExtensions message = new TestAllExtensions();
+    setAllExtensions(message);
+    message.freeze();
+    assertAllExtensionsSet(message);
+  });
+
   // void testExtensionReflectionGetters() {} // UNSUPPORTED -- reflection
   // void testExtensionReflectionSetters() {} // UNSUPPORTED -- reflection
   // void testExtensionReflectionSettersRejectNull() {} // UNSUPPORTED


### PR DESCRIPTION
# Current (incorrect behaviour)
`getExtension` always returns the default value when it is called after `freeze`, even if the extension was set before the proto was frozen.

# New behaviour
`getExtension` returns extensions when they were set before `freeze()`.
It does not call `_ensureExtensions()` which would mutate the proto.

Note: The additional test fails without the code changes.