### PR TITLE
Support for Timestamp

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 16.0.1
+
+* Add `DateTime` conversion methods to `google.protobuf.Timestamp`.
+
 ## 16.0.0
 
 * Add ability to generate Kythe metadata files via the

--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -12,6 +12,7 @@ PLUGIN_PATH=bin/$(PLUGIN_NAME)
 TEST_PROTO_LIST = \
 	_leading_underscores \
 	google/protobuf/any \
+	google/protobuf/timestamp \
 	google/protobuf/unittest_import \
 	google/protobuf/unittest_optimize_for \
 	google/protobuf/unittest \

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -330,12 +330,25 @@ class FileGenerator extends ProtobufContainer {
     }
     if (enumImports.isNotEmpty) out.println();
 
+    _writeWellKnownImports(out);
+
     // Export enums in main file for backward compatibility.
     if (enumCount > 0) {
       Uri resolvedImport =
           config.resolveImport(protoFileUri, protoFileUri, ".pbenum.dart");
       out.println("export '$resolvedImport';");
       out.println();
+    }
+  }
+
+  void _writeWellKnownImports(IndentingWriter out) {
+    for (final message in messageGenerators) {
+      final importStatements =
+          wellKnownTypeForFullName(message.fullName)?.extraImports ??
+              <String>[];
+      for (String importStatement in importStatements) {
+        out.println(importStatement);
+      }
     }
   }
 

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -385,9 +385,7 @@ class MessageGenerator extends ProtobufContainer {
           'static ${classname} getDefault() => _defaultInstance ??= create()..freeze();');
       out.println('static ${classname} _defaultInstance;');
       generateFieldsAccessorsMutators(out);
-      if (fullName == 'google.protobuf.Any') {
-        generateAnyMethods(out);
-      }
+      wellKnownTypeForFullName(fullName)?.generateMethods(out);
     });
     out.println();
   }
@@ -432,45 +430,6 @@ class MessageGenerator extends ProtobufContainer {
       }
     }
     return false;
