### PR TITLE
Sync Kythe metadata updates from internal repo.

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 16.0.3
+* Sync Kythe metadata updates from internal repo:
+* Remove the extra 1 (field name) from generated field paths,
+  so they refer to the whole field rather than the name.
+* Add missing proto message field metadata to the Dart proto generator
+  (attached to setter/getter/has/clear methods). Fix a bug with indented space counting,
+  which would cause all indented fields to use the incorrect count (off by the size of the indent)
+* Add metadata to the unnamed constructors in the generated dart proto files.
+  Removed extra list copy constructor calls when the field path isn't being modified.
+  The named constructors (e.g. fromJson) don't need this because, at the call site,
+  the class name and the constructor name are two separate links.
+
 ## 16.0.2
 
 * Generated files now import 'dart:core' with a prefix

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -92,18 +92,14 @@ class EnumGenerator extends ProtobufContainer {
     return "$fileImportPrefix.$name";
   }
 
-  static const int _enumNameTag = 1;
   static const int _enumValueTag = 2;
-  static const int _enumValueNameTag = 1;
 
   void generate(IndentingWriter out) {
     out.addAnnotatedBlock(
         'class ${classname} extends $_protobufImportPrefix.ProtobufEnum {',
         '}\n', [
       new NamedLocation(
-          name: classname,
-          fieldPathSegment: new List.from(fieldPath)..add(_enumNameTag),
-          start: 'class '.length)
+          name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
     ], () {
       // -----------------------------------------------------------------
       // Define enum types.
@@ -117,11 +113,7 @@ class EnumGenerator extends ProtobufContainer {
               new NamedLocation(
                   name: name,
                   fieldPathSegment: new List.from(fieldPath)
-                    ..addAll([
-                      _enumValueTag,
-                      _originalCanonicalIndices[i],
-                      _enumValueNameTag
-                    ]),
+                    ..addAll([_enumValueTag, _originalCanonicalIndices[i]]),
                   start: 'static const ${classname} '.length)
             ]);
       }
@@ -137,11 +129,7 @@ class EnumGenerator extends ProtobufContainer {
                 new NamedLocation(
                     name: name,
                     fieldPathSegment: new List.from(fieldPath)
-                      ..addAll([
-                        _enumValueTag,
-                        _originalAliasIndices[i],
-                        _enumValueNameTag
-                      ]),
+                      ..addAll([_enumValueTag, _originalAliasIndices[i]]),
                     start: 'static const ${classname} '.length)
               ]);
         }

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -106,7 +106,7 @@ class ExtensionGenerator {
           [
             new NamedLocation(
                 name: name,
-                fieldPathSegment: new List.from(fieldPath)..add(1),
+                fieldPathSegment: new List.from(fieldPath),
                 start: 'static final $_protobufImportPrefix.Extension '.length)
           ]);
       if (type.isMessage || type.isGroup) {
@@ -130,7 +130,7 @@ class ExtensionGenerator {
         [
           new NamedLocation(
               name: name,
-              fieldPathSegment: new List.from(fieldPath)..add(1),
+              fieldPathSegment: new List.from(fieldPath),
               start: 'static final $_protobufImportPrefix.Extension '.length)
         ]);
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -221,14 +221,10 @@ class FileGenerator extends ProtobufContainer {
 
     if (options.generateMetadata) {
       files.addAll([
-        makeFile(
-            ".pb.dart.meta",
-            new String.fromCharCodes(
-                mainWriter.sourceLocationInfo.writeToBuffer())),
-        makeFile(
-            ".pbenum.dart.meta",
-            new String.fromCharCodes(
-                enumWriter.sourceLocationInfo.writeToBuffer()))
+        makeFile(".pb.dart.meta",
+            mainWriter.sourceLocationInfo.writeToJson().toString()),
+        makeFile(".pbenum.dart.meta",
+            enumWriter.sourceLocationInfo.writeToJson().toString())
       ]);
     }
     if (options.useGrpc) {

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -52,9 +52,11 @@ class IndentingWriter {
   }
 
   void printAnnotated(String text, List<NamedLocation> namedLocations) {
+    final indentOffset = _needIndent ? _indent.length : 0;
     print(text);
     for (final location in namedLocations) {
-      addAnnotation(location.fieldPathSegment, location.name, location.start);
+      _addAnnotation(location.fieldPathSegment, location.name,
+          location.start + indentOffset);
     }
   }
 
@@ -121,7 +123,7 @@ class IndentingWriter {
   /// [start] should be the location of the identifier as it appears in the
   /// string that was passed to the previous [print]. Name should be the string
   /// that was written to file.
-  void addAnnotation(List<int> fieldPath, String name, int start) {
+  void _addAnnotation(List<int> fieldPath, String name, int start) {
     if (_sourceFile == null) {
       return;
     }

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.2
+version: 16.0.3
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/goldens/enum.meta
+++ b/protoc_plugin/test/goldens/enum.meta
@@ -1,7 +1,6 @@
 annotation: {
   path: 5
   path: 0
-  path: 1
   sourceFile: sample.proto
   begin: 6
   end: 15
@@ -11,38 +10,34 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: sample.proto
-  begin: 66
-  end: 72
+  begin: 68
+  end: 74
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: sample.proto
-  begin: 132
-  end: 136
+  begin: 134
+  end: 138
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: sample.proto
-  begin: 194
-  end: 198
+  begin: 196
+  end: 200
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: sample.proto
-  begin: 257
-  end: 265
+  begin: 259
+  end: 267
 }

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -1,8 +1,122 @@
 annotation: {
   path: 4
   path: 0
-  path: 1
   sourceFile: 
   begin: 6
   end: 17
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: 
+  begin: 362
+  end: 373
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1189
+  end: 1195
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1220
+  end: 1226
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1273
+  end: 1282
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1311
+  end: 1322
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1372
+  end: 1376
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1397
+  end: 1401
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1454
+  end: 1461
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1490
+  end: 1499
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1540
+  end: 1544
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1571
+  end: 1575
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1622
+  end: 1629
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1658
+  end: 1667
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums.meta
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums.meta
@@ -3,7 +3,6 @@ annotation: {
   path: 0
   path: 4
   path: 0
-  path: 1
   sourceFile: 
   begin: 6
   end: 27
@@ -15,10 +14,9 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: 
-  begin: 90
-  end: 96
+  begin: 92
+  end: 98
 }
 annotation: {
   path: 4
@@ -27,10 +25,9 @@ annotation: {
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: 
-  begin: 180
-  end: 184
+  begin: 182
+  end: 186
 }
 annotation: {
   path: 4
@@ -39,10 +36,9 @@ annotation: {
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: 
-  begin: 266
-  end: 270
+  begin: 268
+  end: 272
 }
 annotation: {
   path: 4
@@ -51,8 +47,7 @@ annotation: {
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: 
-  begin: 353
-  end: 361
+  begin: 355
+  end: 363
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -1,8 +1,122 @@
 annotation: {
   path: 4
   path: 0
-  path: 1
   sourceFile: test
   begin: 325
   end: 336
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: test
+  begin: 578
+  end: 589
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1405
+  end: 1411
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1436
+  end: 1442
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1489
+  end: 1498
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1527
+  end: 1538
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1576
+  end: 1580
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1603
+  end: 1607
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1656
+  end: 1663
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1692
+  end: 1701
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1742
+  end: 1746
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1773
+  end: 1777
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1824
+  end: 1831
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1860
+  end: 1869
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -1,7 +1,6 @@
 annotation: {
   path: 5
   path: 0
-  path: 1
   sourceFile: test
   begin: 339
   end: 348
@@ -11,38 +10,34 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: test
-  begin: 399
-  end: 405
+  begin: 401
+  end: 407
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: test
-  begin: 465
-  end: 469
+  begin: 467
+  end: 471
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: test
-  begin: 527
-  end: 531
+  begin: 529
+  end: 533
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: test
-  begin: 590
-  end: 598
+  begin: 592
+  end: 600
 }

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -30,8 +30,9 @@ class test {
   test('IndentingWriter annotation tracks previous output', () {
     var out = new IndentingWriter(filename: 'sample.proto');
     out.print('13 characters');
-    out.print('sample text');
-    out.addAnnotation([1, 2, 3], 'text', 7);
+    out.printAnnotated('sample text', [
+      NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
+    ]);
     GeneratedCodeInfo_Annotation expected = new GeneratedCodeInfo_Annotation()
       ..path.addAll([1, 2, 3])
       ..sourceFile = 'sample.proto'
@@ -45,26 +46,24 @@ class test {
   test('IndentingWriter annotation counts indents correctly', () {
     var out = new IndentingWriter(filename: '');
     out.addBlock('34 characters including newline {', '}', () {
-      out.println('sample text');
-      out.addAnnotation([], 'sample', 0);
+      out.printlnAnnotated('sample text',
+          [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
     });
     GeneratedCodeInfo_Annotation annotation =
         out.sourceLocationInfo.annotation[0];
-    expect(annotation.begin, equals(34));
-    expect(annotation.end, equals(40));
+    // The indent is 2 characters, so these should be shifted by 2.
+    expect(annotation.begin, equals(36));
+    expect(annotation.end, equals(42));
   });
 
   test('IndentingWriter annotations counts multiline output correctly', () {
     var out = new IndentingWriter(filename: '');
     out.print('20 characters\ntotal\n');
-    out.println('20 characters before this');
-    out.addAnnotation([], 'ch', 3);
+    out.printlnAnnotated('20 characters before this',
+        [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);
     GeneratedCodeInfo_Annotation annotation =
         out.sourceLocationInfo.annotation[0];
     expect(annotation.begin, equals(23));
     expect(annotation.end, equals(25));
   });
-
-  test('IndentingWriter does not break when making annotation for null file',
-      () {});
 }


### PR DESCRIPTION
Changes:

1. Remove the extra 1 (field name) from generated field paths, so they refer to the whole field rather than the name.
2. Add missing proto message field metadata to the Dart proto generator (attached to setter/getter/has/clear methods). Fix a bug with indented space counting, which would cause all indented fields to use the incorrect count (off by the size of the indent)
3. Add metadata to the unnamed constructors in the generated dart proto files.  Also removed extra list copy constructor calls when the field path isn't being modified. The named constructors (e.g. fromJson) don't need this because, at the call site, the class name and the constructor name are two separate links.