### PR TITLE
Generate '@Deprecated' Annotation for Deprecated Proto Fields

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 16.0.4
+
+* Generate '@Deprecated' annotations on fields that have been deprecated in the
+  corresponding .proto file.
+
 ## 16.0.3
 * Sync Kythe metadata updates from internal repo:
 * Remove the extra 1 (field name) from generated field paths,

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 16.0.3
+* Sync Kythe metadata updates from internal repo:
+* Remove the extra 1 (field name) from generated field paths,
+  so they refer to the whole field rather than the name.
+* Add missing proto message field metadata to the Dart proto generator
+  (attached to setter/getter/has/clear methods). Fix a bug with indented space counting,
+  which would cause all indented fields to use the incorrect count (off by the size of the indent)
+* Add metadata to the unnamed constructors in the generated dart proto files.
+  Removed extra list copy constructor calls when the field path isn't being modified.
+  The named constructors (e.g. fromJson) don't need this because, at the call site,
+  the class name and the constructor name are two separate links.
+
 ## 16.0.2
 
 * Generated files now import 'dart:core' with a prefix

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -92,18 +92,14 @@ class EnumGenerator extends ProtobufContainer {
     return "$fileImportPrefix.$name";
   }
 
-  static const int _enumNameTag = 1;
   static const int _enumValueTag = 2;
