### PR TITLE
Add addAll() method to ExtensionRegistry

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.5
+
+* Add new method `addAll` on ExtensionRegistry for more conveniently adding multiple extensions at once.
+
 ## 0.13.4
 
 * Add new method `pc` on BuilderInfo for adding repeated composite fields and remove redundant type check on items added

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -19,6 +19,11 @@ class ExtensionRegistry {
     map[extension.tagNumber] = extension;
   }
 
+  /// Stores all [extensions] in the registry.
+  void addAll(Iterable<Extension> extensions) {
+    extensions.forEach(add);
+  }
+
   /// Retrieves an extension from the registry that adds tag number [tagNumber]
   /// to the [messageName] message type.
   Extension getExtension(String messageName, int tagNumber) {

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -44,7 +44,7 @@ class _EmptyExtensionRegistry implements ExtensionRegistry {
   void add(Extension extension) {
     throw new UnsupportedError('Immutable ExtensionRegistry');
   }
-  
+
   void addAll(Iterable<Extension> extensions) {
     throw new UnsupportedError('Immutable ExtensionRegistry');
   }

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -44,6 +44,10 @@ class _EmptyExtensionRegistry implements ExtensionRegistry {
   void add(Extension extension) {
     throw new UnsupportedError('Immutable ExtensionRegistry');
   }
+  
+  void addAll(Iterable<Extension> extensions) {
+    throw new UnsupportedError('Immutable ExtensionRegistry');
+  }
 
   Extension getExtension(String messageName, int tagNumber) => null;
 }

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.13.4
+version: 0.13.5
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.


### PR DESCRIPTION
Convenience method for when you have a list of extensions and you want to add them all at once (e.g. via cascade operator while constructing the registry, which you can't otherwise easily do today).