### PR TITLE
Add more words to the Dart reserved names list.

### DIFF
--- a/protobuf/lib/src/protobuf/readonly_message.dart
+++ b/protobuf/lib/src/protobuf/readonly_message.dart
@@ -49,7 +49,7 @@ abstract class ReadonlyMessageMixin {
   void setExtension(Extension extension, var value) =>
       _readonly("setExtension");
 
-  void setField(int tagNumber, var value, [int fieldType = null]) =>
+  void setField(int tagNumber, var value, [int fieldType]) =>
       _readonly("setField");
 
   void _readonly(String methodName) {

--- a/protobuf/test/test_util.dart
+++ b/protobuf/test/test_util.dart
@@ -7,12 +7,12 @@ library test_util;
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
-Int64 make64(lo, [hi = null]) {
+Int64 make64(int lo, [int hi]) {
   if (hi == null) hi = lo < 0 ? -1 : 0;
   return new Int64.fromInts(hi, lo);
 }
 
-expect64(lo, [hi = null]) {
+expect64(int lo, [int hi]) {
   final Int64 expected = make64(lo, hi);
   return predicate((Int64 actual) => actual == expected);
 }

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -455,6 +455,7 @@ final List<String> forbiddenExtensionNames = <String>[]
 // subclass of GeneratedMessage.
 const List<String> _dartReservedWords = const [
   'assert',
+  'bool',
   'break',
   'case',
   'catch',
@@ -463,6 +464,7 @@ const List<String> _dartReservedWords = const [
   'continue',
   'default',
   'do',
+  'double',
   'else',
   'enum',
   'extends',
@@ -472,6 +474,7 @@ const List<String> _dartReservedWords = const [
   'for',
   'if',
   'in',
+  'int',
   'is',
   'new',
   'null',

--- a/protoc_plugin/test/test_util.dart
+++ b/protoc_plugin/test/test_util.dart
@@ -8,17 +8,17 @@ import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
-import '../out/protos/google/protobuf/unittest_import.pb.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
+import '../out/protos/google/protobuf/unittest_import.pb.dart';
 
 final Matcher throwsATypeError = throwsA(new TypeMatcher<TypeError>());
 
-Int64 make64(lo, [hi = null]) {
+Int64 make64(int lo, [int hi]) {
   if (hi == null) hi = lo < 0 ? -1 : 0;
   return new Int64.fromInts(hi, lo);
 }
 
-expect64(lo, [hi = null]) {
+expect64(int lo, [int hi]) {
   final Int64 expected = make64(lo, hi);
   return predicate((Int64 actual) => actual == expected);
 }


### PR DESCRIPTION
This was causing some issues internally--words that match some data types here (int, double, bool), generate invalid Dart code but work fine in other proto languages.

Since there shouldn't be language-specific unusable words, these should just go through normal name disambiguation.

I tested this out with several other keywords that weren't in the list already: https://www.dartlang.org/guides/language/language-tour#keywords

However, these three were really the only ones that generated broken code when used as field identifiers.