### PR TITLE
Avoid storing the BuilderInfo in _FieldSet

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -33,7 +33,6 @@ FrozenMessageErrorHandler frozenMessageModificationHandler =
 /// be faster when compiled to JavaScript.
 class _FieldSet {
   final GeneratedMessage _message;
-  final BuilderInfo _meta;
   final EventPlugin _eventPlugin;
   bool _isReadOnly = false;
 
@@ -53,8 +52,9 @@ class _FieldSet {
   final Map<int, int> oneofCases = <int, int>{};
 
   _FieldSet(this._message, BuilderInfo meta, this._eventPlugin)
-      : this._meta = meta,
-        _values = _makeValueList(meta.byIndex.length);
+      : _values = _makeValueList(_message.info_.byIndex.length);
+
+  BuilderInfo get _meta => _message.info_;
 
   static _makeValueList(int length) {
     if (length == 0) return _zeroList;

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -4,6 +4,23 @@
 
 part of protobuf;
 
+class _PBMapEntry extends GeneratedMessage {
+  _PBMapEntry(this.info_);
+
+  @override
+  GeneratedMessage clone() {
+    throw StateError('This method should not have been called');
+  }
+
+  @override
+  GeneratedMessage createEmptyInstance() {
+    throw StateError('This method should not have been called');
+  }
+
+  @override
+  final BuilderInfo info_;
+}
+
 class PbMap<K, V> extends MapBase<K, V> {
   final int keyFieldType;
   final int valueFieldType;
@@ -15,7 +32,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   final BuilderInfo _entryBuilderInfo;
 
   bool _isReadonly = false;
-  _FieldSet _entryFieldSet() => new _FieldSet(null, _entryBuilderInfo, null);
+  _FieldSet _entryFieldSet() => new _FieldSet(_PBMapEntry(_entryBuilderInfo), null, null);
 
   PbMap(this.keyFieldType, this.valueFieldType, this._entryBuilderInfo)
       : _wrappedMap = <K, V>{};

--- a/protoc_plugin/test/isolate_communication.dart
+++ b/protoc_plugin/test/isolate_communication.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate' as isolate;
+import '../out/protos/foo.pb.dart';
+import 'package:test/test.dart';
+
+runInIsolate(isolate.SendPort sendPort) {
+  sendPort.send(Outer()
+    ..inner = (Inner()..value = 'pip')
+    ..inners.add(Inner()..value = 'pop'));
+}
+
+main() async {
+  test('Messages can be sent across isolates', () async {
+    isolate.ReceivePort receivePort = isolate.ReceivePort();
+    isolate.Isolate.spawn(runInIsolate, receivePort.sendPort);
+    Outer received = await receivePort.first;
+    expect(received.inner.value, 'pip');
+    expect(received.inners.single.value, 'pop');
+  }, onPlatform: {
+    'js': Skip(
+        'Dart compiled to javascript does not allow complex objects to be sent '
+        'between isolates.')
+  });
+}


### PR DESCRIPTION
This should allow us to send messages between isolates (https://github.com/dart-lang/protobuf/issues/167). And also make this more efficient (as we do not need to copy the metadata.