-  }
-
-  /// Generates methods for the Any message class for packing and unpacking
-  /// values.
-  void generateAnyMethods(IndentingWriter out) {
-    out.println('''
-  /// Unpacks the message in [value] into [instance].
-  ///
-  /// Throws a [InvalidProtocolBufferException] if [typeUrl] does not correspond
-  /// to the type of [instance].
-  ///
-  /// A typical usage would be `any.unpackInto(new Message())`.
-  ///
-  /// Returns [instance].
-  T unpackInto<T extends $_protobufImportPrefix.GeneratedMessage>(T instance,
-      {$_protobufImportPrefix.ExtensionRegistry extensionRegistry = $_protobufImportPrefix.ExtensionRegistry.EMPTY}) {
-    $_protobufImportPrefix.unpackIntoHelper(value, instance, typeUrl,
-        extensionRegistry: extensionRegistry);
-    return instance;
-  }
-
-  /// Returns `true` if the encoded message matches the type of [instance].
-  ///
-  /// Can be used with a default instance:
-  /// `any.canUnpackInto(Message.getDefault())`
-  bool canUnpackInto($_protobufImportPrefix.GeneratedMessage instance) {
-    return $_protobufImportPrefix.canUnpackIntoHelper(instance, typeUrl);
-  }
-
-  /// Creates a new [Any] encoding [message].
-  ///
-  /// The [typeUrl] will be [typeUrlPrefix]/`fullName` where `fullName` is
-  /// the fully qualified name of the type of [message].
-  static Any pack($_protobufImportPrefix.GeneratedMessage message,
-      {String typeUrlPrefix = 'type.googleapis.com'}) {
-    return new Any()
-      ..value = message.writeToBuffer()
-      ..typeUrl = '\${typeUrlPrefix}/\${message.info_.qualifiedMessageName}';
-  }''');
   }
 
   void generateFieldsAccessorsMutators(IndentingWriter out) {

--- a/protoc_plugin/lib/protoc.dart
+++ b/protoc_plugin/lib/protoc.dart
@@ -29,3 +29,4 @@ part 'options.dart';
 part 'output_config.dart';
 part 'protobuf_field.dart';
 part 'service_generator.dart';
+part 'well_known_types.dart';

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -67,10 +67,11 @@ class _Timestamp extends WellKnownType {
     out.println(r'''
   /// Converts an instance to [DateTime].
   ///
-  /// The result has microsecond precision, as [DateTime] does not support
-  /// nanosecond precision.
+  /// The result is in UTC time zone and has microsecond precision, as
+  /// [DateTime] does not support nanosecond precision.
   $core.DateTime toDateTime() => new $core.DateTime.fromMicrosecondsSinceEpoch(
-      seconds.toInt() * $core.Duration.microsecondsPerSecond + nanos ~/ 1000);
+      seconds.toInt() * $core.Duration.microsecondsPerSecond + nanos ~/ 1000,
+      isUtc: true);
 
   /// Creates a new instance from [dateTime].
   ///

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -73,6 +73,8 @@ class _Timestamp extends WellKnownType {
       seconds.toInt() * $core.Duration.microsecondsPerSecond + nanos ~/ 1000);
 
   /// Creates a new instance from [dateTime].
+  ///
+  /// Time zone information will not be preserved.
   static Timestamp fromDateTime($core.DateTime dateTime) {
     int micros = dateTime.microsecondsSinceEpoch;
     return new Timestamp()

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -68,7 +68,7 @@ class _Timestamp extends WellKnownType {
   /// Converts an instance to [DateTime].
   ///
   /// The result has microsecond precision, as [DateTime] does not support
-  /// nanosecond precision
+  /// nanosecond precision.
   $core.DateTime toDateTime() => new $core.DateTime.fromMicrosecondsSinceEpoch(
       seconds.toInt() * $core.Duration.microsecondsPerSecond + nanos ~/ 1000);
 

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of protoc;
+
+abstract class WellKnownType {
+  const WellKnownType();
+
+  List<String> get extraImports => <String>[];
+
+  void generateMethods(IndentingWriter out);
+}
+
+class _Any extends WellKnownType {
+  const _Any();
+
+  /// Generates methods for the Any message class for packing and unpacking
+  /// values.
+  @override
+  void generateMethods(IndentingWriter out) {
+    out.println('''
+  /// Unpacks the message in [value] into [instance].
+  ///
+  /// Throws a [InvalidProtocolBufferException] if [typeUrl] does not correspond
+  /// to the type of [instance].
+  ///
+  /// A typical usage would be `any.unpackInto(new Message())`.
+  ///
+  /// Returns [instance].
+  T unpackInto<T extends $_protobufImportPrefix.GeneratedMessage>(T instance,
+      {$_protobufImportPrefix.ExtensionRegistry extensionRegistry = $_protobufImportPrefix.ExtensionRegistry.EMPTY}) {
+    $_protobufImportPrefix.unpackIntoHelper(value, instance, typeUrl,
+        extensionRegistry: extensionRegistry);
+    return instance;
+  }
+
+  /// Returns `true` if the encoded message matches the type of [instance].
+  ///
+  /// Can be used with a default instance:
+  /// `any.canUnpackInto(Message.getDefault())`
+  bool canUnpackInto($_protobufImportPrefix.GeneratedMessage instance) {
+    return $_protobufImportPrefix.canUnpackIntoHelper(instance, typeUrl);
+  }
+
+  /// Creates a new [Any] encoding [message].
+  ///
+  /// The [typeUrl] will be [typeUrlPrefix]/`fullName` where `fullName` is
+  /// the fully qualified name of the type of [message].
+  static Any pack($_protobufImportPrefix.GeneratedMessage message,
+      {String typeUrlPrefix = 'type.googleapis.com'}) {
+    return new Any()
+      ..value = message.writeToBuffer()
+      ..typeUrl = '\${typeUrlPrefix}/\${message.info_.qualifiedMessageName}';
+  }''');
+  }
+}
+
+class _Timestamp extends WellKnownType {
+  const _Timestamp();
+
+  List<String> get extraImports =>
+      [r"import 'dart:core' as $core show DateTime, Duration;"];
+
+  @override
+  void generateMethods(IndentingWriter out) {
+    out.println(r'''
+  /// Converts an instance to [DateTime].
+  ///
+  /// The result has microsecond precision, as [DateTime] does not support
+  /// nanosecond precision
+  $core.DateTime toDateTime() => new $core.DateTime.fromMicrosecondsSinceEpoch(
+      seconds.toInt() * $core.Duration.microsecondsPerSecond + nanos ~/ 1000);
+
+  /// Creates a new instance from [dateTime].
+  static Timestamp fromDateTime($core.DateTime dateTime) {
+    int micros = dateTime.microsecondsSinceEpoch;
+    return new Timestamp()
+      ..seconds = new Int64(micros ~/ $core.Duration.microsecondsPerSecond)
+      ..nanos = (micros % $core.Duration.microsecondsPerSecond).toInt() * 1000;
+  }''');
+  }
+}
+
+const _wellKnownTypes = {
+  'google.protobuf.Any': _Any(),
+  'google.protobuf.Timestamp': _Timestamp(),
+};
+
+WellKnownType wellKnownTypeForFullName(String fullName) =>
+    _wellKnownTypes[fullName];

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.0
+version: 16.0.1
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/protos/google/protobuf/timestamp.proto
+++ b/protoc_plugin/test/protos/google/protobuf/timestamp.proto
@@ -1,0 +1,137 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/timestamp";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "TimestampProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// A Timestamp represents a point in time independent of any time zone or local
+// calendar, encoded as a count of seconds and fractions of seconds at
+// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+// January 1, 1970, in the proleptic Gregorian calendar which extends the
+// Gregorian calendar backwards to year one.
+//
+// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+// second table is needed for interpretation, using a [24-hour linear
+// smear](https://developers.google.com/time/smear).
+//
+// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+// restricting to that range, we ensure that we can convert to and from [RFC
+// 3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+//
+// # Examples
+//
+// Example 1: Compute Timestamp from POSIX `time()`.
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(time(NULL));
+//     timestamp.set_nanos(0);
+//
+// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+//
+//     struct timeval tv;
+//     gettimeofday(&tv, NULL);
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(tv.tv_sec);
+//     timestamp.set_nanos(tv.tv_usec * 1000);
+//
+// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+//
+//     FILETIME ft;
+//     GetSystemTimeAsFileTime(&ft);
+//     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+//
+//     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+//     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+//     Timestamp timestamp;
+//     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+//     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+//
+// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+//
+//     long millis = System.currentTimeMillis();
+//
+//     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+//         .setNanos((int) ((millis % 1000) * 1000000)).build();
+//
+//
+// Example 5: Compute Timestamp from current time in Python.
+//
+//     timestamp = Timestamp()
+//     timestamp.GetCurrentTime()
+//
+// # JSON Mapping
+//
+// In JSON format, the Timestamp type is encoded as a string in the
+// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+// where {year} is always expressed using four digits while {month}, {day},
+// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+// is required. A proto3 JSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// able to accept both UTC and other timezones (as indicated by an offset).
+//
+// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+// 01:30 UTC on January 15, 2017.
+//
+// In JavaScript, one can convert a Date object to this format using the
+// standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+// method. In Python, a standard `datetime.datetime` object can be converted
+// to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+// with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+// can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+// http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D
+// ) to obtain a formatter capable of generating timestamps in this format.
+//
+//
+message Timestamp {
+
+  // Represents seconds of UTC time since Unix epoch
+  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  // 9999-12-31T23:59:59Z inclusive.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at nanosecond resolution. Negative
+  // second values with fractions must still have non-negative nanos values
+  // that count forward in time. Must be from 0 to 999,999,999
+  // inclusive.
+  int32 nanos = 2;
+}

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -19,7 +19,7 @@ void main() {
     DateTime dateTime = new DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
     DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
-    /// The time zone information is lost, so cannot use equality on these dates.s
+    /// The time zone information is lost, so cannot use equality on these dates.
     expect(fromProto.isAtSameMomentAs(dateTime), true,
         reason: "$fromProto is not at the same moment as $dateTime");
   });

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+import '../out/protos/google/protobuf/timestamp.pb.dart';
+
+void main() {
+  test('timestamp -> datetime -> timestamp', () {
+    Timestamp timestamp = new Timestamp()
+      ..seconds = new Int64(1550225928)
+      ..nanos = 12345000;
+    expect(Timestamp.fromDateTime(timestamp.toDateTime()), timestamp);
+  });
+
+  test('datetime -> timestamp -> datetime', () {
+    DateTime dateTime = new DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
+    DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
+
+    /// The time zone information is lost, so cannot use equality on these dates.s
+    expect(fromProto.isAtSameMomentAs(dateTime), true,
+        reason: "$fromProto is not at the same moment as $dateTime");
+  });
+}

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -15,12 +15,19 @@ void main() {
     expect(Timestamp.fromDateTime(timestamp.toDateTime()), timestamp);
   });
 
-  test('datetime -> timestamp -> datetime', () {
+  test('utc datetime -> timestamp -> datetime', () {
     DateTime dateTime = new DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
     DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
-    /// The time zone information is lost, so cannot use equality on these dates.
-    expect(fromProto.isAtSameMomentAs(dateTime), true,
-        reason: "$fromProto is not at the same moment as $dateTime");
+    expect(fromProto.isUtc, true, reason: "$fromProto is not a UTC time.");
+    expect(fromProto, dateTime);
+  });
+
+  test('local datetime -> timestamp -> datetime', () {
+    DateTime dateTime = new DateTime(2019, 02, 15, 10, 21, 25, 5, 5);
+    DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
+
+    expect(fromProto.isUtc, true, reason: "$fromProto is not a UTC time.");
+    expect(fromProto, dateTime.toUtc());
   });
 }


### PR DESCRIPTION
Added generation of `toDateTime` / `fromDateTime` methods to `google.protobuf.Timestamp`. This required adding new imports to generated code, so to avoid potential name collisions I'm adding an extra import like this:

```
import 'dart:core' as $dct show DateTime, Duration;
```

I have added a new file `well_known_types` to make it easier to add similar methods to other types (e.g. to `google.protobuf.Duration`) and also moved `Any` methods generation to it.