-  static const int _enumValueNameTag = 1;
 
   void generate(IndentingWriter out) {
     out.addAnnotatedBlock(
         'class ${classname} extends $_protobufImportPrefix.ProtobufEnum {',
         '}\n', [
       new NamedLocation(
-          name: classname,
-          fieldPathSegment: new List.from(fieldPath)..add(_enumNameTag),
-          start: 'class '.length)
+          name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
     ], () {
       // -----------------------------------------------------------------
       // Define enum types.
@@ -117,11 +113,7 @@ class EnumGenerator extends ProtobufContainer {
               new NamedLocation(
                   name: name,
                   fieldPathSegment: new List.from(fieldPath)
-                    ..addAll([
-                      _enumValueTag,
-                      _originalCanonicalIndices[i],
-                      _enumValueNameTag
-                    ]),
+                    ..addAll([_enumValueTag, _originalCanonicalIndices[i]]),
                   start: 'static const ${classname} '.length)
             ]);
       }
@@ -137,11 +129,7 @@ class EnumGenerator extends ProtobufContainer {
                 new NamedLocation(
                     name: name,
                     fieldPathSegment: new List.from(fieldPath)
-                      ..addAll([
-                        _enumValueTag,
-                        _originalAliasIndices[i],
-                        _enumValueNameTag
-                      ]),
+                      ..addAll([_enumValueTag, _originalAliasIndices[i]]),
                     start: 'static const ${classname} '.length)
               ]);
         }

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -108,7 +108,7 @@ class EnumGenerator extends ProtobufContainer {
         final name = dartNames[val.name];
         out.printlnAnnotated(
             'static const ${classname} $name = '
-            "const ${classname}._(${val.number}, ${singleQuote(name)});",
+            "${classname}._(${val.number}, ${singleQuote(name)});",
             [
               NamedLocation(
                   name: name,
@@ -137,7 +137,7 @@ class EnumGenerator extends ProtobufContainer {
       out.println();
 
       out.println('static const $_coreImportPrefix.List<${classname}> values ='
-          ' const <${classname}> [');
+          ' <${classname}> [');
       for (EnumValueDescriptorProto val in _canonicalValues) {
         final name = dartNames[val.name];
         out.println('  $name,');

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -106,7 +106,7 @@ class ExtensionGenerator {
           [
             new NamedLocation(
                 name: name,
-                fieldPathSegment: new List.from(fieldPath)..add(1),
+                fieldPathSegment: new List.from(fieldPath),
                 start: 'static final $_protobufImportPrefix.Extension '.length)
           ]);
       if (type.isMessage || type.isGroup) {
@@ -130,7 +130,7 @@ class ExtensionGenerator {
         [
           new NamedLocation(
               name: name,
-              fieldPathSegment: new List.from(fieldPath)..add(1),
+              fieldPathSegment: new List.from(fieldPath),
               start: 'static final $_protobufImportPrefix.Extension '.length)
         ]);
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -285,9 +285,8 @@ class FileGenerator extends ProtobufContainer {
       out.println(_asyncImport);
     }
 
-    out.println('// ignore: UNUSED_SHOWN_NAME');
     out.println(
-        '$_coreImport show int, bool, double, String, List, Map, override, Deprecated;\n');
+        '$_coreImport show bool, Deprecated, double, int, List, Map, override, String;\n');
 
     if (_needsFixnumImport) {
       out.println("import 'package:fixnum/fixnum.dart';");
@@ -565,7 +564,7 @@ class FileGenerator extends ProtobufContainer {
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 ''');
   }
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -221,14 +221,10 @@ class FileGenerator extends ProtobufContainer {
 
     if (options.generateMetadata) {
       files.addAll([
-        makeFile(
-            ".pb.dart.meta",
-            new String.fromCharCodes(
-                mainWriter.sourceLocationInfo.writeToBuffer())),
-        makeFile(
-            ".pbenum.dart.meta",
-            new String.fromCharCodes(
-                enumWriter.sourceLocationInfo.writeToBuffer()))
+        makeFile(".pb.dart.meta",
+            mainWriter.sourceLocationInfo.writeToJson().toString()),
+        makeFile(".pbenum.dart.meta",
+            enumWriter.sourceLocationInfo.writeToJson().toString())
       ]);
     }
     if (options.useGrpc) {

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -292,7 +292,7 @@ class FileGenerator extends ProtobufContainer {
 
     out.println('// ignore: UNUSED_SHOWN_NAME');
     out.println(
-        '$_coreImport show int, bool, double, String, List, Map, override;\n');
+        '$_coreImport show int, bool, double, String, List, Map, override, Deprecated;\n');
 
     if (_needsFixnumImport) {
       out.println("import 'package:fixnum/fixnum.dart';");

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -52,9 +52,11 @@ class IndentingWriter {
   }
 
   void printAnnotated(String text, List<NamedLocation> namedLocations) {
+    final indentOffset = _needIndent ? _indent.length : 0;
     print(text);
     for (final location in namedLocations) {
-      addAnnotation(location.fieldPathSegment, location.name, location.start);
+      _addAnnotation(location.fieldPathSegment, location.name,
+          location.start + indentOffset);
     }
   }
 
@@ -121,7 +123,7 @@ class IndentingWriter {
   /// [start] should be the location of the identifier as it appears in the
   /// string that was passed to the previous [print]. Name should be the string
   /// that was written to file.
-  void addAnnotation(List<int> fieldPath, String name, int start) {
+  void _addAnnotation(List<int> fieldPath, String name, int start) {
     if (_sourceFile == null) {
       return;
     }

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -460,6 +460,7 @@ class MessageGenerator extends ProtobufContainer {
     var defaultExpr = field.getDefaultExpr();
     var names = field.memberNames;
 
+    _emitDeprecatedIf(field.isDeprecated, out);
     _emitOverrideIf(field.overridesGetter, out);
     final getterExpr = _getterExpression(fieldTypeString, field.index,
         defaultExpr, field.isRepeated, field.isMapField);
@@ -486,6 +487,7 @@ class MessageGenerator extends ProtobufContainer {
       }
     } else {
       var fastSetter = field.baseType.setter;
+      _emitDeprecatedIf(field.isDeprecated, out);
       _emitOverrideIf(field.overridesSetter, out);
       if (fastSetter != null) {
         out.printlnAnnotated(
@@ -512,6 +514,7 @@ class MessageGenerator extends ProtobufContainer {
                   start: 'set '.length)
             ]);
       }
+      _emitDeprecatedIf(field.isDeprecated, out);
       _emitOverrideIf(field.overridesHasMethod, out);
       out.printlnAnnotated(
           '$_coreImportPrefix.bool ${names.hasMethodName}() =>'
@@ -522,6 +525,7 @@ class MessageGenerator extends ProtobufContainer {
                 fieldPathSegment: memberFieldPath,
                 start: 'bool '.length)
           ]);
+      _emitDeprecatedIf(field.isDeprecated, out);
       _emitOverrideIf(field.overridesClearMethod, out);
       out.printlnAnnotated(
           'void ${names.clearMethodName}() =>'
@@ -550,6 +554,13 @@ class MessageGenerator extends ProtobufContainer {
       return isRepeated ? '\$_getList($index)' : '\$_getN($index)';
     }
     return '\$_get($index, $defaultExpr)';
+  }
+
+  void _emitDeprecatedIf(bool condition, IndentingWriter out) {
+    if (condition) {
+      out.println(
+          '@$_coreImportPrefix.Deprecated(\'This field is deprecated.\')');
+    }
   }
 
   void _emitOverrideIf(bool condition, IndentingWriter out) {

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -45,6 +45,9 @@ class ProtobufField {
   /// `null` for an extension.
   int get index => memberNames?.index;
 
+  /// True if the field is to be encoded with [deprecated = true] encoding.
+  bool get isDeprecated => descriptor.options?.deprecated;
+
   bool get isRequired =>
       descriptor.label == FieldDescriptorProto_Label.LABEL_REQUIRED;
 

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -2,11 +2,10 @@
 //  Generated code. Do not modify.
 //  source: dart_options.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
 import 'dart:core' as $core
-    show int, bool, double, String, List, Map, override, Deprecated;
+    show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -5,7 +5,8 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core
+    show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -5,7 +5,8 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core
+    show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart' as $pb;
@@ -827,12 +828,16 @@ class FileOptions extends $pb.GeneratedMessage {
   $core.bool hasPyGenericServices() => $_has(7);
   void clearPyGenericServices() => clearField(18);
 
+  @$core.Deprecated('This field is deprecated.')
   $core.bool get javaGenerateEqualsAndHash => $_get(8, false);
+  @$core.Deprecated('This field is deprecated.')
   set javaGenerateEqualsAndHash($core.bool v) {
     $_setBool(8, v);
   }
 
+  @$core.Deprecated('This field is deprecated.')
   $core.bool hasJavaGenerateEqualsAndHash() => $_has(8);
+  @$core.Deprecated('This field is deprecated.')
   void clearJavaGenerateEqualsAndHash() => clearField(20);
 
   $core.bool get deprecated => $_get(9, false);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -2,11 +2,10 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
 import 'dart:core' as $core
-    show int, bool, double, String, List, Map, override, Deprecated;
+    show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart' as $pb;

--- a/protoc_plugin/lib/src/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/descriptor.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
 import 'dart:core' as $core show int, dynamic, String, List, Map;

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -5,7 +5,8 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core
+    show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -2,11 +2,10 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
 import 'dart:core' as $core
-    show int, bool, double, String, List, Map, override, Deprecated;
+    show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.2
+version: 16.0.3
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.3-dev-1
+version: 16.0.4
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   protobuf: ^0.13.7
   dart_style: ^1.0.6
 
-dev_dependencies:s
+dev_dependencies:
   test: ^1.3.0
 
 executables:

--- a/protoc_plugin/test/goldens/enum
+++ b/protoc_plugin/test/goldens/enum
@@ -1,11 +1,11 @@
 class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = const PhoneType._(0, 'MOBILE');
-  static const PhoneType HOME = const PhoneType._(1, 'HOME');
-  static const PhoneType WORK = const PhoneType._(2, 'WORK');
+  static const PhoneType MOBILE = PhoneType._(0, 'MOBILE');
+  static const PhoneType HOME = PhoneType._(1, 'HOME');
+  static const PhoneType WORK = PhoneType._(2, 'WORK');
 
   static const PhoneType BUSINESS = WORK;
 
-  static const $core.List<PhoneType> values = const <PhoneType> [
+  static const $core.List<PhoneType> values = <PhoneType> [
     MOBILE,
     HOME,
     WORK,

--- a/protoc_plugin/test/goldens/enum.meta
+++ b/protoc_plugin/test/goldens/enum.meta
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: sample.proto
-  begin: 134
-  end: 138
+  begin: 128
+  end: 132
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: sample.proto
-  begin: 196
-  end: 200
+  begin: 184
+  end: 188
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: sample.proto
-  begin: 259
-  end: 267
+  begin: 241
+  end: 249
 }

--- a/protoc_plugin/test/goldens/enum.meta
+++ b/protoc_plugin/test/goldens/enum.meta
@@ -1,7 +1,6 @@
 annotation: {
   path: 5
   path: 0
-  path: 1
   sourceFile: sample.proto
   begin: 6
   end: 15
@@ -11,38 +10,34 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: sample.proto
-  begin: 66
-  end: 72
+  begin: 68
+  end: 74
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: sample.proto
-  begin: 132
-  end: 136
+  begin: 134
+  end: 138
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: sample.proto
-  begin: 194
-  end: 198
+  begin: 196
+  end: 200
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: sample.proto
-  begin: 257
-  end: 265
+  begin: 259
+  end: 267
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 import 'dart:async' as $async;
 

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart' as $pb;

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart' as $pb;

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -2,5 +2,5 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -3,6 +3,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
     ..aQS(1, 'number')
     ..e<PhoneNumber_PhoneType>(2, 'type', $pb.PbFieldType.OE, PhoneNumber_PhoneType.MOBILE, PhoneNumber_PhoneType.valueOf, PhoneNumber_PhoneType.values)
     ..a<$core.String>(3, 'name', $pb.PbFieldType.OS, '\$')
+    ..aOS(4, 'deprecatedField')
   ;
 
   PhoneNumber() : super();
@@ -31,5 +32,14 @@ class PhoneNumber extends $pb.GeneratedMessage {
   set name($core.String v) { $_setString(2, v); }
   $core.bool hasName() => $_has(2);
   void clearName() => clearField(3);
+
+  @$core.Deprecated('This field is deprecated.')
+  $core.String get deprecatedField => $_getS(3, '');
+  @$core.Deprecated('This field is deprecated.')
+  set deprecatedField($core.String v) { $_setString(3, v); }
+  @$core.Deprecated('This field is deprecated.')
+  $core.bool hasDeprecatedField() => $_has(3);
+  @$core.Deprecated('This field is deprecated.')
+  void clearDeprecatedField() => clearField(4);
 }
 

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 394
-  end: 405
+  begin: 390
+  end: 401
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1221
-  end: 1227
+  begin: 1205
+  end: 1211
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1252
-  end: 1258
+  begin: 1236
+  end: 1242
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1305
-  end: 1314
+  begin: 1289
+  end: 1298
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1343
-  end: 1354
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: 
-  begin: 1404
-  end: 1408
+  begin: 1327
+  end: 1338
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1429
-  end: 1433
+  begin: 1388
+  end: 1392
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1486
-  end: 1493
+  begin: 1413
+  end: 1417
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1522
-  end: 1531
+  begin: 1470
+  end: 1477
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1506
+  end: 1515
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1572
-  end: 1576
+  begin: 1556
+  end: 1560
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1603
-  end: 1607
+  begin: 1587
+  end: 1591
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1654
-  end: 1661
+  begin: 1638
+  end: 1645
 }
 annotation: {
   path: 4
@@ -117,26 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1690
-  end: 1699
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 1789
-  end: 1804
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 1878
-  end: 1893
+  begin: 1674
+  end: 1683
 }
 annotation: {
   path: 4
@@ -144,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 1989
-  end: 2007
+  begin: 1773
+  end: 1788
 }
 annotation: {
   path: 4
@@ -153,6 +135,24 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2085
-  end: 2105
+  begin: 1862
+  end: 1877
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 1973
+  end: 1991
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 2069
+  end: 2089
 }

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 362
-  end: 373
+  begin: 394
+  end: 405
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1189
-  end: 1195
+  begin: 1221
+  end: 1227
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1220
-  end: 1226
+  begin: 1252
+  end: 1258
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1273
-  end: 1282
+  begin: 1305
+  end: 1314
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1311
-  end: 1322
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: 
-  begin: 1372
-  end: 1376
+  begin: 1343
+  end: 1354
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1397
-  end: 1401
+  begin: 1404
+  end: 1408
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1454
-  end: 1461
+  begin: 1429
+  end: 1433
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1490
-  end: 1499
+  begin: 1486
+  end: 1493
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1522
+  end: 1531
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1540
-  end: 1544
+  begin: 1572
+  end: 1576
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1571
-  end: 1575
+  begin: 1603
+  end: 1607
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1622
-  end: 1629
+  begin: 1654
+  end: 1661
 }
 annotation: {
   path: 4
@@ -117,6 +117,42 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1658
-  end: 1667
+  begin: 1690
+  end: 1699
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 1789
+  end: 1804
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 1878
+  end: 1893
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 1989
+  end: 2007
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 2085
+  end: 2105
 }

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -1,8 +1,122 @@
 annotation: {
   path: 4
   path: 0
-  path: 1
   sourceFile: 
   begin: 6
   end: 17
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: 
+  begin: 362
+  end: 373
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1189
+  end: 1195
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1220
+  end: 1226
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1273
+  end: 1282
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: 
+  begin: 1311
+  end: 1322
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1372
+  end: 1376
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1397
+  end: 1401
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1454
+  end: 1461
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1490
+  end: 1499
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1540
+  end: 1544
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1571
+  end: 1575
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1622
+  end: 1629
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: 
+  begin: 1658
+  end: 1667
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums
@@ -1,11 +1,11 @@
 class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
-  static const PhoneNumber_PhoneType MOBILE = const PhoneNumber_PhoneType._(0, 'MOBILE');
-  static const PhoneNumber_PhoneType HOME = const PhoneNumber_PhoneType._(1, 'HOME');
-  static const PhoneNumber_PhoneType WORK = const PhoneNumber_PhoneType._(2, 'WORK');
+  static const PhoneNumber_PhoneType MOBILE = PhoneNumber_PhoneType._(0, 'MOBILE');
+  static const PhoneNumber_PhoneType HOME = PhoneNumber_PhoneType._(1, 'HOME');
+  static const PhoneNumber_PhoneType WORK = PhoneNumber_PhoneType._(2, 'WORK');
 
   static const PhoneNumber_PhoneType BUSINESS = WORK;
 
-  static const $core.List<PhoneNumber_PhoneType> values = const <PhoneNumber_PhoneType> [
+  static const $core.List<PhoneNumber_PhoneType> values = <PhoneNumber_PhoneType> [
     MOBILE,
     HOME,
     WORK,

--- a/protoc_plugin/test/goldens/messageGeneratorEnums.meta
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums.meta
@@ -26,8 +26,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 182
-  end: 186
+  begin: 176
+  end: 180
 }
 annotation: {
   path: 4
@@ -37,8 +37,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 268
-  end: 272
+  begin: 256
+  end: 260
 }
 annotation: {
   path: 4
@@ -48,6 +48,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 355
-  end: 363
+  begin: 337
+  end: 345
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums.meta
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums.meta
@@ -3,7 +3,6 @@ annotation: {
   path: 0
   path: 4
   path: 0
-  path: 1
   sourceFile: 
   begin: 6
   end: 27
@@ -15,10 +14,9 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: 
-  begin: 90
-  end: 96
+  begin: 92
+  end: 98
 }
 annotation: {
   path: 4
@@ -27,10 +25,9 @@ annotation: {
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: 
-  begin: 180
-  end: 184
+  begin: 182
+  end: 186
 }
 annotation: {
   path: 4
@@ -39,10 +36,9 @@ annotation: {
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: 
-  begin: 266
-  end: 270
+  begin: 268
+  end: 272
 }
 annotation: {
   path: 4
@@ -51,8 +47,7 @@ annotation: {
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: 
-  begin: 353
-  end: 361
+  begin: 355
+  end: 363
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 325
-  end: 336
+  begin: 337
+  end: 348
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 578
-  end: 589
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 1405
-  end: 1411
+  begin: 590
+  end: 601
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1436
-  end: 1442
+  begin: 1417
+  end: 1423
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1489
-  end: 1498
+  begin: 1448
+  end: 1454
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1527
-  end: 1538
+  begin: 1501
+  end: 1510
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 1576
-  end: 1580
+  begin: 1539
+  end: 1550
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1603
-  end: 1607
+  begin: 1588
+  end: 1592
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1656
-  end: 1663
+  begin: 1615
+  end: 1619
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1692
-  end: 1701
+  begin: 1668
+  end: 1675
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1704
+  end: 1713
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1742
-  end: 1746
+  begin: 1754
+  end: 1758
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1773
-  end: 1777
+  begin: 1785
+  end: 1789
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1824
-  end: 1831
+  begin: 1836
+  end: 1843
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1860
-  end: 1869
+  begin: 1872
+  end: 1881
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 337
-  end: 348
+  begin: 326
+  end: 337
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 590
-  end: 601
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 1417
-  end: 1423
+  begin: 575
+  end: 586
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1448
-  end: 1454
+  begin: 1390
+  end: 1396
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1501
-  end: 1510
+  begin: 1421
+  end: 1427
 }
 annotation: {
   path: 4
@@ -45,8 +36,26 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1539
-  end: 1550
+  begin: 1474
+  end: 1483
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1512
+  end: 1523
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1561
+  end: 1565
 }
 annotation: {
   path: 4
@@ -63,8 +72,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1615
-  end: 1619
+  begin: 1641
+  end: 1648
 }
 annotation: {
   path: 4
@@ -72,17 +81,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1668
-  end: 1675
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 1704
-  end: 1713
+  begin: 1677
+  end: 1686
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1754
-  end: 1758
+  begin: 1727
+  end: 1731
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1785
-  end: 1789
+  begin: 1758
+  end: 1762
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1836
-  end: 1843
+  begin: 1809
+  end: 1816
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1872
-  end: 1881
+  begin: 1845
+  end: 1854
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -1,8 +1,122 @@
 annotation: {
   path: 4
   path: 0
-  path: 1
   sourceFile: test
   begin: 325
   end: 336
+}
+annotation: {
+  path: 4
+  path: 0
+  sourceFile: test
+  begin: 578
+  end: 589
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1405
+  end: 1411
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1436
+  end: 1442
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1489
+  end: 1498
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 0
+  sourceFile: test
+  begin: 1527
+  end: 1538
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1576
+  end: 1580
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1603
+  end: 1607
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1656
+  end: 1663
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1692
+  end: 1701
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1742
+  end: 1746
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1773
+  end: 1777
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1824
+  end: 1831
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 2
+  sourceFile: test
+  begin: 1860
+  end: 1869
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 const PhoneNumber$json = const {
   '1': 'PhoneNumber',

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -6,7 +6,7 @@
 
 import 'dart:async' as $async;
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -2,11 +2,10 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 import 'dart:async' as $async;
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 import 'dart:async' as $async;
 

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: testpkg.proto
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 import 'foobar.pbjson.dart' as $0;
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -2,10 +2,9 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
+import 'dart:core' as $core show bool, Deprecated, double, int, List, Map, override, String;
 
 export 'test.pbenum.dart';
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -5,7 +5,7 @@
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
 
 // ignore: UNUSED_SHOWN_NAME
-import 'dart:core' as $core show int, bool, double, String, List, Map, override;
+import 'dart:core' as $core show int, bool, double, String, List, Map, override, Deprecated;
 
 export 'test.pbenum.dart';
 

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -2,20 +2,20 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME,UNUSED_SHOWN_NAME
 import 'dart:core' as $core show int, dynamic, String, List, Map;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneType extends $pb.ProtobufEnum {
-  static const PhoneType MOBILE = const PhoneType._(0, 'MOBILE');
-  static const PhoneType HOME = const PhoneType._(1, 'HOME');
-  static const PhoneType WORK = const PhoneType._(2, 'WORK');
+  static const PhoneType MOBILE = PhoneType._(0, 'MOBILE');
+  static const PhoneType HOME = PhoneType._(1, 'HOME');
+  static const PhoneType WORK = PhoneType._(2, 'WORK');
 
   static const PhoneType BUSINESS = WORK;
 
-  static const $core.List<PhoneType> values = const <PhoneType> [
+  static const $core.List<PhoneType> values = <PhoneType> [
     MOBILE,
     HOME,
     WORK,

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 339
-  end: 348
+  begin: 357
+  end: 366
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 401
-  end: 407
+  begin: 419
+  end: 425
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 467
-  end: 471
+  begin: 479
+  end: 483
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 529
-  end: 533
+  begin: 535
+  end: 539
 }
 annotation: {
   path: 5

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -1,7 +1,6 @@
 annotation: {
   path: 5
   path: 0
-  path: 1
   sourceFile: test
   begin: 339
   end: 348
@@ -11,38 +10,34 @@ annotation: {
   path: 0
   path: 2
   path: 0
-  path: 1
   sourceFile: test
-  begin: 399
-  end: 405
+  begin: 401
+  end: 407
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 1
-  path: 1
   sourceFile: test
-  begin: 465
-  end: 469
+  begin: 467
+  end: 471
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 2
-  path: 1
   sourceFile: test
-  begin: 527
-  end: 531
+  begin: 529
+  end: 533
 }
 annotation: {
   path: 5
   path: 0
   path: 2
   path: 3
-  path: 1
   sourceFile: test
-  begin: 590
-  end: 598
+  begin: 592
+  end: 600
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 ///
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import
+// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name
 
 const PhoneType$json = const {
   '1': 'PhoneType',

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -30,8 +30,9 @@ class test {
   test('IndentingWriter annotation tracks previous output', () {
     var out = new IndentingWriter(filename: 'sample.proto');
     out.print('13 characters');
-    out.print('sample text');
-    out.addAnnotation([1, 2, 3], 'text', 7);
+    out.printAnnotated('sample text', [
+      NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
+    ]);
     GeneratedCodeInfo_Annotation expected = new GeneratedCodeInfo_Annotation()
       ..path.addAll([1, 2, 3])
       ..sourceFile = 'sample.proto'
@@ -45,26 +46,24 @@ class test {
   test('IndentingWriter annotation counts indents correctly', () {
     var out = new IndentingWriter(filename: '');
     out.addBlock('34 characters including newline {', '}', () {
-      out.println('sample text');
-      out.addAnnotation([], 'sample', 0);
+      out.printlnAnnotated('sample text',
+          [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
     });
     GeneratedCodeInfo_Annotation annotation =
         out.sourceLocationInfo.annotation[0];
-    expect(annotation.begin, equals(34));
-    expect(annotation.end, equals(40));
+    // The indent is 2 characters, so these should be shifted by 2.
+    expect(annotation.begin, equals(36));
+    expect(annotation.end, equals(42));
   });
 
   test('IndentingWriter annotations counts multiline output correctly', () {
     var out = new IndentingWriter(filename: '');
     out.print('20 characters\ntotal\n');
-    out.println('20 characters before this');
-    out.addAnnotation([], 'ch', 3);
+    out.printlnAnnotated('20 characters before this',
+        [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);
     GeneratedCodeInfo_Annotation annotation =
         out.sourceLocationInfo.annotation[0];
     expect(annotation.begin, equals(23));
     expect(annotation.end, equals(25));
   });
-
-  test('IndentingWriter does not break when making annotation for null file',
-      () {});
 }

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -39,7 +39,7 @@ void main() {
     expect(rec["msg"], predicate((x) => x is pb.NonMap));
   });
 
-  test('operator [] returns value when set', () {
+  test('operator [] returns new value when set', () {
     var rec = pb.Rec();
     rec.num = 42;
     expect(rec["num"], 42);
@@ -132,7 +132,7 @@ void main() {
     expect(rec["nums"], []);
   });
 
-  test("addAll sets each field to a value", () {
+  test("addAll sets each field to a new value", () {
     var rec = pb.Rec();
     rec.addAll({"str": "hello", "num": 123});
     expect(rec["str"], "hello");

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -55,12 +55,12 @@ void main() {
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_STRING
           ..defaultValue = r'$',
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'deprecated_field'
           ..number = 4
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_STRING
-          ..options = (new FieldOptions()..deprecated = true),
+          ..options = (FieldOptions()..deprecated = true),
       ])
       ..enumType.add(ed);
     var options =

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -54,7 +54,13 @@ void main() {
           ..number = 3
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_STRING
-          ..defaultValue = r'$'
+          ..defaultValue = r'$',
+        new FieldDescriptorProto()
+          ..name = 'deprecated_field'
+          ..number = 4
+          ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
+          ..type = FieldDescriptorProto_Type.TYPE_STRING
+          ..options = (new FieldOptions()..deprecated = true),
       ])
       ..enumType.add(ed);
     var options = parseGenerationOptions(


### PR DESCRIPTION
This change brings Dart closer in line to other languages like Java, which already generate this annotation. It should be dropped in dart2js and have no real code impact size for production users.