### PR TITLE
Fix unnecessary_new lint in generated code.

### DIFF
--- a/api_benchmark/lib/benchmark.dart
+++ b/api_benchmark/lib/benchmark.dart
@@ -33,7 +33,7 @@ abstract class Benchmark {
   pb.Request makeRequest(
           [Duration duration = const Duration(milliseconds: 50),
           int samples = 20]) =>
-      new pb.Request()
+      pb.Request()
         ..id = id
         ..params = makeParams()
         ..duration = duration.inMilliseconds
@@ -72,10 +72,10 @@ abstract class Benchmark {
 
   void checkRequest(pb.Request r) {
     if (r.id != id) {
-      throw new ArgumentError("invalid benchmark id: ${r.id}");
+      throw ArgumentError("invalid benchmark id: ${r.id}");
     }
     if (r.params != makeParams()) {
-      throw new ArgumentError("parameters don't match: ${r.params}");
+      throw ArgumentError("parameters don't match: ${r.params}");
     }
   }
 
@@ -171,15 +171,15 @@ abstract class Benchmark {
     int minimumMicros = minimumMillis * 1000;
     int reps = 0;
     int elapsed = 0;
-    Stopwatch watch = new Stopwatch()..start();
+    Stopwatch watch = Stopwatch()..start();
     while (elapsed < minimumMicros) {
       reps += runner();
       elapsed = watch.elapsedMicroseconds;
     }
-    return new pb.Sample()
+    return pb.Sample()
       ..duration = elapsed
       ..loopCount = reps
-      ..counts = new pb.Counts();
+      ..counts = pb.Counts();
   }
 }
 

--- a/api_benchmark/lib/benchmarks/get_strings.dart
+++ b/api_benchmark/lib/benchmarks/get_strings.dart
@@ -26,7 +26,7 @@ class GetStringsBenchmark extends Benchmark {
 
   @override
   Params makeParams() {
-    var p = new Params()..messageCount = height;
+    var p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue;
     return p;
   }
@@ -38,10 +38,10 @@ class GetStringsBenchmark extends Benchmark {
 
   // makes a rectangle where every cell has the same value.
   static pb.Grid10 _makeGrid(int height, String fillValue) {
-    var grid = new pb.Grid10();
+    var grid = pb.Grid10();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       if (fillValue != null) {
         for (int x = 0; x < width; x++) {
           int tag = getTagForColumn(line, x);
@@ -122,12 +122,12 @@ class GetStringsBenchmark extends Benchmark {
   get measureSampleUnits => "string reads/ms";
 
   static const $id = BenchmarkID.GET_STRINGS;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static GetStringsBenchmark $create(Request r) {
     assert(r.params.hasMessageCount());
     var value = null;
     if (r.params.hasStringValue()) value = r.params.stringValue;
-    return new GetStringsBenchmark(r.params.messageCount, value);
+    return GetStringsBenchmark(r.params.messageCount, value);
   }
 }

--- a/api_benchmark/lib/benchmarks/has_strings.dart
+++ b/api_benchmark/lib/benchmarks/has_strings.dart
@@ -26,7 +26,7 @@ class HasStringsBenchmark extends Benchmark {
 
   @override
   Params makeParams() {
-    var p = new Params()..messageCount = height;
+    var p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue;
     return p;
   }
@@ -38,10 +38,10 @@ class HasStringsBenchmark extends Benchmark {
 
   // makes a rectangle where no fields have been set.
   static pb.Grid10 _makeGrid(int width, int height, String fillValue) {
-    var grid = new pb.Grid10();
+    var grid = pb.Grid10();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       if (fillValue != null) {
         for (int x = 0; x < width; x++) {
           int tag = getTagForColumn(line, x);
@@ -122,12 +122,12 @@ class HasStringsBenchmark extends Benchmark {
   get measureSampleUnits => "string reads/ms";
 
   static const $id = BenchmarkID.HAS_STRINGS;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static HasStringsBenchmark $create(Request r) {
     assert(r.params.hasMessageCount());
     var value = null;
     if (r.params.hasStringValue()) value = r.params.stringValue;
-    return new HasStringsBenchmark(r.params.messageCount, value);
+    return HasStringsBenchmark(r.params.messageCount, value);
   }
 }

--- a/api_benchmark/lib/benchmarks/index.dart
+++ b/api_benchmark/lib/benchmarks/index.dart
@@ -24,7 +24,7 @@ import '../generated/benchmark.pb.dart' as pb;
 Benchmark createBenchmark(pb.Request r) {
   var type = allBenchmarks[r.id];
   if (type == null) {
-    throw new ArgumentError("unknown benchmark: ${r.id.name}");
+    throw ArgumentError("unknown benchmark: ${r.id.name}");
   }
   return type.create(r);
 }
@@ -49,5 +49,5 @@ Map<pb.BenchmarkID, BenchmarkType> _makeTypeMap(List<BenchmarkType> types) {
     }
     out[type.id] = type;
   }
-  return new Map.unmodifiable(out);
+  return Map.unmodifiable(out);
 }

--- a/api_benchmark/lib/benchmarks/int32_json.dart
+++ b/api_benchmark/lib/benchmarks/int32_json.dart
@@ -22,7 +22,7 @@ class Int32Benchmark extends Benchmark {
   get summary => "${id.name}($width x $height int32s)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..int32FieldCount = width
     ..messageCount = height;
 
@@ -30,7 +30,7 @@ class Int32Benchmark extends Benchmark {
   void setup() {
     var grid = _makeGrid(width, height);
     json = grid.writeToJson();
-    lastFieldTag = getTagForColumn(new pb.Line10(), width - 1);
+    lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
 
   // makes a rectangle of the of the form:
@@ -38,11 +38,11 @@ class Int32Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid10 _makeGrid(int width, int height) {
-    if (width > 10) throw new ArgumentError("width out of range: ${width}");
-    var grid = new pb.Grid10();
+    if (width > 10) throw ArgumentError("width out of range: ${width}");
+    var grid = pb.Grid10();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       for (int x = 0; x < width; x++) {
         int tag = getTagForColumn(line, x);
         line.setField(tag, x + y);
@@ -59,7 +59,7 @@ class Int32Benchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid10 grid = new pb.Grid10.fromJson(json);
+    pb.Grid10 grid = pb.Grid10.fromJson(json);
     var actual = grid.lines[height - 1].getField(lastFieldTag);
     if (actual != width + height - 2) throw "failed; got ${actual}";
   }
@@ -76,11 +76,11 @@ class Int32Benchmark extends Benchmark {
   get measureSampleUnits => "int32 reads/ms";
 
   static const $id = BenchmarkID.READ_INT32_FIELDS_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static Int32Benchmark $create(Request r) {
     assert(r.params.hasInt32FieldCount());
     assert(r.params.hasMessageCount());
-    return new Int32Benchmark(r.params.int32FieldCount, r.params.messageCount);
+    return Int32Benchmark(r.params.int32FieldCount, r.params.messageCount);
   }
 }

--- a/api_benchmark/lib/benchmarks/int64_json.dart
+++ b/api_benchmark/lib/benchmarks/int64_json.dart
@@ -24,7 +24,7 @@ class Int64Benchmark extends Benchmark {
   get summary => "${id.name}($width x $height int64s)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..int64FieldCount = width
     ..messageCount = height;
 
@@ -32,7 +32,7 @@ class Int64Benchmark extends Benchmark {
   void setup() {
     var grid = _makeGrid(width, height);
     json = grid.writeToJson();
-    lastFieldTag = getTagForColumn(new pb.Line10(), width - 1);
+    lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
 
   // makes a rectangle of the of the form:
@@ -40,14 +40,14 @@ class Int64Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid10 _makeGrid(int width, int height) {
-    if (width > 10) throw new ArgumentError("width out of range: ${width}");
-    var grid = new pb.Grid10();
+    if (width > 10) throw ArgumentError("width out of range: ${width}");
+    var grid = pb.Grid10();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       for (int x = 0; x < width; x++) {
         int tag = getTagForColumn(line, x);
-        line.setField(tag, new Int64(x + y));
+        line.setField(tag, Int64(x + y));
       }
       grid.lines.add(line);
     }
@@ -61,7 +61,7 @@ class Int64Benchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid10 grid = new pb.Grid10.fromJson(json);
+    pb.Grid10 grid = pb.Grid10.fromJson(json);
     var actual = grid.lines[height - 1].getField(lastFieldTag);
     if (actual != width + height - 2) throw "failed; got ${actual}";
   }
@@ -78,11 +78,11 @@ class Int64Benchmark extends Benchmark {
   get measureSampleUnits => "int64 reads/ms";
 
   static const $id = BenchmarkID.READ_INT64_FIELDS_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static Int64Benchmark $create(Request r) {
     assert(r.params.hasInt64FieldCount());
     assert(r.params.hasMessageCount());
-    return new Int64Benchmark(r.params.int64FieldCount, r.params.messageCount);
+    return Int64Benchmark(r.params.int64FieldCount, r.params.messageCount);
   }
 }

--- a/api_benchmark/lib/benchmarks/repeated_int32_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_int32_json.dart
@@ -21,7 +21,7 @@ class RepeatedInt32Benchmark extends Benchmark {
   get summary => "${id.name}($width x $height ints)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..int32RepeatCount = width
     ..messageCount = height;
 
@@ -36,10 +36,10 @@ class RepeatedInt32Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid _makeGrid(int width, int height) {
-    var grid = new pb.Grid();
+    var grid = pb.Grid();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line();
+      var line = pb.Line();
       for (int x = 0; x < width; x++) {
         line.cells.add(x + y);
       }
@@ -51,7 +51,7 @@ class RepeatedInt32Benchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid grid = new pb.Grid.fromJson(json);
+    pb.Grid grid = pb.Grid.fromJson(json);
     var actual = grid.lines[height - 1].cells[width - 1];
     if (actual != width + height - 2) throw "failed; got ${actual}";
   }
@@ -68,11 +68,11 @@ class RepeatedInt32Benchmark extends Benchmark {
   get measureSampleUnits => "int32 reads/ms";
 
   static const $id = BenchmarkID.READ_INT32_REPEATED_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
   static RepeatedInt32Benchmark $create(Request r) {
     assert(r.params.hasInt32RepeatCount());
     assert(r.params.hasMessageCount());
-    return new RepeatedInt32Benchmark(
+    return RepeatedInt32Benchmark(
         r.params.int32RepeatCount, r.params.messageCount);
   }
 }

--- a/api_benchmark/lib/benchmarks/repeated_int64_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_int64_json.dart
@@ -23,7 +23,7 @@ class RepeatedInt64Benchmark extends Benchmark {
   get summary => "${id.name}($width x $height ints)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..int64RepeatCount = width
     ..messageCount = height;
 
@@ -38,12 +38,12 @@ class RepeatedInt64Benchmark extends Benchmark {
   // 1 2 3 4
   // 2 3 4 5
   static pb.Grid _makeGrid(int width, int height) {
-    var grid = new pb.Grid();
+    var grid = pb.Grid();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line();
+      var line = pb.Line();
       for (int x = 0; x < width; x++) {
-        line.cells.add(new Int64(x + y));
+        line.cells.add(Int64(x + y));
       }
       grid.lines.add(line);
     }
@@ -53,7 +53,7 @@ class RepeatedInt64Benchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid grid = new pb.Grid.fromJson(json);
+    pb.Grid grid = pb.Grid.fromJson(json);
     var actual = grid.lines[height - 1].cells[width - 1];
     if (actual != width + height - 2) throw "failed; got ${actual}";
   }
@@ -70,11 +70,11 @@ class RepeatedInt64Benchmark extends Benchmark {
   get measureSampleUnits => "int64 reads/ms";
 
   static const $id = BenchmarkID.READ_INT64_REPEATED_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
   static RepeatedInt64Benchmark $create(Request r) {
     assert(r.params.hasInt64RepeatCount());
     assert(r.params.hasMessageCount());
-    return new RepeatedInt64Benchmark(
+    return RepeatedInt64Benchmark(
         r.params.int64RepeatCount, r.params.messageCount);
   }
 }

--- a/api_benchmark/lib/benchmarks/repeated_string_json.dart
+++ b/api_benchmark/lib/benchmarks/repeated_string_json.dart
@@ -24,7 +24,7 @@ class RepeatedStringBenchmark extends Benchmark {
   get summary => "${id.name}($width x $height x $stringSize)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..stringFieldCount = width
     ..messageCount = height
     ..stringSize = stringSize;
@@ -40,19 +40,19 @@ class RepeatedStringBenchmark extends Benchmark {
   // "12" "23" "34" "45"
   // "23" "34" "45" "56"
   static pb.Grid _makeGrid(int width, int height, int stringSize) {
-    if (width > 10) throw new ArgumentError("width out of range: ${width}");
-    var grid = new pb.Grid();
+    if (width > 10) throw ArgumentError("width out of range: ${width}");
+    var grid = pb.Grid();
 
     int zero = "0".codeUnits[0];
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line();
+      var line = pb.Line();
       for (int x = 0; x < width; x++) {
         var charCodes = <int>[];
         for (var i = 0; i < stringSize; i++) {
           charCodes.add(zero + ((x + y + i) % 10));
         }
-        line.cells.add(new String.fromCharCodes(charCodes));
+        line.cells.add(String.fromCharCodes(charCodes));
       }
       grid.lines.add(line);
     }
@@ -61,7 +61,7 @@ class RepeatedStringBenchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid grid = new pb.Grid.fromJson(json);
+    pb.Grid grid = pb.Grid.fromJson(json);
     var actual = grid.lines[height - 1].cells[width - 1];
     if (actual.length != stringSize) throw "failed; got ${actual}";
   }
@@ -78,13 +78,13 @@ class RepeatedStringBenchmark extends Benchmark {
   get measureSampleUnits => "string reads/ms";
 
   static const $id = BenchmarkID.READ_STRING_REPEATED_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static RepeatedStringBenchmark $create(Request r) {
     assert(r.params.hasStringFieldCount());
     assert(r.params.hasMessageCount());
     assert(r.params.hasStringSize());
-    return new RepeatedStringBenchmark(
+    return RepeatedStringBenchmark(
         r.params.stringFieldCount, r.params.messageCount, r.params.stringSize);
   }
 }

--- a/api_benchmark/lib/benchmarks/set_strings.dart
+++ b/api_benchmark/lib/benchmarks/set_strings.dart
@@ -26,7 +26,7 @@ class SetStringsBenchmark extends Benchmark {
 
   @override
   Params makeParams() {
-    var p = new Params()..messageCount = height;
+    var p = Params()..messageCount = height;
     if (fillValue != null) p.stringValue = fillValue;
     return p;
   }
@@ -38,10 +38,10 @@ class SetStringsBenchmark extends Benchmark {
 
   // makes a rectangle where no fields have been set.
   static pb.Grid10 _makeGrid(int width, int height, String fillValue) {
-    var grid = new pb.Grid10();
+    var grid = pb.Grid10();
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       if (fillValue != null) {
         for (int x = 0; x < width; x++) {
           int tag = getTagForColumn(line, x);
@@ -96,12 +96,12 @@ class SetStringsBenchmark extends Benchmark {
   get measureSampleUnits => "string writes/ms";
 
   static const $id = BenchmarkID.SET_STRINGS;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static SetStringsBenchmark $create(Request r) {
     assert(r.params.hasMessageCount());
     var value = null;
     if (r.params.hasStringValue()) value = r.params.stringValue;
-    return new SetStringsBenchmark(r.params.messageCount, value);
+    return SetStringsBenchmark(r.params.messageCount, value);
   }
 }

--- a/api_benchmark/lib/benchmarks/string_json.dart
+++ b/api_benchmark/lib/benchmarks/string_json.dart
@@ -23,7 +23,7 @@ class StringBenchmark extends Benchmark {
   get summary => "${id.name}($width x $height x $stringSize)";
 
   @override
-  Params makeParams() => new Params()
+  Params makeParams() => Params()
     ..stringFieldCount = width
     ..messageCount = height
     ..stringSize = stringSize;
@@ -32,7 +32,7 @@ class StringBenchmark extends Benchmark {
   void setup() {
     var grid = _makeGrid(width, height, stringSize);
     json = grid.writeToJson();
-    lastFieldTag = getTagForColumn(new pb.Line10(), width - 1);
+    lastFieldTag = getTagForColumn(pb.Line10(), width - 1);
   }
 
   // makes a rectangle of the of the form:
@@ -40,20 +40,20 @@ class StringBenchmark extends Benchmark {
   // "12" "23" "34" "45"
   // "23" "34" "45" "56"
   static pb.Grid10 _makeGrid(int width, int height, int stringSize) {
-    if (width > 10) throw new ArgumentError("width out of range: ${width}");
-    var grid = new pb.Grid10();
+    if (width > 10) throw ArgumentError("width out of range: ${width}");
+    var grid = pb.Grid10();
 
     int zero = "0".codeUnits[0];
 
     for (int y = 0; y < height; y++) {
-      var line = new pb.Line10();
+      var line = pb.Line10();
       for (int x = 0; x < width; x++) {
         int tag = getTagForColumn(line, x);
         var charCodes = <int>[];
         for (var i = 0; i < stringSize; i++) {
           charCodes.add(zero + ((x + y + i) % 10));
         }
-        line.setField(tag, new String.fromCharCodes(charCodes));
+        line.setField(tag, String.fromCharCodes(charCodes));
       }
       grid.lines.add(line);
     }
@@ -67,7 +67,7 @@ class StringBenchmark extends Benchmark {
 
   @override
   void run() {
-    pb.Grid10 grid = new pb.Grid10.fromJson(json);
+    pb.Grid10 grid = pb.Grid10.fromJson(json);
     var actual = grid.lines[height - 1].getField(lastFieldTag);
     if (actual.length != stringSize) throw "failed; got ${actual}";
   }
@@ -84,13 +84,13 @@ class StringBenchmark extends Benchmark {
   get measureSampleUnits => "string reads/ms";
 
   static const $id = BenchmarkID.READ_STRING_FIELDS_JSON;
-  static final $type = new BenchmarkType($id, $create);
+  static final $type = BenchmarkType($id, $create);
 
   static StringBenchmark $create(Request r) {
     assert(r.params.hasStringFieldCount());
     assert(r.params.hasMessageCount());
     assert(r.params.hasStringSize());
-    return new StringBenchmark(
+    return StringBenchmark(
         r.params.stringFieldCount, r.params.messageCount, r.params.stringSize);
   }
 }

--- a/api_benchmark/lib/dashboard.dart
+++ b/api_benchmark/lib/dashboard.dart
@@ -26,22 +26,22 @@ Future showDashboard(pb.Suite suite, Element container) async {
   var env = await loadBrowserEnv();
   var reports = await loadReports(suite);
 
-  var defaultReport = new pb.Report()..env = env;
-  var model = new DashboardModel(reports, new Table(suite), defaultReport);
+  var defaultReport = pb.Report()..env = env;
+  var model = DashboardModel(reports, Table(suite), defaultReport);
 
   var baseline = chooseBaseline(env, reports);
   if (baseline != null) {
     model = model.withBaseline(baseline);
   }
 
-  var view = new DashboardView();
+  var view = DashboardView();
 
   Future render(pb.Report report) async {
     report.env = env;
     model = model.withReport(report);
     await window.animationFrame;
     view.render(model);
-    await new Future(() => null); // exit to regular timer task
+    await Future(() => null); // exit to regular timer task
   }
 
   // Set up the main loop that runs the suite.
@@ -49,7 +49,7 @@ Future showDashboard(pb.Suite suite, Element container) async {
   bool running = false;
   void runBenchmarks() {
     if (running) return;
-    var profiler = new JsProfiler();
+    var profiler = JsProfiler();
     running = true;
     () async {
       var requests = model.table.selections.toList();
@@ -119,7 +119,7 @@ Future<pb.Env> loadBrowserEnv() async {
     ..hostname = hostname
     ..userAgent = window.navigator.userAgent;
 
-  return new pb.Env()
+  return pb.Env()
     ..page = window.location.pathname
     ..platform = platform
     ..packages = createPackages(pubspecYaml, pubspecLock);
@@ -133,7 +133,7 @@ Future<Map<String, pb.Report>> loadReports(pb.Suite suite) async {
   var dataJson = jsonDecode(dataJsonContent) as Map<String, dynamic>;
 
   for (var entry in dataJson.entries) {
-    var report = new pb.Report.fromJson(entry.value);
+    var report = pb.Report.fromJson(entry.value);
     if (isCompatibleBaseline(suite, report)) {
       out[entry.key] = report;
     }

--- a/api_benchmark/lib/dashboard_model.dart
+++ b/api_benchmark/lib/dashboard_model.dart
@@ -19,14 +19,14 @@ class DashboardModel {
 
   DashboardModel withBaseline(String name) {
     var nextTable = table.withBaseline(name, savedReports[name]);
-    return new DashboardModel(savedReports, nextTable, latest);
+    return DashboardModel(savedReports, nextTable, latest);
   }
 
   DashboardModel withReport(pb.Report right) =>
-      new DashboardModel(savedReports, table, right);
+      DashboardModel(savedReports, table, right);
 
   DashboardModel withTable(Table table) =>
-      new DashboardModel(savedReports, table, latest);
+      DashboardModel(savedReports, table, latest);
 
   /// Returns true if the Run button should be enabled.
   bool get canRun => !latest.hasStatus() || latest.status != pb.Status.RUNNING;
@@ -40,8 +40,8 @@ class Table {
   final Set<pb.Request> selections;
   final rows = <Row>[];
 
-  factory Table(pb.Suite suite) => new Table._raw(
-      suite, null, null, new Set<pb.Request>.from(suite.requests));
+  factory Table(pb.Suite suite) =>
+      Table._raw(suite, null, null, Set<pb.Request>.from(suite.requests));
 
   Table._raw(this.suite, this.baseline, this.report, this.selections) {
     Iterator it = report == null ? [].iterator : report.responses.iterator;
@@ -52,30 +52,30 @@ class Table {
         b.checkRequest(it.current.request);
         baseline = b.medianSample(it.current);
       }
-      rows.add(new Row(r, b, baseline, selected: this.selections.contains(r)));
+      rows.add(Row(r, b, baseline, selected: this.selections.contains(r)));
     }
   }
 
   Table withBaseline(String baseline, pb.Report report) =>
-      new Table._raw(suite, baseline, report, selections);
+      Table._raw(suite, baseline, report, selections);
 
   Table withAllSelected() {
-    return new Table._raw(
-        suite, baseline, report, new Set<pb.Request>.from(suite.requests));
+    return Table._raw(
+        suite, baseline, report, Set<pb.Request>.from(suite.requests));
   }
 
   Table withNoneSelected() {
-    return new Table._raw(suite, baseline, report, new Set<pb.Request>());
+    return Table._raw(suite, baseline, report, Set<pb.Request>());
   }
 
   Table withSelection(pb.Request request, bool selected) {
-    var s = new Set<pb.Request>.from(selections);
+    var s = Set<pb.Request>.from(selections);
     if (selected) {
       s.add(request);
     } else {
       s.remove(request);
     }
-    return new Table._raw(suite, baseline, report, s);
+    return Table._raw(suite, baseline, report, s);
   }
 }
 

--- a/api_benchmark/lib/dashboard_view.dart
+++ b/api_benchmark/lib/dashboard_view.dart
@@ -16,7 +16,7 @@ import 'package:api_benchmark/report.dart' show encodeReport;
 class DashboardView {
   static const noBaseline = "<none>";
 
-  static final _template = new DivElement()
+  static final _template = DivElement()
     ..innerHtml = '''
 <div>
   <button class="dv-run"></button>
@@ -59,7 +59,7 @@ Choose baseline: <select class="dv-menu"></select>
   final rowViews = <_ResponseView>[];
 
   final _selectionChanges =
-      new StreamController<SelectEvent<pb.Request>>.broadcast();
+      StreamController<SelectEvent<pb.Request>>.broadcast();
 
   DashboardView._raw(
       this.elt,
@@ -75,11 +75,11 @@ Choose baseline: <select class="dv-menu"></select>
   factory DashboardView() {
     Element elt = _template.clone(true);
     find(String q) => elt.querySelector(q);
-    _Button button(q) => new _Button(find(q));
-    label(q) => new _Label(find(q));
-    menu(q) => new _Menu(find(q));
-    json(q) => new _JsonView(find(q));
-    return new DashboardView._raw(
+    _Button button(q) => _Button(find(q));
+    label(q) => _Label(find(q));
+    menu(q) => _Menu(find(q));
+    json(q) => _JsonView(find(q));
+    return DashboardView._raw(
         elt,
         button('.dv-run')
           ..elt.style.color = "#FFFFFF"
@@ -142,8 +142,7 @@ Choose baseline: <select class="dv-menu"></select>
 
     // Add any new rows
     while (rowIt.moveNext()) {
-      var row = new _ResponseView()
-        ..render(rowIt.current, r, _selectionChanges);
+      var row = _ResponseView()..render(rowIt.current, r, _selectionChanges);
       _responseTable.append(row.elt);
       rowViews.add(row);
     }
@@ -155,14 +154,14 @@ Choose baseline: <select class="dv-menu"></select>
 /// Displays how many samples were collected and the median and max samples.
 /// Also displays a baseline sample for comparison.
 class _ResponseView {
-  final elt = new TableRowElement();
-  final _selected = new _Checkbox<pb.Request>();
-  final _summary = new _Label(new TableCellElement());
-  final _baseline = new _SampleView();
-  final _median = new _SampleView();
-  final _max = new _SampleView();
-  final _count = new _Label(new TableCellElement()..style.textAlign = "right");
-  final _units = new _Label(new TableCellElement());
+  final elt = TableRowElement();
+  final _selected = _Checkbox<pb.Request>();
+  final _summary = _Label(TableCellElement());
+  final _baseline = _SampleView();
+  final _median = _SampleView();
+  final _max = _SampleView();
+  final _count = _Label(TableCellElement()..style.textAlign = "right");
+  final _units = _Label(TableCellElement());
 
   _ResponseView() {
     elt.children.addAll([
@@ -192,7 +191,7 @@ class _ResponseView {
 
 /// A table cell holding the measurement for one sample.
 class _SampleView {
-  final elt = new TableCellElement()..style.textAlign = "right";
+  final elt = TableCellElement()..style.textAlign = "right";
   double _rendered;
 
   void render(double value) {
@@ -225,8 +224,8 @@ class _JsonView {
     elt.children.clear();
     if (json == "") return;
     elt.children.addAll([
-      new HeadingElement.h2()..text = "Report data as JSON:",
-      new PreElement()..text = json
+      HeadingElement.h2()..text = "Report data as JSON:",
+      PreElement()..text = json
     ]);
     _rendered = json;
   }
@@ -235,8 +234,8 @@ class _JsonView {
 /// A menu of selectable text items.
 class _Menu {
   final SelectElement elt;
-  final _changes = new StreamController<String>.broadcast();
-  final _options = new List<_MenuOption>();
+  final _changes = StreamController<String>.broadcast();
+  final _options = List<_MenuOption>();
 
   _Menu(this.elt) {
     elt.onChange.listen((e) => _changes.add(elt.value));
@@ -256,7 +255,7 @@ class _Menu {
 
     // Add any new items
     while (it.moveNext()) {
-      var opt = new _MenuOption();
+      var opt = _MenuOption();
       opt.render(it.current, it.current == selected);
       elt.append(opt.elt);
       _options.add(opt);
@@ -265,7 +264,7 @@ class _Menu {
 }
 
 class _MenuOption {
-  final elt = new OptionElement();
+  final elt = OptionElement();
   String _renderedItem;
   bool _renderedSelected;
 
@@ -296,7 +295,7 @@ class _Label {
 
 class _Button {
   final ButtonElement elt;
-  final _clicks = new StreamController.broadcast();
+  final _clicks = StreamController.broadcast();
   String _renderedLabel;
   bool _renderedEnabled;
 
@@ -319,7 +318,7 @@ class _Button {
 }
 
 class _Checkbox<T> {
-  final elt = new CheckboxInputElement();
+  final elt = CheckboxInputElement();
 
   bool _renderedChecked;
   EventSink<SelectEvent<T>> _sink;
@@ -328,7 +327,7 @@ class _Checkbox<T> {
   _Checkbox() {
     elt.onChange.listen((e) {
       if (_sink != null) {
-        _sink.add(new SelectEvent<T>(elt.checked, _item));
+        _sink.add(SelectEvent<T>(elt.checked, _item));
       }
     });
   }

--- a/api_benchmark/lib/report.dart
+++ b/api_benchmark/lib/report.dart
@@ -28,7 +28,7 @@ pb.Response findUpdatedResponse(pb.Report beforeRep, pb.Report afterRep) {
 ///
 /// It only includes the values we can determine without dart:html or dart:io.
 pb.Platform createPlatform() {
-  return new pb.Platform()
+  return pb.Platform()
     ..dartVM = _isDartVM
     ..checkedMode = _implicitChecksEnabled;
 }
@@ -51,7 +51,7 @@ final bool _implicitChecksEnabled = () {
 /// Given the contents of the pubspec.yaml and pubspec.lock files,
 /// create a pb.Packages object.
 pb.Packages createPackages(String pubspecYaml, String pubspecLock) {
-  var out = new pb.Packages();
+  var out = pb.Packages();
 
   for (var line in pubspecYaml.split("\n")) {
     line = line.trim();
@@ -77,7 +77,7 @@ Iterable<pb.PackageVersion> _parseLockFile(String contents) sync* {
 
   for (var entry in packages.entries) {
     var map = entry.value as YamlMap;
-    var pkgVersion = new pb.PackageVersion()
+    var pkgVersion = pb.PackageVersion()
       ..name = entry.key as String
       ..source = map['source']
       ..version = map['version'];
@@ -93,7 +93,7 @@ Iterable<pb.PackageVersion> _parseLockFile(String contents) sync* {
 /// Encodes a report as nicely-formatted JSON.
 String encodeReport(pb.Report report) {
   var json = report.writeToJsonMap();
-  var out = new StringBuffer();
+  var out = StringBuffer();
   _stringifyMap(out, json, "");
   out.writeln();
   return out.toString();

--- a/api_benchmark/lib/suite.dart
+++ b/api_benchmark/lib/suite.dart
@@ -17,9 +17,9 @@ import 'generated/benchmark.pb.dart' as pb;
 Iterable<pb.Report> runSuite(List<pb.Request> requests,
     {samplesPerBatch = 1, Profiler profiler}) sync* {
   // Create a blank report with one response per request.
-  var report = new pb.Report()..status = pb.Status.RUNNING;
+  var report = pb.Report()..status = pb.Status.RUNNING;
   for (var request in requests) {
-    var r = new pb.Response()..request = request;
+    var r = pb.Response()..request = request;
     report.responses.add(r);
   }
 

--- a/api_benchmark/lib/suites/json.dart
+++ b/api_benchmark/lib/suites/json.dart
@@ -13,7 +13,7 @@ import '../benchmarks/repeated_string_json.dart';
 import '../generated/benchmark.pb.dart' show Suite;
 
 final Suite jsonSuite = () {
-  var suite = new Suite();
+  var suite = Suite();
   suite.requests.addAll([
     _int32(1, 100),
     _int32(2, 100),
@@ -46,20 +46,18 @@ final Suite jsonSuite = () {
   return suite;
 }();
 
-_int32(int width, int height) =>
-    new Int32Benchmark(width, height).makeRequest();
+_int32(int width, int height) => Int32Benchmark(width, height).makeRequest();
 
 _repeatedInt32(int width, int height) =>
-    new RepeatedInt32Benchmark(width, height).makeRequest();
+    RepeatedInt32Benchmark(width, height).makeRequest();
 
-_int64(int width, int height) =>
-    new Int64Benchmark(width, height).makeRequest();
+_int64(int width, int height) => Int64Benchmark(width, height).makeRequest();
 
 _repeatedInt64(int width, int height) =>
-    new RepeatedInt64Benchmark(width, height).makeRequest();
+    RepeatedInt64Benchmark(width, height).makeRequest();
 
 _string(int width, int height, int size) =>
-    new StringBenchmark(width, height, size).makeRequest();
+    StringBenchmark(width, height, size).makeRequest();
 
 _repeatedString(int width, int height, int size) =>
-    new RepeatedStringBenchmark(width, height, size).makeRequest();
+    RepeatedStringBenchmark(width, height, size).makeRequest();

--- a/api_benchmark/lib/suites/props.dart
+++ b/api_benchmark/lib/suites/props.dart
@@ -10,7 +10,7 @@ import '../benchmarks/has_strings.dart';
 import '../generated/benchmark.pb.dart' show Suite;
 
 final Suite propsSuite = () {
-  var suite = new Suite();
+  var suite = Suite();
   suite.requests.addAll([
     _getStrings(10, null),
     _getStrings(10, "x"),
@@ -24,8 +24,8 @@ final Suite propsSuite = () {
 }();
 
 _getStrings(int height, String fill) =>
-    new GetStringsBenchmark(height, fill).makeRequest();
+    GetStringsBenchmark(height, fill).makeRequest();
 _setStrings(int height, String fill) =>
-    new SetStringsBenchmark(height, fill).makeRequest();
+    SetStringsBenchmark(height, fill).makeRequest();
 _hasStrings(int height, String fill) =>
-    new HasStringsBenchmark(height, fill).makeRequest();
+    HasStringsBenchmark(height, fill).makeRequest();

--- a/api_benchmark/lib/vm.dart
+++ b/api_benchmark/lib/vm.dart
@@ -43,7 +43,7 @@ runSuiteInVM(pb.Suite suite) async {
 
   // save the report to a file
   var outFile = "${dataDir.path}/$latestVMReportName";
-  var tmpFile = new File("$outFile.tmp");
+  var tmpFile = File("$outFile.tmp");
   await tmpFile.writeAsString(encodeReport(lastReport));
   await tmpFile.rename(outFile);
   print("\nWrote result to ${outFile}");
@@ -55,7 +55,7 @@ String _summarize(pb.Response r) {
   return b.summarizeResponse(r);
 }
 
-final _escapeChar = new String.fromCharCode(27);
+final _escapeChar = String.fromCharCode(27);
 final _clearLine = "\r$_escapeChar[2K";
 
 /// Overwrite the last line printed to the terminal.
@@ -71,10 +71,10 @@ Future<pb.Env> _loadEnv() async {
     ..osType = _osType
     ..dartVersion = Platform.version;
 
-  var pubspec = await (new File(pubspecYaml.path).readAsString());
-  var lock = await (new File(pubspecLock.path).readAsString());
+  var pubspec = await (File(pubspecYaml.path).readAsString());
+  var lock = await (File(pubspecLock.path).readAsString());
 
-  return new pb.Env()
+  return pb.Env()
     ..script = _script
     ..platform = platform
     ..packages = createPackages(pubspec, lock);
@@ -118,12 +118,12 @@ pb.OSType get _osType {
   throw "unknown OS type";
 }
 
-final File hostnameFile = new File("${dataDir.path}/$hostfileName");
-final Link pubspecYaml = new Link("${dataDir.path}/$pubspecYamlName");
-final Link pubspecLock = new Link("${dataDir.path}/$pubspecLockName");
+final File hostnameFile = File("${dataDir.path}/$hostfileName");
+final Link pubspecYaml = Link("${dataDir.path}/$pubspecYamlName");
+final Link pubspecLock = Link("${dataDir.path}/$pubspecLockName");
 
 final Directory dataDir = () {
-  var d = new Directory("${pubspecDir.path}/web/data");
+  var d = Directory("${pubspecDir.path}/web/data");
   if (!d.existsSync()) {
     throw "data dir doesn't exist at ${d.path}";
   }
@@ -133,7 +133,7 @@ final Directory dataDir = () {
 /// Returns the drectory containing the pubspec.yaml file.
 final Directory pubspecDir = () {
   for (var d = Directory.current; d.parent != d; d = d.parent) {
-    if (new File("${d.path}/pubspec.yaml").existsSync()) {
+    if (File("${d.path}/pubspec.yaml").existsSync()) {
       return d;
     }
   }

--- a/protobuf/benchmarks/benchmark_js.dart
+++ b/protobuf/benchmarks/benchmark_js.dart
@@ -19,11 +19,11 @@ final files = [
 
 void main(List<String> arguments) {
   final List<Dataset> datasets = files
-      .map((file) => new Dataset.fromBinary(readAsBytesSync(file)))
+      .map((file) => Dataset.fromBinary(readAsBytesSync(file)))
       .toList(growable: false);
 
-  new FromBinaryBenchmark(datasets).report();
-  new ToBinaryBenchmark(datasets).report();
-  new ToJsonBenchmark(datasets).report();
-  new FromJsonBenchmark(datasets).report();
+  FromBinaryBenchmark(datasets).report();
+  ToBinaryBenchmark(datasets).report();
+  ToJsonBenchmark(datasets).report();
+  FromJsonBenchmark(datasets).report();
 }

--- a/protobuf/benchmarks/benchmark_vm.dart
+++ b/protobuf/benchmarks/benchmark_vm.dart
@@ -13,15 +13,15 @@ import 'dart:io';
 import 'common.dart';
 
 void main(List<String> arguments) {
-  final datasetPattern = new RegExp(r'dataset\.[._\w]*\.pb$');
-  final datasets = new Directory(Platform.script.resolve('..').toFilePath())
+  final datasetPattern = RegExp(r'dataset\.[._\w]*\.pb$');
+  final datasets = Directory(Platform.script.resolve('..').toFilePath())
       .listSync(recursive: true)
       .where((file) => datasetPattern.hasMatch(file.path))
-      .map((file) => new Dataset.fromBinary((file as File).readAsBytesSync()))
+      .map((file) => Dataset.fromBinary((file as File).readAsBytesSync()))
       .toList(growable: false);
 
-  new FromBinaryBenchmark(datasets).report();
-  new ToBinaryBenchmark(datasets).report();
-  new ToJsonBenchmark(datasets).report();
-  new FromJsonBenchmark(datasets).report();
+  FromBinaryBenchmark(datasets).report();
+  ToBinaryBenchmark(datasets).report();
+  ToJsonBenchmark(datasets).report();
+  FromJsonBenchmark(datasets).report();
 }

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -45,13 +45,13 @@ class Dataset {
   /// Create [Dataset] from a [BenchmarkDataset] proto.
   factory Dataset.fromBinary(List<int> binary) {
     final dataSet =
-        new BenchmarkDataset.fromBuffer(binary); // ignore: undefined_class
+        BenchmarkDataset.fromBuffer(binary); // ignore: undefined_class
 
     final factories = Factories.forMessage(dataSet.messageName);
-    final ds = new Dataset._(dataSet.name, factories);
+    final ds = Dataset._(dataSet.name, factories);
 
     for (var payload in dataSet.payload) {
-      final bytes = new Uint8List.fromList(payload);
+      final bytes = Uint8List.fromList(payload);
       final msg = factories.fromBuffer(bytes);
       ds.packed.add(bytes);
       ds.unpacked.add(msg);
@@ -77,23 +77,21 @@ class Factories {
   /// Mapping between [BenchmarkProto.messageName] and corresponding
   /// deserialization factories.
   static final _factories = {
-    "benchmarks.proto2.GoogleMessage1": new Factories._(
-        fromBuffer: (List<int> binary) =>
-            new p2.GoogleMessage1.fromBuffer(binary),
-        fromJson: (String json) => new p2.GoogleMessage1.fromJson(json)),
-    "benchmarks.proto3.GoogleMessage1": new Factories._(
-        fromBuffer: (List<int> binary) =>
-            new p3.GoogleMessage1.fromBuffer(binary),
-        fromJson: (String json) => new p3.GoogleMessage1.fromJson(json)),
-    "benchmarks.proto2.GoogleMessage2": new Factories._(
-        fromBuffer: (List<int> binary) => new GoogleMessage2.fromBuffer(binary),
-        fromJson: (String json) => new GoogleMessage2.fromJson(json)),
-    "benchmarks.google_message3.GoogleMessage3": new Factories._(
-        fromBuffer: (List<int> binary) => new GoogleMessage3.fromBuffer(binary),
-        fromJson: (String json) => new GoogleMessage3.fromJson(json)),
-    "benchmarks.google_message4.GoogleMessage4": new Factories._(
-        fromBuffer: (List<int> binary) => new GoogleMessage4.fromBuffer(binary),
-        fromJson: (String json) => new GoogleMessage4.fromJson(json)),
+    "benchmarks.proto2.GoogleMessage1": Factories._(
+        fromBuffer: (List<int> binary) => p2.GoogleMessage1.fromBuffer(binary),
+        fromJson: (String json) => p2.GoogleMessage1.fromJson(json)),
+    "benchmarks.proto3.GoogleMessage1": Factories._(
+        fromBuffer: (List<int> binary) => p3.GoogleMessage1.fromBuffer(binary),
+        fromJson: (String json) => p3.GoogleMessage1.fromJson(json)),
+    "benchmarks.proto2.GoogleMessage2": Factories._(
+        fromBuffer: (List<int> binary) => GoogleMessage2.fromBuffer(binary),
+        fromJson: (String json) => GoogleMessage2.fromJson(json)),
+    "benchmarks.google_message3.GoogleMessage3": Factories._(
+        fromBuffer: (List<int> binary) => GoogleMessage3.fromBuffer(binary),
+        fromJson: (String json) => GoogleMessage3.fromJson(json)),
+    "benchmarks.google_message4.GoogleMessage4": Factories._(
+        fromBuffer: (List<int> binary) => GoogleMessage4.fromBuffer(binary),
+        fromJson: (String json) => GoogleMessage4.fromJson(json)),
   };
 
   Factories._({this.fromBuffer, this.fromJson});

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// ignore_for_file: uri_has_not_been_generated,undefined_class
+// ignore_for_file: uri_has_not_been_generated,undefined_identifier
 
 /// Common platform independent benchmark infrastructure that can run
 /// both on the VM and when compiled to JavaScript.
@@ -45,7 +45,7 @@ class Dataset {
   /// Create [Dataset] from a [BenchmarkDataset] proto.
   factory Dataset.fromBinary(List<int> binary) {
     final dataSet =
-        BenchmarkDataset.fromBuffer(binary); // ignore: undefined_class
+        BenchmarkDataset.fromBuffer(binary);
 
     final factories = Factories.forMessage(dataSet.messageName);
     final ds = Dataset._(dataSet.name, factories);

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -44,8 +44,7 @@ class Dataset {
 
   /// Create [Dataset] from a [BenchmarkDataset] proto.
   factory Dataset.fromBinary(List<int> binary) {
-    final dataSet =
-        BenchmarkDataset.fromBuffer(binary);
+    final dataSet = BenchmarkDataset.fromBuffer(binary);
 
     final factories = Factories.forMessage(dataSet.messageName);
     final ds = Dataset._(dataSet.name, factories);

--- a/protobuf/benchmarks/d8.dart
+++ b/protobuf/benchmarks/d8.dart
@@ -18,5 +18,5 @@ external ByteBuffer readbuffer(String path);
 /// Read the file at the given [path] and return its contents in
 /// a Uint8List.
 Uint8List readAsBytesSync(String file) {
-  return new Uint8List.view(readbuffer(file));
+  return Uint8List.view(readbuffer(file));
 }

--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -7,7 +7,7 @@
 library protobuf.meta;
 
 // List of names which cannot be used in a subclass of GeneratedMessage.
-const GeneratedMessage_reservedNames = const <String>[
+const GeneratedMessage_reservedNames = <String>[
   'hashCode',
   'noSuchMethod',
   'copyWith',
@@ -74,7 +74,7 @@ const GeneratedMessage_reservedNames = const <String>[
 ];
 
 // List of names which cannot be used in a subclass of ProtobufEnum.
-const ProtobufEnum_reservedNames = const <String>[
+const ProtobufEnum_reservedNames = <String>[
   '==',
   'Object',
   'ProtobufEnum',

--- a/protobuf/lib/mixins_meta.dart
+++ b/protobuf/lib/mixins_meta.dart
@@ -48,7 +48,7 @@ class PbMixin {
 
   /// Returns all the reserved names, including from ancestor mixins.
   Iterable<String> findReservedNames() {
-    var names = new Set<String>();
+    var names = Set<String>();
     for (var m = this; m != null; m = m.parent) {
       names.add(m.name);
       if (m.reservedNames != null) {
@@ -62,15 +62,15 @@ class PbMixin {
 /// The mixins that findMixin() can return.
 final _exportedMixins = [_pbMapMixin, _pbEventMixin];
 
-const _pbMapMixin = const PbMixin("PbMapMixin",
+const _pbMapMixin = PbMixin("PbMapMixin",
     importFrom: "package:protobuf/src/protobuf/mixins/map_mixin.dart",
     parent: _mapMixin);
 
-const _pbEventMixin = const PbMixin("PbEventMixin",
+const _pbEventMixin = PbMixin("PbEventMixin",
     importFrom: "package:protobuf/src/protobuf/mixins/event_mixin.dart",
-    reservedNames: const ["changes", "deliverChanges"]);
+    reservedNames: ["changes", "deliverChanges"]);
 
-const List<String> _reservedNamesForMap = const [
+const List<String> _reservedNamesForMap = [
   '[]',
   '[]=',
   'addAll',
@@ -94,5 +94,5 @@ const List<String> _reservedNamesForMap = const [
   'values',
 ];
 
-const _mapMixin = const PbMixin("MapMixin",
+const _mapMixin = PbMixin("MapMixin",
     importFrom: "dart:collection", reservedNames: _reservedNamesForMap);

--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -40,7 +40,7 @@ part 'src/protobuf/unpack.dart';
 part 'src/protobuf/wire_format.dart';
 
 // TODO(sra): Remove this method when clients upgrade to protoc 0.3.5
-Int64 makeLongInt(int n) => new Int64(n);
+Int64 makeLongInt(int n) => Int64(n);
 
 // TODO(sra): Use Int64.parse() when available - see http://dartbug.com/21915.
 Int64 parseLongInt(String text) {
@@ -50,4 +50,4 @@ Int64 parseLongInt(String text) {
   return Int64.parseInt(text);
 }
 
-const _utf8 = const Utf8Codec(allowMalformed: true);
+const _utf8 = Utf8Codec(allowMalformed: true);

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -9,7 +9,7 @@ class BuilderInfo {
   /// The fully qualified name of this message.
   final String qualifiedMessageName;
   final List<FieldInfo> byIndex = <FieldInfo>[];
-  final Map<int, FieldInfo> fieldInfo = new Map<int, FieldInfo>();
+  final Map<int, FieldInfo> fieldInfo = Map<int, FieldInfo>();
   final Map<String, FieldInfo> byTagAsString = <String, FieldInfo>{};
   final Map<String, FieldInfo> byName = <String, FieldInfo>{};
   // Maps a tag number to the corresponding oneof index (if any).
@@ -30,8 +30,8 @@ class BuilderInfo {
       ValueOfFunc valueOf,
       List<ProtobufEnum> enumValues) {
     var index = byIndex.length;
-    _addField(new FieldInfo<T>(name, tagNumber, index, fieldType,
-        defaultOrMaker, subBuilder, valueOf, enumValues));
+    _addField(FieldInfo<T>(name, tagNumber, index, fieldType, defaultOrMaker,
+        subBuilder, valueOf, enumValues));
   }
 
   void addMapField<K, V>(int tagNumber, String name, int keyFieldType,
@@ -50,8 +50,8 @@ class BuilderInfo {
       ValueOfFunc valueOf,
       List<ProtobufEnum> enumValues) {
     var index = byIndex.length;
-    _addField(new FieldInfo<T>.repeated(name, tagNumber, index, fieldType,
-        check, subBuilder, valueOf, enumValues));
+    _addField(FieldInfo<T>.repeated(name, tagNumber, index, fieldType, check,
+        subBuilder, valueOf, enumValues));
   }
 
   void _addField(FieldInfo fi) {
@@ -207,7 +207,7 @@ class BuilderInfo {
   List<FieldInfo> _computeSortedByTag() {
     // TODO(skybrian): perhaps the code generator should insert the FieldInfos
     // in tag number order, to avoid sorting them?
-    return new List<FieldInfo>.from(fieldInfo.values, growable: false)
+    return List<FieldInfo>.from(fieldInfo.values, growable: false)
       ..sort((FieldInfo a, FieldInfo b) => a.tagNumber.compareTo(b.tagNumber));
   }
 

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -72,7 +72,7 @@ void _mergeFromCodedBufferReader(
         var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
         if (value == null) {
           var unknown = fs._ensureUnknownFields();
-          unknown.mergeVarintField(tagNumber, new Int64(rawValue));
+          unknown.mergeVarintField(tagNumber, Int64(rawValue));
         } else {
           fs._setFieldUnchecked(fi, value);
         }
@@ -209,7 +209,7 @@ void _readPackableToListEnum(_FieldSet fs, CodedBufferReader input,
     var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
     if (value == null) {
       var unknown = fs._ensureUnknownFields();
-      unknown.mergeVarintField(tagNumber, new Int64(rawValue));
+      unknown.mergeVarintField(tagNumber, Int64(rawValue));
     } else {
       list.add(value);
     }

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -19,7 +19,7 @@ class CodedBufferReader {
   CodedBufferReader(List<int> buffer,
       {int recursionLimit = DEFAULT_RECURSION_LIMIT,
       int sizeLimit = DEFAULT_SIZE_LIMIT})
-      : _buffer = buffer is Uint8List ? buffer : new Uint8List(buffer.length)
+      : _buffer = buffer is Uint8List ? buffer : Uint8List(buffer.length)
           ..setRange(0, buffer.length, buffer),
         _recursionLimit = recursionLimit,
         _sizeLimit = math.min(sizeLimit, buffer.length) {
@@ -28,7 +28,7 @@ class CodedBufferReader {
 
   void checkLastTagWas(int value) {
     if (_lastTag != value) {
-      throw new InvalidProtocolBufferException.invalidEndTag();
+      throw InvalidProtocolBufferException.invalidEndTag();
     }
   }
 
@@ -36,14 +36,14 @@ class CodedBufferReader {
 
   void _withLimit(int byteLimit, callback) {
     if (byteLimit < 0) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'CodedBufferReader encountered an embedded string or message'
           ' which claimed to have negative size.');
     }
     byteLimit += _bufferPos;
     int oldLimit = _currentLimit;
     if ((oldLimit != -1 && byteLimit > oldLimit) || byteLimit > _sizeLimit) {
-      throw new InvalidProtocolBufferException.truncatedMessage();
+      throw InvalidProtocolBufferException.truncatedMessage();
     }
     _currentLimit = byteLimit;
     callback();
@@ -54,14 +54,14 @@ class CodedBufferReader {
     assert(_currentLimit != -1);
     _bufferPos += increment;
     if (_bufferPos > _currentLimit) {
-      throw new InvalidProtocolBufferException.truncatedMessage();
+      throw InvalidProtocolBufferException.truncatedMessage();
     }
   }
 
   void readGroup(int fieldNumber, GeneratedMessage message,
       ExtensionRegistry extensionRegistry) {
     if (_recursionDepth >= _recursionLimit) {
-      throw new InvalidProtocolBufferException.recursionLimitExceeded();
+      throw InvalidProtocolBufferException.recursionLimitExceeded();
     }
     ++_recursionDepth;
     message.mergeFromCodedBufferReader(this, extensionRegistry);
@@ -71,10 +71,10 @@ class CodedBufferReader {
 
   UnknownFieldSet readUnknownFieldSetGroup(int fieldNumber) {
     if (_recursionDepth >= _recursionLimit) {
-      throw new InvalidProtocolBufferException.recursionLimitExceeded();
+      throw InvalidProtocolBufferException.recursionLimitExceeded();
     }
     ++_recursionDepth;
-    UnknownFieldSet unknownFieldSet = new UnknownFieldSet();
+    UnknownFieldSet unknownFieldSet = UnknownFieldSet();
     unknownFieldSet.mergeFromCodedBufferReader(this);
     checkLastTagWas(makeTag(fieldNumber, WIRETYPE_END_GROUP));
     --_recursionDepth;
@@ -85,10 +85,10 @@ class CodedBufferReader {
       GeneratedMessage message, ExtensionRegistry extensionRegistry) {
     int length = readInt32();
     if (_recursionDepth >= _recursionLimit) {
-      throw new InvalidProtocolBufferException.recursionLimitExceeded();
+      throw InvalidProtocolBufferException.recursionLimitExceeded();
     }
     if (length < 0) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'CodedBufferReader encountered an embedded string or message'
           ' which claimed to have negative size.');
     }
@@ -96,7 +96,7 @@ class CodedBufferReader {
     int oldLimit = _currentLimit;
     _currentLimit = _bufferPos + length;
     if (_currentLimit > oldLimit) {
-      throw new InvalidProtocolBufferException.truncatedMessage();
+      throw InvalidProtocolBufferException.truncatedMessage();
     }
     ++_recursionDepth;
     message.mergeFromCodedBufferReader(this, extensionRegistry);
@@ -117,15 +117,15 @@ class CodedBufferReader {
   int readSfixed32() => _readByteData(4).getInt32(0, Endian.little);
   Int64 readSfixed64() {
     var data = _readByteData(8);
-    var view = new Uint8List.view(data.buffer, data.offsetInBytes, 8);
-    return new Int64.fromBytes(view);
+    var view = Uint8List.view(data.buffer, data.offsetInBytes, 8);
+    return Int64.fromBytes(view);
   }
 
   bool readBool() => _readRawVarint32(true) != 0;
   List<int> readBytes() {
     int length = readInt32();
     _checkLimit(length);
-    return new Uint8List.view(
+    return Uint8List.view(
         _buffer.buffer, _buffer.offsetInBytes + _bufferPos - length, length);
   }
 
@@ -141,7 +141,7 @@ class CodedBufferReader {
 
     _lastTag = readInt32();
     if (getTagFieldNumber(_lastTag) == 0) {
-      throw new InvalidProtocolBufferException.invalidTag();
+      throw InvalidProtocolBufferException.invalidTag();
     }
     return _lastTag;
   }
@@ -182,7 +182,7 @@ class CodedBufferReader {
       }
     }
     _bufferPos = bufferPos;
-    throw new InvalidProtocolBufferException.malformedVarint();
+    throw InvalidProtocolBufferException.malformedVarint();
   }
 
   Int64 _readRawVarint64() {
@@ -193,7 +193,7 @@ class CodedBufferReader {
     for (int i = 0; i < 4; i++) {
       int byte = _readRawVarintByte();
       lo |= (byte & 0x7f) << (i * 7);
-      if ((byte & 0x80) == 0) return new Int64.fromInts(hi, lo);
+      if ((byte & 0x80) == 0) return Int64.fromInts(hi, lo);
     }
 
     // Read middle 7 bits: 4 low belong to low part above,
@@ -202,21 +202,21 @@ class CodedBufferReader {
     lo |= (byte & 0xf) << 28;
     hi = (byte >> 4) & 0x7;
     if ((byte & 0x80) == 0) {
-      return new Int64.fromInts(hi, lo);
+      return Int64.fromInts(hi, lo);
     }
 
     // Read remaining bits of hi.
     for (int i = 0; i < 5; i++) {
       int byte = _readRawVarintByte();
       hi |= (byte & 0x7f) << ((i * 7) + 3);
-      if ((byte & 0x80) == 0) return new Int64.fromInts(hi, lo);
+      if ((byte & 0x80) == 0) return Int64.fromInts(hi, lo);
     }
-    throw new InvalidProtocolBufferException.malformedVarint();
+    throw InvalidProtocolBufferException.malformedVarint();
   }
 
   ByteData _readByteData(int sizeInBytes) {
     _checkLimit(sizeInBytes);
-    return new ByteData.view(_buffer.buffer,
+    return ByteData.view(_buffer.buffer,
         _buffer.offsetInBytes + _bufferPos - sizeInBytes, sizeInBytes);
   }
 }

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -107,7 +107,7 @@ class CodedBufferWriter {
   }
 
   Uint8List toBuffer() {
-    Uint8List result = new Uint8List(_bytesTotal);
+    Uint8List result = Uint8List(_bytesTotal);
     writeTo(result);
     return result;
   }
@@ -184,9 +184,9 @@ class CodedBufferWriter {
     }
 
     if (allocateNew) {
-      _outputChunk = new Uint8List(_chunkLength);
+      _outputChunk = Uint8List(_chunkLength);
       _bytesInChunk = 0;
-      _outputChunkAsByteData = new ByteData.view(_outputChunk.buffer);
+      _outputChunkAsByteData = ByteData.view(_outputChunk.buffer);
     } else {
       _outputChunk = _outputChunkAsByteData = null;
       _bytesInChunk = 0;
@@ -335,7 +335,7 @@ class CodedBufferWriter {
         break;
       case PbFieldType._BYTES_BIT:
         _writeBytesNoTag(
-            value is TypedData ? value : new Uint8List.fromList(value));
+            value is TypedData ? value : Uint8List.fromList(value));
         break;
       case PbFieldType._STRING_BIT:
         _writeBytesNoTag(_utf8.encode(value));
@@ -424,7 +424,7 @@ class CodedBufferWriter {
       return pos;
     } else {
       int len = value.lengthInBytes;
-      Uint8List u8 = new Uint8List.view(
+      Uint8List u8 = Uint8List.view(
           value.buffer, value.offsetInBytes, value.lengthInBytes);
       for (int j = 0; j < len; j++) {
         buffer[pos++] = u8[j];
@@ -470,7 +470,7 @@ class CodedBufferWriter {
   static const _MESSAGE_BIT_INDEX = 20;
 
   /// Mapping from value types to wire-types indexed by _valueTypeIndex(...).
-  static final Uint8List _wireTypes = new Uint8List(32)
+  static final Uint8List _wireTypes = Uint8List(32)
     ..[_BOOL_BIT_INDEX] = WIRETYPE_VARINT
     ..[_BYTES_BIT_INDEX] = WIRETYPE_LENGTH_DELIMITED
     ..[_STRING_BIT_INDEX] = WIRETYPE_LENGTH_DELIMITED

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -50,7 +50,7 @@ class _ExtensionFieldSet {
   List<T> _getList<T>(Extension<T> fi) {
     var value = _values[fi.tagNumber];
     if (value != null) return value as List<T>;
-    if (_isReadOnly) return new List<T>.unmodifiable(const []);
+    if (_isReadOnly) return List<T>.unmodifiable(const []);
     return _addInfoAndCreateList(fi);
   }
 
@@ -81,11 +81,11 @@ class _ExtensionFieldSet {
   void _setField(int tagNumber, value) {
     var fi = _getInfoOrNull(tagNumber);
     if (fi == null) {
-      throw new ArgumentError(
+      throw ArgumentError(
           "tag $tagNumber not defined in $_parent._messageName");
     }
     if (fi.isRepeated) {
-      throw new ArgumentError(_parent._setFieldFailedMessage(
+      throw ArgumentError(_parent._setFieldFailedMessage(
           fi, value, 'repeating field (use get + .add())'));
     }
     _ensureWritable();
@@ -98,7 +98,7 @@ class _ExtensionFieldSet {
   void _setFieldAndInfo(Extension fi, value) {
     _ensureWritable();
     if (fi.isRepeated) {
-      throw new ArgumentError(_parent._setFieldFailedMessage(
+      throw ArgumentError(_parent._setFieldFailedMessage(
           fi, value, 'repeating field (use get + .add())'));
     }
     _ensureWritable();
@@ -114,7 +114,7 @@ class _ExtensionFieldSet {
 
   void _validateInfo(Extension fi) {
     if (fi.extendee != _parent._messageName) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'Extension $fi not legal for message ${_parent._messageName}');
     }
   }

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -10,12 +10,12 @@ class ExtensionRegistry {
   final Map<String, Map<int, Extension>> _extensions =
       <String, Map<int, Extension>>{};
 
-  static const ExtensionRegistry EMPTY = const _EmptyExtensionRegistry();
+  static const ExtensionRegistry EMPTY = _EmptyExtensionRegistry();
 
   /// Stores an [extension] in the registry.
   void add(Extension extension) {
     var map = _extensions.putIfAbsent(
-        extension.extendee, () => new Map<int, Extension>());
+        extension.extendee, () => Map<int, Extension>());
     map[extension.tagNumber] = extension;
   }
 
@@ -42,11 +42,11 @@ class _EmptyExtensionRegistry implements ExtensionRegistry {
   get _extensions => null;
 
   void add(Extension extension) {
-    throw new UnsupportedError('Immutable ExtensionRegistry');
+    throw UnsupportedError('Immutable ExtensionRegistry');
   }
 
   void addAll(Iterable<Extension> extensions) {
-    throw new UnsupportedError('Immutable ExtensionRegistry');
+    throw UnsupportedError('Immutable ExtensionRegistry');
   }
 
   Extension getExtension(String messageName, int tagNumber) => null;

--- a/protobuf/lib/src/protobuf/field_error.dart
+++ b/protobuf/lib/src/protobuf/field_error.dart
@@ -68,7 +68,7 @@ String _getFieldError(int fieldType, var value) {
 
 // generated checkItem for message, group, enum calls this
 void checkItemFailed(val, String className) {
-  throw new ArgumentError('Value ($val) is not an instance of ${className}');
+  throw ArgumentError('Value ($val) is not an instance of ${className}');
 }
 
 /// Returns a function for validating items in a repeated field.
@@ -107,14 +107,14 @@ CheckFunc getCheckFunction(int fieldType) {
     case PbFieldType._FIXED32_BIT:
       return _checkUnsigned32;
   }
-  throw new ArgumentError('check function not implemented: ${fieldType}');
+  throw ArgumentError('check function not implemented: ${fieldType}');
 }
 
 // check functions for repeated fields
 
 void _checkNotNull(Object val) {
   if (val == null) {
-    throw new ArgumentError("Can't add a null to a repeated field");
+    throw ArgumentError("Can't add a null to a repeated field");
   }
 }
 
@@ -133,7 +133,7 @@ void _checkUnsigned32(Object val) {
 }
 
 RangeError _createFieldRangeError(val, String wantedType) =>
-    new RangeError('Value ($val) is not ${wantedType}');
+    RangeError('Value ($val) is not ${wantedType}');
 
 bool _isSigned32(int value) => (-2147483648 <= value) && (value <= 2147483647);
 

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -53,7 +53,7 @@ class FieldInfo<T> {
       this.check, this.subBuilder,
       [this.valueOf, this.enumValues])
       : this.type = type,
-        this.makeDefault = (() => new PbList<T>(check: check)),
+        this.makeDefault = (() => PbList<T>(check: check)),
         _mapEntryBuilderInfo = null {
     assert(name != null);
     assert(tagNumber != null);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -9,10 +9,10 @@ typedef void FrozenMessageErrorHandler(String messageName, [String methodName]);
 void defaultFrozenMessageModificationHandler(String messageName,
     [String methodName]) {
   if (methodName != null) {
-    throw new UnsupportedError(
+    throw UnsupportedError(
         "Attempted to call $methodName on a read-only message ($messageName)");
   }
-  throw new UnsupportedError(
+  throw UnsupportedError(
       "Attempted to change a read-only message ($messageName)");
 }
 
@@ -58,12 +58,12 @@ class _FieldSet {
 
   static _makeValueList(int length) {
     if (length == 0) return _zeroList;
-    return new List(length);
+    return List(length);
   }
 
   // Use a fixed length list and not a constant list to ensure that _values
   // always has the same implementation type.
-  static List _zeroList = new List(0);
+  static List _zeroList = List(0);
 
   // Metadata about multiple fields
 
@@ -83,14 +83,14 @@ class _FieldSet {
   bool get _hasUnknownFields => _unknownFields != null;
 
   _ExtensionFieldSet _ensureExtensions() {
-    if (!_hasExtensions) _extensions = new _ExtensionFieldSet(this);
+    if (!_hasExtensions) _extensions = _ExtensionFieldSet(this);
     return _extensions;
   }
 
   UnknownFieldSet _ensureUnknownFields() {
     if (_unknownFields == null) {
       if (_isReadOnly) return UnknownFieldSet.emptyUnknownFieldSet;
-      _unknownFields = new UnknownFieldSet();
+      _unknownFields = UnknownFieldSet();
     }
     return _unknownFields;
   }
@@ -108,7 +108,7 @@ class _FieldSet {
   FieldInfo _ensureInfo(int tagNumber) {
     var fi = _getFieldInfoOrNull(tagNumber);
     if (fi != null) return fi;
-    throw new ArgumentError("tag $tagNumber not defined in $_messageName");
+    throw ArgumentError("tag $tagNumber not defined in $_messageName");
   }
 
   /// Returns the FieldInfo for a regular or extension field.
@@ -176,7 +176,7 @@ class _FieldSet {
         return _extensions._getFieldOrDefault(fi);
       }
     }
-    throw new ArgumentError("tag $tagNumber not defined in $_messageName");
+    throw ArgumentError("tag $tagNumber not defined in $_messageName");
   }
 
   _getDefault(FieldInfo fi) {
@@ -193,7 +193,7 @@ class _FieldSet {
 
   List<T> _getDefaultList<T>(FieldInfo<T> fi) {
     assert(fi.isRepeated);
-    if (_isReadOnly) return new List.unmodifiable(const []);
+    if (_isReadOnly) return List.unmodifiable(const []);
 
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:
@@ -271,19 +271,19 @@ class _FieldSet {
   /// Works for both extended and non-extended fields.
   /// Suitable for public API.
   void _setField(int tagNumber, value) {
-    if (value == null) throw new ArgumentError('value is null');
+    if (value == null) throw ArgumentError('value is null');
 
     var fi = _nonExtensionInfo(tagNumber);
     if (fi == null) {
       if (!_hasExtensions) {
-        throw new ArgumentError("tag $tagNumber not defined in $_messageName");
+        throw ArgumentError("tag $tagNumber not defined in $_messageName");
       }
       _extensions._setField(tagNumber, value);
       return;
     }
 
     if (fi.isRepeated) {
-      throw new ArgumentError(_setFieldFailedMessage(
+      throw ArgumentError(_setFieldFailedMessage(
           fi, value, 'repeating field (use get + .add())'));
     }
     _validateField(fi, value);
@@ -617,7 +617,7 @@ class _FieldSet {
     if (_hasUnknownFields) {
       out.write(_unknownFields.toString());
     } else {
-      out.write(new UnknownFieldSet().toString());
+      out.write(UnknownFieldSet().toString());
     }
   }
 
@@ -724,7 +724,7 @@ class _FieldSet {
     _ensureWritable();
     var message = _getFieldError(fi.type, newValue);
     if (message != null) {
-      throw new ArgumentError(_setFieldFailedMessage(fi, newValue, message));
+      throw ArgumentError(_setFieldFailedMessage(fi, newValue, message));
     }
   }
 

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -20,19 +20,19 @@ abstract class GeneratedMessage {
   _FieldSet _fieldSet;
 
   GeneratedMessage() {
-    _fieldSet = new _FieldSet(this, info_, eventPlugin);
+    _fieldSet = _FieldSet(this, info_, eventPlugin);
     if (eventPlugin != null) eventPlugin.attach(this);
   }
 
   GeneratedMessage.fromBuffer(
       List<int> input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = new _FieldSet(this, info_, eventPlugin);
+    _fieldSet = _FieldSet(this, info_, eventPlugin);
     if (eventPlugin != null) eventPlugin.attach(this);
     mergeFromBuffer(input, extensionRegistry);
   }
 
   GeneratedMessage.fromJson(String input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = new _FieldSet(this, info_, eventPlugin);
+    _fieldSet = _FieldSet(this, info_, eventPlugin);
     if (eventPlugin != null) eventPlugin.attach(this);
     mergeFromJson(input, extensionRegistry);
   }
@@ -132,7 +132,7 @@ abstract class GeneratedMessage {
   /// This generates the same output as [toString], but can be used by mixins
   /// to compose debug strings with additional information.
   String toDebugString() {
-    var out = new StringBuffer();
+    var out = StringBuffer();
     _fieldSet.writeString(out, '');
     return out.toString();
   }
@@ -142,12 +142,12 @@ abstract class GeneratedMessage {
       List<String> invalidFields = <String>[];
       _fieldSet._appendInvalidFields(invalidFields, "");
       String missingFields = (invalidFields..sort()).join(', ');
-      throw new StateError('Message missing required fields: $missingFields');
+      throw StateError('Message missing required fields: $missingFields');
     }
   }
 
   Uint8List writeToBuffer() {
-    CodedBufferWriter out = new CodedBufferWriter();
+    CodedBufferWriter out = CodedBufferWriter();
     writeToCodedBufferWriter(out);
     return out.toBuffer();
   }
@@ -169,7 +169,7 @@ abstract class GeneratedMessage {
   ///   the existing sub-message.
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
-    CodedBufferReader codedInput = new CodedBufferReader(input);
+    CodedBufferReader codedInput = CodedBufferReader(input);
     _mergeFromCodedBufferReader(_fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);
   }
@@ -223,7 +223,7 @@ abstract class GeneratedMessage {
   /// If the list already exists, the old extension won't be overwritten.
   void addExtension(Extension extension, var value) {
     if (!extension.isRepeated) {
-      throw new ArgumentError(
+      throw ArgumentError(
           'Cannot add to a non-repeated field (use setExtension())');
     }
     _fieldSet._ensureExtensions().._ensureRepeatedField(extension).add(value);
@@ -264,7 +264,7 @@ abstract class GeneratedMessage {
   /// validate all items added to it. This can most easily be done
   /// using the FieldInfo.check function.
   List<T> createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
-    return new PbList<T>(check: fi.check);
+    return PbList<T>(check: fi.check);
   }
 
   /// Creates a Map representing a map field.
@@ -309,9 +309,9 @@ abstract class GeneratedMessage {
 
   /// Sets the value of a non-repeated extension field to [value].
   void setExtension(Extension extension, value) {
-    if (value == null) throw new ArgumentError('value is null');
+    if (value == null) throw ArgumentError('value is null');
     if (_isRepeated(extension.type)) {
-      throw new ArgumentError(_fieldSet._setFieldFailedMessage(
+      throw ArgumentError(_fieldSet._setFieldFailedMessage(
           extension, value, 'repeating field (use get + .add())'));
     }
     _fieldSet._ensureExtensions()._setFieldAndInfo(extension, value);

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -9,7 +9,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
     int baseType = PbFieldType._baseType(fieldType);
 
     if (_isRepeated(fieldType)) {
-      return new List.from(fieldValue.map((e) => convertToMap(e, baseType)));
+      return List.from(fieldValue.map((e) => convertToMap(e, baseType)));
     }
 
     switch (baseType) {
@@ -43,7 +43,7 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
   }
 
   _writeMap(dynamic fieldValue, MapFieldInfo fi) {
-    return new List.from(fieldValue.entries.map((MapEntry e) => {
+    return List.from(fieldValue.entries.map((MapEntry e) => {
           '${PbMap._keyFieldNumber}': convertToMap(e.key, fi.keyFieldType),
           '${PbMap._valueFieldNumber}': convertToMap(e.value, fi.valueFieldType)
         }));
@@ -228,7 +228,7 @@ _convertJsonValue(_FieldSet fs, value, int tagNumber, int fieldType,
     case PbFieldType._UINT64_BIT:
     case PbFieldType._FIXED64_BIT:
     case PbFieldType._SFIXED64_BIT:
-      if (value is int) return new Int64(value);
+      if (value is int) return Int64(value);
       if (value is String) return Int64.parseInt(value);
       expectedType = 'int or stringified int';
       break;
@@ -244,7 +244,7 @@ _convertJsonValue(_FieldSet fs, value, int tagNumber, int fieldType,
       expectedType = 'nested message or group';
       break;
     default:
-      throw new ArgumentError('Unknown type $fieldType');
+      throw ArgumentError('Unknown type $fieldType');
   }
-  throw new ArgumentError('Expected type $expectedType, got $value');
+  throw ArgumentError('Expected type $expectedType, got $value');
 }

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -16,7 +16,7 @@ import "package:protobuf/protobuf.dart"
 /// This mixin is enabled via an option in
 /// dart_options.proto in dart-protoc-plugin.
 abstract class PbEventMixin {
-  final eventPlugin = new EventBuffer();
+  final eventPlugin = EventBuffer();
 
   /// A stream of changes to fields in the GeneratedMessage.
   ///
@@ -63,7 +63,7 @@ class EventBuffer extends EventPlugin {
 
   Stream<List<PbFieldChange>> get changes {
     if (_controller == null) {
-      _controller = new StreamController.broadcast(sync: true);
+      _controller = StreamController.broadcast(sync: true);
     }
     return _controller.stream;
   }
@@ -74,7 +74,7 @@ class EventBuffer extends EventPlugin {
     var records = _buffer;
     _buffer = null;
     if (records != null && hasObservers) {
-      _controller.add(new UnmodifiableListView<PbFieldChange>(records));
+      _controller.add(UnmodifiableListView<PbFieldChange>(records));
     }
   }
 
@@ -92,7 +92,7 @@ class EventBuffer extends EventPlugin {
     var oldValue = _parent.getFieldOrNull(fi.tagNumber);
     if (oldValue == null) oldValue = fi.readonlyDefault;
     if (identical(oldValue, newValue)) return;
-    addEvent(new PbFieldChange(_parent, fi, oldValue, newValue));
+    addEvent(PbFieldChange(_parent, fi, oldValue, newValue));
   }
 
   @override
@@ -100,6 +100,6 @@ class EventBuffer extends EventPlugin {
     var oldValue = _parent.getFieldOrNull(fi.tagNumber);
     if (oldValue == null) return;
     var newValue = fi.readonlyDefault;
-    addEvent(new PbFieldChange(_parent, fi, oldValue, newValue));
+    addEvent(PbFieldChange(_parent, fi, oldValue, newValue));
   }
 }

--- a/protobuf/lib/src/protobuf/mixins/map_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/map_mixin.dart
@@ -31,7 +31,7 @@ abstract class PbMapMixin {
   operator []=(key, val) {
     var tag = getTagNumber(key as String);
     if (tag == null) {
-      throw new ArgumentError(
+      throw ArgumentError(
           "field '${key}' not found in ${info_.qualifiedMessageName}");
     }
     setField(tag, val);
@@ -44,7 +44,7 @@ abstract class PbMapMixin {
   int get length => info_.byName.length;
 
   remove(key) {
-    throw new UnsupportedError(
+    throw UnsupportedError(
         "remove() not supported by ${info_.qualifiedMessageName}");
   }
 }

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -10,10 +10,10 @@ class FrozenPbList<E> extends PbListBase<E> {
   FrozenPbList._(List<E> wrappedList) : super._(wrappedList);
 
   factory FrozenPbList.from(PbList<E> other) =>
-      new FrozenPbList._(other._wrappedList);
+      FrozenPbList._(other._wrappedList);
 
   UnsupportedError _unsupported(String method) =>
-      new UnsupportedError("Cannot call $method on an unmodifiable list");
+      UnsupportedError("Cannot call $method on an unmodifiable list");
 
   void operator []=(int index, E value) => throw _unsupported("set");
   set length(int newLength) => throw _unsupported("set length");
@@ -54,7 +54,7 @@ class PbList<E> extends PbListBase<E> {
       : super._noList(check: getCheckFunction(fieldType));
 
   /// Freezes the list by converting to [FrozenPbList].
-  FrozenPbList<E> toFrozenPbList() => new FrozenPbList<E>.from(this);
+  FrozenPbList<E> toFrozenPbList() => FrozenPbList<E>.from(this);
 
   /// Adds [value] at the end of the list, extending the length by one.
   /// Throws an [UnsupportedError] if the list is not extendable.
@@ -164,7 +164,7 @@ abstract class PbListBase<E> extends ListBase<E> {
 
   PbListBase._from(List from)
       // TODO(sra): Should this be validated?
-      : _wrappedList = new List<E>.from(from),
+      : _wrappedList = List<E>.from(from),
         check = _checkNotNull;
 
   @override
@@ -321,7 +321,7 @@ abstract class PbListBase<E> extends ListBase<E> {
   /// [UnsupportedError] if the list is not extendable.
   set length(int newLength) {
     if (newLength > length) {
-      throw new UnsupportedError('Extending protobuf lists is not supported');
+      throw UnsupportedError('Extending protobuf lists is not supported');
     }
     _wrappedList.length = newLength;
   }

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -15,7 +15,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   final BuilderInfo _entryBuilderInfo;
 
   bool _isReadonly = false;
-  _FieldSet _entryFieldSet() => new _FieldSet(null, _entryBuilderInfo, null);
+  _FieldSet _entryFieldSet() => _FieldSet(null, _entryBuilderInfo, null);
 
   PbMap(this.keyFieldType, this.valueFieldType, this._entryBuilderInfo)
       : _wrappedMap = <K, V>{};
@@ -33,7 +33,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   @override
   void operator []=(K key, V value) {
     if (_isReadonly)
-      throw new UnsupportedError('Attempted to change a read-only map field');
+      throw UnsupportedError('Attempted to change a read-only map field');
     _checkNotNull(key);
     _checkNotNull(value);
     _wrappedMap[key] = value;
@@ -42,7 +42,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   @override
   void clear() {
     if (_isReadonly)
-      throw new UnsupportedError('Attempted to change a read-only map field');
+      throw UnsupportedError('Attempted to change a read-only map field');
     _wrappedMap.clear();
   }
 
@@ -52,7 +52,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   @override
   V remove(Object key) {
     if (_isReadonly)
-      throw new UnsupportedError('Attempted to change a read-only map field');
+      throw UnsupportedError('Attempted to change a read-only map field');
     return _wrappedMap.remove(key);
   }
 
@@ -77,7 +77,7 @@ class PbMap<K, V> extends MapBase<K, V> {
 
   void _checkNotNull(Object val) {
     if (val == null) {
-      throw new ArgumentError("Can't add a null to a map field");
+      throw ArgumentError("Can't add a null to a map field");
     }
   }
 

--- a/protobuf/lib/src/protobuf/protobuf_enum.dart
+++ b/protobuf/lib/src/protobuf/protobuf_enum.dart
@@ -38,7 +38,7 @@ class ProtobufEnum {
   /// Returns a Map for all of the [ProtobufEnum]s in [byIndex], mapping each
   /// [ProtobufEnum]'s [value] to the [ProtobufEnum].
   static Map<int, T> initByValue<T extends ProtobufEnum>(List<T> byIndex) {
-    var byValue = new Map<int, T>();
+    var byValue = Map<int, T>();
     for (T v in byIndex) {
       byValue[v.value] = v;
     }

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -8,7 +8,7 @@ class UnknownFieldSet {
   static final UnknownFieldSet emptyUnknownFieldSet = UnknownFieldSet()
     .._markReadOnly();
   final Map<int, UnknownFieldSetField> _fields =
-      new Map<int, UnknownFieldSetField>();
+      Map<int, UnknownFieldSetField>();
 
   UnknownFieldSet();
 
@@ -16,13 +16,13 @@ class UnknownFieldSet {
     mergeFromUnknownFieldSet(unknownFieldSet);
   }
 
-  UnknownFieldSet clone() => new UnknownFieldSet._clone(this);
+  UnknownFieldSet clone() => UnknownFieldSet._clone(this);
 
   bool get isEmpty => _fields.isEmpty;
   bool get isNotEmpty => _fields.isNotEmpty;
   bool _isReadOnly = false;
 
-  Map<int, UnknownFieldSetField> asMap() => new Map.from(_fields);
+  Map<int, UnknownFieldSetField> asMap() => Map.from(_fields);
 
   void clear() {
     _ensureWritable('clear');
@@ -72,7 +72,7 @@ class UnknownFieldSet {
         mergeFixed32Field(number, input.readFixed32());
         return true;
       default:
-        throw new InvalidProtocolBufferException.invalidWireType();
+        throw InvalidProtocolBufferException.invalidWireType();
     }
   }
 
@@ -95,7 +95,7 @@ class UnknownFieldSet {
 
   _checkFieldNumber(int number) {
     if (number == 0) {
-      throw new ArgumentError('Zero is not a valid field number.');
+      throw ArgumentError('Zero is not a valid field number.');
     }
   }
 
@@ -127,7 +127,7 @@ class UnknownFieldSet {
   UnknownFieldSetField _getField(int number) {
     _checkFieldNumber(number);
     if (_isReadOnly) assert(_fields.containsKey(number));
-    return _fields.putIfAbsent(number, () => new UnknownFieldSetField());
+    return _fields.putIfAbsent(number, () => UnknownFieldSetField());
   }
 
   bool operator ==(other) {
@@ -149,7 +149,7 @@ class UnknownFieldSet {
   String toString() => _toString('');
 
   String _toString(String indent) {
-    var stringBuffer = new StringBuffer();
+    var stringBuffer = StringBuffer();
 
     for (int tag in sorted(_fields.keys)) {
       var field = _fields[tag];

--- a/protobuf/lib/src/protobuf/unpack.dart
+++ b/protobuf/lib/src/protobuf/unpack.dart
@@ -22,7 +22,7 @@ void unpackIntoHelper<T extends GeneratedMessage>(
   //   name "y.z".
   if (!canUnpackIntoHelper(instance, typeUrl)) {
     String typeName = instance.info_.qualifiedMessageName;
-    throw new InvalidProtocolBufferException.wrongAnyMessage(
+    throw InvalidProtocolBufferException.wrongAnyMessage(
         _typeNameFromUrl(typeUrl), typeName);
   }
   instance.mergeFromBuffer(value, extensionRegistry);

--- a/protobuf/lib/src/protobuf/utils.dart
+++ b/protobuf/lib/src/protobuf/utils.dart
@@ -31,8 +31,8 @@ bool _areMapsEqual(Map lhs, Map rhs) {
 }
 
 bool _areByteDataEqual(ByteData lhs, ByteData rhs) {
-  asBytes(d) => new Uint8List.view(d.buffer, d.offsetInBytes, d.lengthInBytes);
+  asBytes(d) => Uint8List.view(d.buffer, d.offsetInBytes, d.lengthInBytes);
   return _areListsEqual(asBytes(lhs), asBytes(rhs));
 }
 
-List<T> sorted<T>(Iterable<T> list) => new List.from(list)..sort();
+List<T> sorted<T>(Iterable<T> list) => List.from(list)..sort();

--- a/protobuf/test/builder_info_test.dart
+++ b/protobuf/test/builder_info_test.dart
@@ -10,12 +10,12 @@ main() {
     final qualifiedmessageName = 'proto.test.TestMessage';
     final expectedMessageName = 'TestMessage';
     test('truncates qualifiedMessageName containing dots', () {
-      final info = new BuilderInfo(qualifiedmessageName);
+      final info = BuilderInfo(qualifiedmessageName);
       expect(info.messageName, expectedMessageName);
     });
 
     test('uses qualifiedMessageName if it contains no dots', () {
-      final info = new BuilderInfo(expectedMessageName);
+      final info = BuilderInfo(expectedMessageName);
       expect(info.messageName, expectedMessageName);
     });
   });

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -15,17 +15,17 @@ import 'test_util.dart';
 typedef void RoundtripTester<T>(T value, List<int> bytes);
 
 void main() {
-  ByteData makeData(Uint8List bytes) => new ByteData.view(bytes.buffer);
+  ByteData makeData(Uint8List bytes) => ByteData.view(bytes.buffer);
 
   convertToBytes(fieldType) => (value) {
-        var writer = new CodedBufferWriter()..writeField(0, fieldType, value);
+        var writer = CodedBufferWriter()..writeField(0, fieldType, value);
         return writer.toBuffer().sublist(1);
       };
 
   RoundtripTester<T> roundtripTester<T>(
       {T fromBytes(CodedBufferReader bytes), List<int> toBytes(T value)}) {
     return (T value, List<int> bytes) {
-      expect(fromBytes(new CodedBufferReader(bytes)), equals(value));
+      expect(fromBytes(CodedBufferReader(bytes)), equals(value));
       expect(toBytes(value), bytes);
     };
   }
@@ -126,7 +126,7 @@ void main() {
   });
 
   test('testBool', () {
-    readBool(List<int> bytes) => new CodedBufferReader(bytes).readBool();
+    readBool(List<int> bytes) => CodedBufferReader(bytes).readBool();
 
     expect(readBool([0x00]), isFalse);
     expect(readBool([0x01]), isTrue);
@@ -139,17 +139,15 @@ void main() {
       ? predicate((x) => x.isNaN, 'NaN expected')
       : equals(expected);
 
-  List<int> dataToBytes(ByteData byteData) =>
-      new Uint8List.view(byteData.buffer);
+  List<int> dataToBytes(ByteData byteData) => Uint8List.view(byteData.buffer);
   final floatToBytes = convertToBytes(PbFieldType.OF);
   floatToBits(double value) =>
       makeData(floatToBytes(value)).getUint32(0, Endian.little);
 
   void _test32(int bits, double value) {
     readFloat(int bits) {
-      var bytes =
-          dataToBytes(new ByteData(4)..setUint32(0, bits, Endian.little));
-      return new CodedBufferReader(bytes).readFloat();
+      var bytes = dataToBytes(ByteData(4)..setUint32(0, bits, Endian.little));
+      return CodedBufferReader(bytes).readFloat();
     }
 
     expect(floatToBits(value), bits);
@@ -170,7 +168,7 @@ void main() {
 
     // Decode it again (round trip).
     List<int> bytes = dataToBytes(data);
-    double reencoded = new CodedBufferReader(bytes).readDouble();
+    double reencoded = CodedBufferReader(bytes).readDouble();
     expect(reencoded, doubleEquals(value));
   }
 
@@ -715,9 +713,9 @@ void main() {
   });
 
   test('testWriteTo', () {
-    var writer = new CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
+    var writer = CodedBufferWriter()..writeField(0, PbFieldType.O3, 1337);
     expect(writer.lengthInBytes, 3);
-    var buffer = new Uint8List(5);
+    var buffer = Uint8List(5);
     buffer[0] = 0x55;
     buffer[4] = 0xAA;
     var expected = writer.toBuffer();

--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -14,7 +14,7 @@ import 'test_util.dart';
 
 void main() {
   final throwsInvalidProtocolBufferException =
-      throwsA(new TypeMatcher<InvalidProtocolBufferException>());
+      throwsA(TypeMatcher<InvalidProtocolBufferException>());
 
   group('testCodedBufferReader', () {
     List<int> inputBuffer = <int>[
@@ -40,7 +40,7 @@ void main() {
     ];
 
     testWithList(List<int> inputBuffer) {
-      CodedBufferReader cis = new CodedBufferReader(inputBuffer);
+      CodedBufferReader cis = CodedBufferReader(inputBuffer);
 
       expect(cis.readTag(), makeTag(103, WIRETYPE_VARINT));
       expect(cis.readInt32(), 32);
@@ -87,24 +87,24 @@ void main() {
     });
 
     test('uint8-list', () {
-      var uint8List = new Uint8List.fromList(inputBuffer);
+      var uint8List = Uint8List.fromList(inputBuffer);
       testWithList(uint8List);
     });
 
     test('uint8-list-view', () {
-      var uint8List = new Uint8List(inputBuffer.length + 4);
+      var uint8List = Uint8List(inputBuffer.length + 4);
       uint8List[0] = 0xc0;
       uint8List[1] = 0xc8;
       uint8List.setRange(2, 2 + inputBuffer.length, inputBuffer);
       uint8List[inputBuffer.length + 2] = 0xe0;
       uint8List[inputBuffer.length + 3] = 0xed;
-      var view = new Uint8List.view(uint8List.buffer, 2, inputBuffer.length);
+      var view = Uint8List.view(uint8List.buffer, 2, inputBuffer.length);
       testWithList(view);
     });
   });
 
   test('testReadMaliciouslyLargeBlob', () {
-    CodedBufferWriter output = new CodedBufferWriter();
+    CodedBufferWriter output = CodedBufferWriter();
 
     int tag = makeTag(1, WIRETYPE_LENGTH_DELIMITED);
     output.writeInt32NoTag(tag);
@@ -114,7 +114,7 @@ void main() {
     output.writeInt32NoTag(32);
     output.writeInt32NoTag(47);
 
-    CodedBufferReader input = new CodedBufferReader(output.toBuffer());
+    CodedBufferReader input = CodedBufferReader(output.toBuffer());
     expect(input.readTag(), tag);
 
     expect(() {
@@ -126,7 +126,7 @@ void main() {
   /// is thrown. Instead, the invalid bytes are replaced with the Unicode
   /// 'replacement character' U+FFFD.
   test('testReadInvalidUtf8', () {
-    CodedBufferReader input = new CodedBufferReader([1, 0x80]);
+    CodedBufferReader input = CodedBufferReader([1, 0x80]);
     String text = input.readString();
     expect(text.codeUnitAt(0), 0xfffd);
   });
@@ -136,7 +136,7 @@ void main() {
     // should throw InvalidProtocolBufferException.
     for (int i = 0; i < 8; i++) {
       expect(() {
-        new CodedBufferReader([i]).readTag();
+        CodedBufferReader([i]).readTag();
       }, throwsInvalidProtocolBufferException);
     }
   });

--- a/protobuf/test/event_test.dart
+++ b/protobuf/test/event_test.dart
@@ -17,16 +17,16 @@ import 'mock_util.dart' show MockMessage, mockInfo;
 
 class Rec extends MockMessage with PbEventMixin {
   get info_ => _info;
-  static final _info = mockInfo("Rec", () => new Rec());
-  Rec createEmptyInstance() => new Rec();
+  static final _info = mockInfo("Rec", () => Rec());
+  Rec createEmptyInstance() => Rec();
 }
 
-Extension comment = new Extension("Rec", "comment", 6, PbFieldType.OS);
+Extension comment = Extension("Rec", "comment", 6, PbFieldType.OS);
 
 main() {
   test('Events are sent when setting and clearing a non-repeated field', () {
     var log = makeLog();
-    var r = new Rec();
+    var r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -54,7 +54,7 @@ main() {
 
   test('Events are sent when creating and clearing a repeated field', () {
     var log = makeLog();
-    var r = new Rec();
+    var r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -82,10 +82,10 @@ main() {
 
   test('Events are sent when clearing multiple fields', () {
     var log = makeLog();
-    var r = new Rec()
+    var r = Rec()
       ..val = 123
       ..str = "hello"
-      ..child = new Rec()
+      ..child = Rec()
       ..int32s.add(456);
 
     r.changes.listen((List<PbFieldChange> changes) {
@@ -112,13 +112,13 @@ main() {
 
   test('Events are sent when merging from another protobuf', () {
     var log = makeLog();
-    var src = new Rec()
+    var src = Rec()
       ..val = 123
       ..str = "hello"
-      ..child = new Rec()
+      ..child = Rec()
       ..int32s.add(456);
 
-    var dest = new Rec();
+    var dest = Rec();
     dest.changes.listen((List<PbFieldChange> changes) {
       checkHasAllFields(dest, true);
       log.add(changes);
@@ -142,7 +142,7 @@ main() {
 
   test('Events are sent when merging JSON', () {
     var log = makeLog();
-    var r = new Rec();
+    var r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       // verify that we are not called until all fields are set
       checkHasAllFields(r, true);
@@ -169,14 +169,14 @@ main() {
   test('Events are sent when merging binary', () {
     var log = makeLog();
 
-    Uint8List bytes = (new Rec()
+    Uint8List bytes = (Rec()
           ..val = 123
           ..str = "hello"
-          ..child = new Rec()
+          ..child = Rec()
           ..int32s.add(456))
         .writeToBuffer();
 
-    var r = new Rec();
+    var r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       // verify that we are not called until all fields are set
       checkHasAllFields(r, true);
@@ -202,7 +202,7 @@ main() {
 
   test('Events are sent for extensions', () {
     var log = makeLog();
-    var r = new Rec();
+    var r = Rec();
     r.changes.listen((List<PbFieldChange> changes) {
       log.add(changes);
     });
@@ -240,14 +240,14 @@ main() {
     r.deliverChanges();
     checkLogOnce(log, [tag, "hello", ""]);
 
-    var registry = new ExtensionRegistry()..add(comment);
+    var registry = ExtensionRegistry()..add(comment);
     r.mergeFromJson('{"$tag": "hello"}', registry);
     expect(r.getExtension(comment), "hello");
     r.deliverChanges();
     checkLogOnce(log, [tag, "", "hello"]);
     clear("hello");
 
-    var src = new Rec()..setExtension(comment, "hello");
+    var src = Rec()..setExtension(comment, "hello");
     r.mergeFromMessage(src);
     expect(r.getExtension(comment), "hello");
     r.deliverChanges();

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 import 'mock_util.dart' show T;
 
 main() {
-  T example = new T()
+  T example = T()
     ..val = 123
     ..str = "hello"
     ..int32s.addAll(<int>[1, 2, 3]);
@@ -32,34 +32,34 @@ main() {
   });
 
   test('testMergeFromJson', () {
-    var t = new T();
+    var t = T();
     t.mergeFromJson('''{"1": 123, "2": "hello"}''');
     checkMessage(t);
   });
 
   test('testMergeFromJsonMap', () {
-    var t = new T();
+    var t = T();
     t.mergeFromJsonMap({"1": 123, "2": "hello"});
     checkMessage(t);
   });
 
   test('testInt64JsonEncoding', () {
     final value = Int64.parseInt('1234567890123456789');
-    final t = new T()..int64 = value;
+    final t = T()..int64 = value;
     final encoded = t.writeToJsonMap();
     expect(encoded["5"], "$value");
-    final decoded = new T()..mergeFromJsonMap(encoded);
+    final decoded = T()..mergeFromJsonMap(encoded);
     expect(decoded.int64, value);
   });
 
   test('tesFrozentInt64JsonEncoding', () {
     final value = Int64.parseInt('1234567890123456789');
-    final frozen = new T()
+    final frozen = T()
       ..int64 = value
       ..freeze();
     final encoded = frozen.writeToJsonMap();
     expect(encoded["5"], "$value");
-    final decoded = new T()..mergeFromJsonMap(encoded);
+    final decoded = T()..mergeFromJsonMap(encoded);
     expect(decoded.int64, value);
   });
 }

--- a/protobuf/test/json_vm_test.dart
+++ b/protobuf/test/json_vm_test.dart
@@ -11,11 +11,11 @@ import 'mock_util.dart' show T;
 
 main() {
   test('testInt64JsonEncoding', () {
-    final value = new Int64(1234567890123456789);
-    final t = new T()..int64 = value;
+    final value = Int64(1234567890123456789);
+    final t = T()..int64 = value;
     final encoded = t.writeToJsonMap();
     expect(encoded["5"], "$value");
-    final decoded = new T()..mergeFromJsonMap(encoded);
+    final decoded = T()..mergeFromJsonMap(encoded);
     expect(decoded.int64, value);
   });
 }

--- a/protobuf/test/list_test.dart
+++ b/protobuf/test/list_test.dart
@@ -19,7 +19,7 @@ cast(x) => x;
 
 void main() {
   test('testPbList handles basic operations', () {
-    PbList<int> lb1 = new PbList();
+    PbList<int> lb1 = PbList();
     expect(lb1, []);
 
     lb1.add(1);
@@ -52,7 +52,7 @@ void main() {
     expect(count, 108);
 
     bool isEven(int i) => i % 2 == 0;
-    List<int> evens = new List<int>.from(lb1.where(isEven));
+    List<int> evens = List<int>.from(lb1.where(isEven));
     expect(evens, [0, 2, 6]);
 
     expect(lb1.any(isEven), isTrue);
@@ -65,7 +65,7 @@ void main() {
   });
 
   test('PbList handles range operations', () {
-    PbList<int> lb2 = new PbList();
+    PbList<int> lb2 = PbList();
 
     lb2.addAll([1, 2, 3, 4, 5, 6, 7, 8, 9]);
     expect(lb2.sublist(3, 7), [4, 5, 6, 7]);
@@ -94,12 +94,12 @@ void main() {
 
   test('PbList validates items', () {
     expect(() {
-      (new PbList<int>() as dynamic).add('hello');
-    }, throwsA(new TypeMatcher<TypeError>()));
+      (PbList<int>() as dynamic).add('hello');
+    }, throwsA(TypeMatcher<TypeError>()));
   });
 
   test('PbList for signed int32 validates items', () {
-    List<int> list = new PbList(check: getCheckFunction(PbFieldType.P3));
+    List<int> list = PbList(check: getCheckFunction(PbFieldType.P3));
 
     expect(() {
       list.add(-2147483649);
@@ -119,7 +119,7 @@ void main() {
   });
 
   test('PBList for unsigned int32 validates items', () {
-    List<int> list = new PbList(check: getCheckFunction(PbFieldType.PU3));
+    List<int> list = PbList(check: getCheckFunction(PbFieldType.PU3));
 
     expect(() {
       list.add(-1);
@@ -139,7 +139,7 @@ void main() {
   });
 
   test('PbList for float validates items', () {
-    List<double> list = new PbList(check: getCheckFunction(PbFieldType.PF));
+    List<double> list = PbList(check: getCheckFunction(PbFieldType.PF));
 
     expect(() {
       list.add(3.4028234663852886E39);
@@ -159,13 +159,13 @@ void main() {
   });
 
   test('PbList for signed Int64 validates items', () {
-    List<Int64> list = new PbList();
+    List<Int64> list = PbList();
     expect(() {
       list.add(cast(0)); // not an Int64
     }, badArgument);
 
     expect(() {
-      list.add(new Int64(0));
+      list.add(Int64(0));
     }, returnsNormally, reason: 'could not add Int64(0) to a PbList');
 
     expect(() {
@@ -178,20 +178,20 @@ void main() {
   });
 
   test('PbList for unsigned Int64 validates items', () {
-    List<Int64> list = new PbList();
+    List<Int64> list = PbList();
     expect(() {
       list.add(cast(0)); // not an Int64
     }, badArgument);
 
     expect(() {
-      list.add(new Int64(0));
+      list.add(Int64(0));
     }, returnsNormally, reason: 'could not add Int64(0) to a PbList');
 
     // Adding -1 should work because we are storing the bits as-is.
     // (It will be interpreted as a positive number.)
     // See: https://github.com/dart-lang/protobuf/issues/44
     expect(() {
-      list.add(new Int64(-1));
+      list.add(Int64(-1));
     }, returnsNormally, reason: 'could not add Int64(-1) to a PbList');
 
     expect(() {

--- a/protobuf/test/map_mixin_test.dart
+++ b/protobuf/test/map_mixin_test.dart
@@ -17,8 +17,8 @@ import 'mock_util.dart' show MockMessage, mockInfo;
 // A minimal protobuf implementation compatible with PbMapMixin.
 class Rec extends MockMessage with MapMixin, PbMapMixin {
   get info_ => _info;
-  static final _info = mockInfo("Rec", () => new Rec());
-  Rec createEmptyInstance() => new Rec();
+  static final _info = mockInfo("Rec", () => Rec());
+  Rec createEmptyInstance() => Rec();
 
   @override
   String toString() => "Rec(${val}, \"${str}\")";
@@ -26,7 +26,7 @@ class Rec extends MockMessage with MapMixin, PbMapMixin {
 
 main() {
   test('PbMapMixin methods return default field values', () {
-    var r = new Rec();
+    var r = Rec();
 
     expect(r.isEmpty, false);
     expect(r.isNotEmpty, true);
@@ -47,7 +47,7 @@ main() {
   });
 
   test('operator []= sets record fields', () {
-    var r = new Rec();
+    var r = Rec();
 
     r["val"] = 123;
     expect(r.val, 123);
@@ -57,7 +57,7 @@ main() {
     expect(r.str, "hello");
     expect(r["str"], "hello");
 
-    var child = new Rec();
+    var child = Rec();
     r["child"] = child;
     expect(r.child, same(child));
     expect(r["child"], same(child));
@@ -69,12 +69,12 @@ main() {
   });
 
   test('operator== and hashCode work for Map mixin', () {
-    var a = new Rec();
+    var a = Rec();
     expect(a == a, true);
     expect(a == {}, false);
     expect({} == a, false);
 
-    var b = new Rec();
+    var b = Rec();
     expect(a.info_ == b.info_, true, reason: "BuilderInfo should be the same");
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
@@ -85,24 +85,24 @@ main() {
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
 
-    a.child = new Rec();
+    a.child = Rec();
     expect(a == b, false);
-    b.child = new Rec();
+    b.child = Rec();
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
   });
 
   test("protobuf doesn't compare equal to a map with the same values", () {
-    var a = new Rec();
-    expect(a == new Map.from(a), false);
-    expect(new Map.from(a) == a, false);
+    var a = Rec();
+    expect(a == Map.from(a), false);
+    expect(Map.from(a) == a, false);
   });
 
   test("reading protobuf values shouldn't change equality", () {
-    var a = new Rec();
-    var b = new Rec();
+    var a = Rec();
+    var b = Rec();
     expect(a == b, true);
-    new Map.from(a);
+    Map.from(a);
     expect(a == b, true);
   });
 }

--- a/protobuf/test/message_test.dart
+++ b/protobuf/test/message_test.dart
@@ -11,8 +11,8 @@ import 'mock_util.dart' show MockMessage, mockInfo;
 
 class Rec extends MockMessage {
   get info_ => _info;
-  static final _info = mockInfo("Rec", () => new Rec());
-  Rec createEmptyInstance() => new Rec();
+  static final _info = mockInfo("Rec", () => Rec());
+  Rec createEmptyInstance() => Rec();
 }
 
 throwsError(Type expectedType, String expectedMessage) =>
@@ -24,25 +24,25 @@ throwsError(Type expectedType, String expectedMessage) =>
 
 main() {
   test('getField with invalid tag throws exception', () {
-    var r = new Rec();
+    var r = Rec();
     expect(() {
       r.getField(123);
     }, throwsError(ArgumentError, "tag 123 not defined in Rec"));
   });
 
   test('getDefaultForField with invalid tag throws exception', () {
-    var r = new Rec();
+    var r = Rec();
     expect(() {
       r.getDefaultForField(123);
     }, throwsError(ArgumentError, "tag 123 not defined in Rec"));
   });
 
   test('operator== and hashCode works for frozen message', () {
-    final a = new Rec()
+    final a = Rec()
       ..val = 123
       ..int32s.addAll([1, 2, 3])
       ..freeze();
-    final b = new Rec()
+    final b = Rec()
       ..val = 123
       ..int32s.addAll([1, 2, 3]);
 
@@ -52,10 +52,10 @@ main() {
   });
 
   test('operator== and hashCode work for a simple record', () {
-    var a = new Rec();
+    var a = Rec();
     expect(a == a, true);
 
-    var b = new Rec();
+    var b = Rec();
     expect(a.info_ == b.info_, true, reason: "BuilderInfo should be the same");
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
@@ -66,9 +66,9 @@ main() {
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
 
-    a.child = new Rec();
+    a.child = Rec();
     expect(a == b, false);
-    b.child = new Rec();
+    b.child = Rec();
     expect(a == b, true);
     expect(a.hashCode, b.hashCode);
   });

--- a/protobuf/test/mirror_util.dart
+++ b/protobuf/test/mirror_util.dart
@@ -12,7 +12,7 @@ Set<String> findMemberNames(String importName, Symbol classSymbol) {
   var lib = currentMirrorSystem().libraries[Uri.parse(importName)];
   ClassMirror cls = lib.declarations[classSymbol];
 
-  var result = new Set<String>();
+  var result = Set<String>();
 
   addNames(ClassMirror cls) {
     String prefixToRemove = MirrorSystem.getName(cls.simpleName) + ".";

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -9,7 +9,7 @@ import 'package:protobuf/protobuf.dart'
     show GeneratedMessage, BuilderInfo, CreateBuilderFunc, PbFieldType;
 
 BuilderInfo mockInfo(String className, CreateBuilderFunc create) {
-  return new BuilderInfo(className)
+  return BuilderInfo(className)
     ..a(1, "val", PbFieldType.O3, 42)
     ..a(2, "str", PbFieldType.OS)
     ..a(3, "child", PbFieldType.OM, create, create)
@@ -33,7 +33,7 @@ abstract class MockMessage extends GeneratedMessage {
 
   List<int> get int32s => $_getList(3);
 
-  Int64 get int64 => $_get(4, new Int64(0));
+  Int64 get int64 => $_get(4, Int64(0));
   set int64(x) => setField(5, x);
 
   clone() {
@@ -44,6 +44,6 @@ abstract class MockMessage extends GeneratedMessage {
 
 class T extends MockMessage {
   get info_ => _info;
-  static final _info = mockInfo("T", () => new T());
-  T createEmptyInstance() => new T();
+  static final _info = mockInfo("T", () => T());
+  T createEmptyInstance() => T();
 }

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -24,12 +24,12 @@ throwsError(Type expectedType, Matcher expectedMessage) =>
     }));
 
 class Rec extends GeneratedMessage {
-  static Rec getDefault() => new Rec()..freeze();
-  static Rec create() => new Rec();
-  Rec createEmptyInstance() => new Rec();
+  static Rec getDefault() => Rec()..freeze();
+  static Rec create() => Rec();
+  Rec createEmptyInstance() => Rec();
 
   @override
-  BuilderInfo info_ = new BuilderInfo('rec')
+  BuilderInfo info_ = BuilderInfo('rec')
     ..a(1, 'value', PbFieldType.O3)
     ..pc<Rec>(2, 'sub', PbFieldType.PM, Rec.create)
     ..p<int>(10, 'ints', PbFieldType.P3);
@@ -46,7 +46,7 @@ class Rec extends GeneratedMessage {
   List<int> get ints => $_getList<int>(2);
 
   @override
-  Rec clone() => new Rec()..mergeFromMessage(this);
+  Rec clone() => Rec()..mergeFromMessage(this);
 
   Rec copyWith(void Function(Rec) updates) =>
       super.copyWith((message) => updates(message as Rec));
@@ -248,7 +248,7 @@ main() {
 
   test("can modify unknown fields while rebuilding a frozen message", () {
     final orig = Rec.create()
-      ..unknownFields.addField(20, new UnknownFieldSetField()..fixed32s.add(1));
+      ..unknownFields.addField(20, UnknownFieldSetField()..fixed32s.add(1));
     final rebuilt = orig.copyWith((m) => m.unknownFields.clear());
     expect(orig.unknownFields.hasField(20), true);
     expect(rebuilt.unknownFields.hasField(20), false);

--- a/protobuf/test/reserved_names_test.dart
+++ b/protobuf/test/reserved_names_test.dart
@@ -26,7 +26,7 @@ import 'dart:mirrors';
 
 void main() {
   test('GeneratedMessage reserved names are up to date', () {
-    var actual = new Set<String>.from(GeneratedMessage_reservedNames);
+    var actual = Set<String>.from(GeneratedMessage_reservedNames);
     var expected =
         findMemberNames('package:protobuf/protobuf.dart', #GeneratedMessage);
 
@@ -34,7 +34,7 @@ void main() {
   });
 
   test('ProtobufEnum reserved names are up to date', () {
-    var actual = new Set<String>.from(ProtobufEnum_reservedNames);
+    var actual = Set<String>.from(ProtobufEnum_reservedNames);
     var expected =
         findMemberNames('package:protobuf/protobuf.dart', #ProtobufEnum);
 
@@ -44,7 +44,7 @@ void main() {
   test("ReadonlyMessageMixin doesn't add any reserved names", () {
     var mixinNames = findMemberNames(
         'package:protobuf/protobuf.dart', #ReadonlyMessageMixin);
-    var reservedNames = new Set<String>.from(GeneratedMessage_reservedNames);
+    var reservedNames = Set<String>.from(GeneratedMessage_reservedNames);
     for (var name in mixinNames) {
       if (name == "ReadonlyMessageMixin" || name == "unknownFields") continue;
       if (!reservedNames.contains(name)) {
@@ -55,7 +55,7 @@ void main() {
 
   test('PbMapMixin reserved names are up to date', () {
     var meta = findMixin("PbMapMixin");
-    var actual = new Set<String>.from(meta.findReservedNames());
+    var actual = Set<String>.from(meta.findReservedNames());
 
     var expected = findMemberNames(meta.importFrom, #PbMapMixin)
       ..addAll(findMemberNames("dart:collection", #MapMixin))
@@ -67,7 +67,7 @@ void main() {
 
   test('PbEventMixin reserved names are up to date', () {
     var meta = findMixin("PbEventMixin");
-    var actual = new Set<String>.from(meta.findReservedNames());
+    var actual = Set<String>.from(meta.findReservedNames());
 
     var expected = findMemberNames(meta.importFrom, #PbEventMixin)
       ..removeAll(GeneratedMessage_reservedNames);

--- a/protobuf/test/test_util.dart
+++ b/protobuf/test/test_util.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 Int64 make64(int lo, [int hi]) {
   if (hi == null) hi = lo < 0 ? -1 : 0;
-  return new Int64.fromInts(hi, lo);
+  return Int64.fromInts(hi, lo);
 }
 
 expect64(int lo, [int hi]) {

--- a/protoc_plugin/analysis_options.yaml
+++ b/protoc_plugin/analysis_options.yaml
@@ -19,6 +19,7 @@ linter:
     - recursive_getters
     - throw_in_finally
     - unrelated_type_equality_checks
+    - unnecessary_new
     - use_rethrow_when_possible
     - valid_regexps
     - camel_case_types

--- a/protoc_plugin/bin/protoc_plugin.dart
+++ b/protoc_plugin/bin/protoc_plugin.dart
@@ -7,5 +7,5 @@ import 'dart:io';
 import 'package:protoc_plugin/protoc.dart';
 
 void main() {
-  new CodeGenerator(stdin, stdout).generate();
+  CodeGenerator(stdin, stdout).generate();
 }

--- a/protoc_plugin/bin/protoc_plugin_bazel.dart
+++ b/protoc_plugin/bin/protoc_plugin_bazel.dart
@@ -9,7 +9,7 @@ import 'package:protoc_plugin/protoc.dart';
 
 void main() {
   var packages = <String, BazelPackage>{};
-  new CodeGenerator(stdin, stdout).generate(
-      optionParsers: {bazelOptionId: new BazelOptionParser(packages)},
-      config: new BazelOutputConfiguration(packages));
+  CodeGenerator(stdin, stdout).generate(
+      optionParsers: {bazelOptionId: BazelOptionParser(packages)},
+      config: BazelOutputConfiguration(packages));
 }

--- a/protoc_plugin/lib/base_type.dart
+++ b/protoc_plugin/lib/base_type.dart
@@ -120,7 +120,7 @@ class BaseType {
         break;
 
       default:
-        throw new ArgumentError("unimplemented type: ${field.type.name}");
+        throw ArgumentError("unimplemented type: ${field.type.name}");
     }
 
     ProtobufContainer generator = ctx.getFieldType(field.typeName);
@@ -128,7 +128,7 @@ class BaseType {
       throw 'FAILURE: Unknown type reference ${field.typeName}';
     }
 
-    return new BaseType._raw(
+    return BaseType._raw(
         field.type, constSuffix, generator.classname, null, generator);
   }
 }

--- a/protoc_plugin/lib/bazel.dart
+++ b/protoc_plugin/lib/bazel.dart
@@ -56,7 +56,7 @@ class BazelOptionParser implements SingleOptionParser {
             'ERROR: expected package_name|input_root|output_root. Got: $entry');
         continue;
       }
-      var pkg = new BazelPackage(fields[0], fields[1], fields[2]);
+      var pkg = BazelPackage(fields[0], fields[1], fields[2]);
       if (!output.containsKey(pkg.input_root)) {
         output[pkg.input_root] = pkg;
       } else {
@@ -108,14 +108,14 @@ class BazelOutputConfiguration extends DefaultOutputConfiguration {
   Uri outputPathFor(Uri input, String extension) {
     var pkg = _findPackage(input.path);
     if (pkg == null) {
-      throw new ArgumentError('Unable to locate package for input $input.');
+      throw ArgumentError('Unable to locate package for input $input.');
     }
 
     // Bazel package-relative paths.
     var relativeInput = input.path.substring('${pkg.input_root}/'.length);
     var base = p.withoutExtension(relativeInput);
     var outputPath = p.join(pkg.output_root, "$base$extension");
-    return new Uri.file(outputPath);
+    return Uri.file(outputPath);
   }
 
   @override
@@ -142,6 +142,6 @@ class BazelOutputConfiguration extends DefaultOutputConfiguration {
     var pkg = _findPackage(target);
     if (pkg == null) return null;
     var relPath = target.substring(pkg.input_root.length + 1);
-    return new _PackageUri(pkg.name, relPath);
+    return _PackageUri(pkg.name, relPath);
   }
 }

--- a/protoc_plugin/lib/client_generator.dart
+++ b/protoc_plugin/lib/client_generator.dart
@@ -8,7 +8,7 @@ class ClientApiGenerator {
   // The service that this Client API connects to.
   final ServiceGenerator service;
   final String className;
-  final Set<String> usedMethodNames = new Set<String>()
+  final Set<String> usedMethodNames = Set<String>()
     ..addAll(reservedMemberNames);
 
   ClientApiGenerator(this.service, Set<String> usedNames)
@@ -45,7 +45,7 @@ class ClientApiGenerator {
         '$_asyncImportPrefix.Future<$outputType> $methodName('
         '$_protobufImportPrefix.ClientContext ctx, $inputType request) {',
         '}', () {
-      out.println('var emptyResponse = new $outputType();');
+      out.println('var emptyResponse = $outputType();');
       out.println('return _client.invoke<$outputType>(ctx, \'${className}\', '
           '\'${m.name}\', request, emptyResponse);');
     });

--- a/protoc_plugin/lib/code_generator.dart
+++ b/protoc_plugin/lib/code_generator.dart
@@ -60,19 +60,19 @@ class CodeGenerator extends ProtobufContainer {
       {Map<String, SingleOptionParser> optionParsers,
       OutputConfiguration config}) {
     if (config == null) {
-      config = new DefaultOutputConfiguration();
+      config = DefaultOutputConfiguration();
     }
 
-    var extensions = new ExtensionRegistry();
+    var extensions = ExtensionRegistry();
     Dart_options.registerAllExtensions(extensions);
 
     _streamIn
-        .fold(new BytesBuilder(),
+        .fold(BytesBuilder(),
             (BytesBuilder builder, data) => builder..add(data))
         .then((builder) => builder.takeBytes())
         .then((List<int> bytes) {
-      var request = new CodeGeneratorRequest.fromBuffer(bytes, extensions);
-      var response = new CodeGeneratorResponse();
+      var request = CodeGeneratorRequest.fromBuffer(bytes, extensions);
+      var response = CodeGeneratorResponse();
 
       // Parse the options in the request. Return the errors is any.
       var options = parseGenerationOptions(request, response, optionParsers);
@@ -85,7 +85,7 @@ class CodeGenerator extends ProtobufContainer {
       // (We may import it even if we don't generate the .pb.dart file.)
       List<FileGenerator> generators = <FileGenerator>[];
       for (FileDescriptorProto file in request.protoFile) {
-        generators.add(new FileGenerator(file, options));
+        generators.add(FileGenerator(file, options));
       }
 
       // Collect field types and importable files.

--- a/protoc_plugin/lib/code_generator.dart
+++ b/protoc_plugin/lib/code_generator.dart
@@ -67,8 +67,8 @@ class CodeGenerator extends ProtobufContainer {
     Dart_options.registerAllExtensions(extensions);
 
     _streamIn
-        .fold(BytesBuilder(),
-            (BytesBuilder builder, data) => builder..add(data))
+        .fold(
+            BytesBuilder(), (BytesBuilder builder, data) => builder..add(data))
         .then((builder) => builder.takeBytes())
         .then((List<int> bytes) {
       var request = CodeGeneratorRequest.fromBuffer(bytes, extensions);

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -50,7 +50,7 @@ class EnumGenerator extends ProtobufContainer {
         _canonicalValues.add(value);
         _originalCanonicalIndices.add(i);
       } else {
-        _aliases.add(new EnumAlias(value, canonicalValue));
+        _aliases.add(EnumAlias(value, canonicalValue));
         _originalAliasIndices.add(i);
       }
       dartNames[value.name] = disambiguateName(
@@ -98,7 +98,7 @@ class EnumGenerator extends ProtobufContainer {
     out.addAnnotatedBlock(
         'class ${classname} extends $_protobufImportPrefix.ProtobufEnum {',
         '}\n', [
-      new NamedLocation(
+      NamedLocation(
           name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
     ], () {
       // -----------------------------------------------------------------
@@ -110,9 +110,9 @@ class EnumGenerator extends ProtobufContainer {
             'static const ${classname} $name = '
             "const ${classname}._(${val.number}, ${singleQuote(name)});",
             [
-              new NamedLocation(
+              NamedLocation(
                   name: name,
-                  fieldPathSegment: new List.from(fieldPath)
+                  fieldPathSegment: List.from(fieldPath)
                     ..addAll([_enumValueTag, _originalCanonicalIndices[i]]),
                   start: 'static const ${classname} '.length)
             ]);
@@ -126,9 +126,9 @@ class EnumGenerator extends ProtobufContainer {
               'static const ${classname} $name ='
               ' ${dartNames[alias.canonicalValue.name]};',
               [
-                new NamedLocation(
+                NamedLocation(
                     name: name,
-                    fieldPathSegment: new List.from(fieldPath)
+                    fieldPathSegment: List.from(fieldPath)
                       ..addAll([_enumValueTag, _originalAliasIndices[i]]),
                     start: 'static const ${classname} '.length)
               ]);

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -37,7 +37,7 @@ class ExtensionGenerator {
             descriptor, parent, usedNames, repeatedFieldIndex, _nestedFieldTag);
 
   void resolve(GenerationContext ctx) {
-    _field = new ProtobufField.extension(_descriptor, _parent, ctx);
+    _field = ProtobufField.extension(_descriptor, _parent, ctx);
 
     ProtobufContainer extendedType = ctx.getFieldType(_descriptor.extendee);
     // TODO(skybrian) When would this be null?
@@ -52,13 +52,13 @@ class ExtensionGenerator {
   FileGenerator get fileGen => _parent.fileGen;
 
   String get name {
-    if (_field == null) throw new StateError("resolve not called");
+    if (_field == null) throw StateError("resolve not called");
     String name = _extensionName;
     return _parent is MessageGenerator ? '${_parent.classname}.$name' : name;
   }
 
   bool get needsFixnumImport {
-    if (_field == null) throw new StateError("resolve not called");
+    if (_field == null) throw StateError("resolve not called");
     return _field.needsFixnumImport;
   }
 
@@ -68,7 +68,7 @@ class ExtensionGenerator {
   /// add its generator.
   void addImportsTo(
       Set<FileGenerator> imports, Set<FileGenerator> enumImports) {
-    if (_field == null) throw new StateError("resolve not called");
+    if (_field == null) throw StateError("resolve not called");
     var typeGen = _field.baseType.generator;
     if (typeGen != null) {
       // The type of this extension is defined in a different file,
@@ -87,12 +87,12 @@ class ExtensionGenerator {
   /// For each .pb.dart file that the generated code needs to import,
   /// add its generator.
   void addConstantImportsTo(Set<FileGenerator> imports) {
-    if (_field == null) throw new StateError("resolve not called");
+    if (_field == null) throw StateError("resolve not called");
     // No dependencies - nothing to do.
   }
 
   void generate(IndentingWriter out) {
-    if (_field == null) throw new StateError("resolve not called");
+    if (_field == null) throw StateError("resolve not called");
 
     String name = _extensionName;
     var type = _field.baseType;
@@ -101,12 +101,12 @@ class ExtensionGenerator {
     if (_field.isRepeated) {
       out.printAnnotated(
           'static final $_protobufImportPrefix.Extension $name = '
-          'new $_protobufImportPrefix.Extension<$dartType>.repeated(\'$_extendedFullName\','
+          '$_protobufImportPrefix.Extension<$dartType>.repeated(\'$_extendedFullName\','
           ' \'$name\', ${_field.number}, ${_field.typeConstant}',
           [
-            new NamedLocation(
+            NamedLocation(
                 name: name,
-                fieldPathSegment: new List.from(fieldPath),
+                fieldPathSegment: List.from(fieldPath),
                 start: 'static final $_protobufImportPrefix.Extension '.length)
           ]);
       if (type.isMessage || type.isGroup) {
@@ -125,12 +125,12 @@ class ExtensionGenerator {
 
     out.printAnnotated(
         'static final $_protobufImportPrefix.Extension $name = '
-        'new $_protobufImportPrefix.Extension<$dartType>(\'$_extendedFullName\', \'$name\', '
+        '$_protobufImportPrefix.Extension<$dartType>(\'$_extendedFullName\', \'$name\', '
         '${_field.number}, ${_field.typeConstant}',
         [
-          new NamedLocation(
+          NamedLocation(
               name: name,
-              fieldPathSegment: new List.from(fieldPath),
+              fieldPathSegment: List.from(fieldPath),
               start: 'static final $_protobufImportPrefix.Extension '.length)
         ]);
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -152,13 +152,8 @@ class FileGenerator extends ProtobufContainer {
           descriptor.enumType[i], this, usedTopLevelNames, i));
     }
     for (var i = 0; i < descriptor.messageType.length; i++) {
-      messageGenerators.add(MessageGenerator.topLevel(
-          descriptor.messageType[i],
-          this,
-          declaredMixins,
-          defaultMixin,
-          usedTopLevelNames,
-          i));
+      messageGenerators.add(MessageGenerator.topLevel(descriptor.messageType[i],
+          this, declaredMixins, defaultMixin, usedTopLevelNames, i));
     }
     for (var i = 0; i < descriptor.extension.length; i++) {
       extensionGenerators.add(ExtensionGenerator.topLevel(

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -4,8 +4,8 @@
 
 part of protoc;
 
-final _dartIdentifier = new RegExp(r'^\w+$');
-final _formatter = new DartFormatter();
+final _dartIdentifier = RegExp(r'^\w+$');
+final _formatter = DartFormatter();
 final String _protobufImportPrefix = r'$pb';
 final String _asyncImportPrefix = r'$async';
 const String _coreImportPrefix = r'$core';
@@ -85,7 +85,7 @@ class FileGenerator extends ProtobufContainer {
       if (pbMixins.containsKey(name)) return pbMixins[name];
       if (dartMixins.containsKey(name)) {
         var dartMixin = dartMixins[name];
-        var pbMixin = new PbMixin(dartMixin.name,
+        var pbMixin = PbMixin(dartMixin.name,
             importFrom: dartMixin.importFrom,
             parent: resolveMixin(dartMixin.parent));
         pbMixins[name] = pbMixin;
@@ -130,7 +130,7 @@ class FileGenerator extends ProtobufContainer {
   bool _linked = false;
 
   FileGenerator(this.descriptor, this.options)
-      : protoFileUri = new Uri.file(descriptor.name) {
+      : protoFileUri = Uri.file(descriptor.name) {
     if (protoFileUri.isAbsolute) {
       // protoc should never generate an import with an absolute path.
       throw "FAILURE: Import with absolute path is not supported";
@@ -148,11 +148,11 @@ class FileGenerator extends ProtobufContainer {
 
     // Load and register all enum and message types.
     for (var i = 0; i < descriptor.enumType.length; i++) {
-      enumGenerators.add(new EnumGenerator.topLevel(
+      enumGenerators.add(EnumGenerator.topLevel(
           descriptor.enumType[i], this, usedTopLevelNames, i));
     }
     for (var i = 0; i < descriptor.messageType.length; i++) {
-      messageGenerators.add(new MessageGenerator.topLevel(
+      messageGenerators.add(MessageGenerator.topLevel(
           descriptor.messageType[i],
           this,
           declaredMixins,
@@ -161,18 +161,18 @@ class FileGenerator extends ProtobufContainer {
           i));
     }
     for (var i = 0; i < descriptor.extension.length; i++) {
-      extensionGenerators.add(new ExtensionGenerator.topLevel(
+      extensionGenerators.add(ExtensionGenerator.topLevel(
           descriptor.extension[i], this, usedTopLevelNames, i));
     }
     for (ServiceDescriptorProto service in descriptor.service) {
       if (options.useGrpc) {
-        grpcGenerators.add(new GrpcServiceGenerator(service, this));
+        grpcGenerators.add(GrpcServiceGenerator(service, this));
       } else {
         var serviceGen =
-            new ServiceGenerator(service, this, usedTopLevelServiceNames);
+            ServiceGenerator(service, this, usedTopLevelServiceNames);
         serviceGenerators.add(serviceGen);
         clientApiGenerators
-            .add(new ClientApiGenerator(serviceGen, usedTopLevelNames));
+            .add(ClientApiGenerator(serviceGen, usedTopLevelNames));
       }
     }
   }
@@ -180,7 +180,7 @@ class FileGenerator extends ProtobufContainer {
   /// Creates the fields in each message.
   /// Resolves field types and extension targets using the supplied context.
   void resolve(GenerationContext ctx) {
-    if (_linked) throw new StateError("cross references already resolved");
+    if (_linked) throw StateError("cross references already resolved");
 
     for (var m in messageGenerators) {
       m.resolve(ctx);
@@ -200,12 +200,12 @@ class FileGenerator extends ProtobufContainer {
 
   /// Generates all the Dart files for this .proto file.
   List<CodeGeneratorResponse_File> generateFiles(OutputConfiguration config) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
 
     makeFile(String extension, String content) {
-      Uri protoUrl = new Uri.file(descriptor.name);
+      Uri protoUrl = Uri.file(descriptor.name);
       Uri dartUrl = config.outputPathFor(protoUrl, extension);
-      return new CodeGeneratorResponse_File()
+      return CodeGeneratorResponse_File()
         ..name = dartUrl.path
         ..content = content;
     }
@@ -238,13 +238,13 @@ class FileGenerator extends ProtobufContainer {
   }
 
   /// Creates an IndentingWriter with metadata generation enabled or disabled.
-  IndentingWriter makeWriter() => new IndentingWriter(
+  IndentingWriter makeWriter() => IndentingWriter(
       filename: options.generateMetadata ? descriptor.name : null);
 
   /// Returns the contents of the .pb.dart file for this .proto file.
   IndentingWriter generateMainFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
     IndentingWriter out = makeWriter();
 
     writeMainHeader(out, config);
@@ -313,8 +313,8 @@ class FileGenerator extends ProtobufContainer {
     if (mixinImports.isNotEmpty) out.println();
 
     // Import the .pb.dart files we depend on.
-    var imports = new Set<FileGenerator>.identity();
-    var enumImports = new Set<FileGenerator>.identity();
+    var imports = Set<FileGenerator>.identity();
+    var enumImports = Set<FileGenerator>.identity();
     _findProtosToImport(imports, enumImports);
 
     for (var target in imports) {
@@ -383,7 +383,7 @@ class FileGenerator extends ProtobufContainer {
 
   /// Returns a map from import names to the Dart symbols to be imported.
   Map<String, List<String>> findMixinsToImport() {
-    var mixins = new Set<PbMixin>();
+    var mixins = Set<PbMixin>();
     for (MessageGenerator m in messageGenerators) {
       m.addMixinsTo(mixins);
     }
@@ -409,7 +409,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the contents of the .pbenum.dart file for this .proto file.
   IndentingWriter generateEnumFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
 
     var out = makeWriter();
     _writeHeading(out);
@@ -446,7 +446,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the contents of the .pbserver.dart file for this .proto file.
   String generateServerFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
     var out = makeWriter();
     _writeHeading(out);
 
@@ -459,7 +459,7 @@ class FileGenerator extends ProtobufContainer {
     }
 
     // Import .pb.dart files needed for requests and responses.
-    var imports = new Set<FileGenerator>();
+    var imports = Set<FileGenerator>();
     for (var x in serviceGenerators) {
       x.addImportsTo(imports);
     }
@@ -488,7 +488,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the contents of the .pbgrpc.dart file for this .proto file.
   String generateGrpcFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
     var out = makeWriter();
     _writeHeading(out);
 
@@ -499,7 +499,7 @@ class FileGenerator extends ProtobufContainer {
     out.println("$_coreImport show int, String, List;\n");
 
     // Import .pb.dart files needed for requests and responses.
-    var imports = new Set<FileGenerator>();
+    var imports = Set<FileGenerator>();
     for (var generator in grpcGenerators) {
       generator.addImportsTo(imports);
     }
@@ -522,7 +522,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the contents of the .pbjson.dart file for this .proto file.
   String generateJsonFile(
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
-    if (!_linked) throw new StateError("not linked");
+    if (!_linked) throw StateError("not linked");
     var out = makeWriter();
     _writeHeading(out);
 
@@ -549,7 +549,7 @@ class FileGenerator extends ProtobufContainer {
   /// Returns the generator for each .pbjson.dart file the generated
   /// .pbjson.dart needs to import.
   Set<FileGenerator> _findJsonProtosToImport() {
-    var imports = new Set<FileGenerator>.identity();
+    var imports = Set<FileGenerator>.identity();
     for (var m in messageGenerators) {
       m.addConstantImportsTo(imports);
     }

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -241,8 +241,7 @@ class _GrpcMethod {
   }
 
   void generateServiceMethodRegistration(IndentingWriter out) {
-    out.println(
-        '\$addMethod($_serviceMethod<$_requestType, $_responseType>(');
+    out.println('\$addMethod($_serviceMethod<$_requestType, $_responseType>(');
     out.println('    \'$_grpcName\',');
     out.println('    $_dartName${_clientStreaming ? '' : '_Pre'},');
     out.println('    $_clientStreaming,');

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -57,7 +57,7 @@ class GrpcServiceGenerator {
   /// Precondition: messages have been registered and resolved.
   void resolve(GenerationContext ctx) {
     for (var method in _descriptor.method) {
-      _methods.add(new _GrpcMethod(this, ctx, method));
+      _methods.add(_GrpcMethod(this, ctx, method));
     }
   }
 
@@ -201,7 +201,7 @@ class _GrpcMethod {
     final serverReturnType =
         serverStreaming ? '$_stream<$responseType>' : '$_future<$responseType>';
 
-    return new _GrpcMethod._(
+    return _GrpcMethod._(
         grpcName,
         dartName,
         service._fullServiceName,
@@ -216,11 +216,11 @@ class _GrpcMethod {
 
   void generateClientMethodDescriptor(IndentingWriter out) {
     out.println(
-        'static final _\$$_dartName = new $_clientMethod<$_requestType, $_responseType>(');
+        'static final _\$$_dartName = $_clientMethod<$_requestType, $_responseType>(');
     out.println('    \'/$_serviceName/$_grpcName\',');
     out.println('    ($_requestType value) => value.writeToBuffer(),');
     out.println(
-        '    ($_coreImportPrefix.List<$_coreImportPrefix.int> value) => new $_responseType.fromBuffer(value));');
+        '    ($_coreImportPrefix.List<$_coreImportPrefix.int> value) => $_responseType.fromBuffer(value));');
   }
 
   void generateClientStub(IndentingWriter out) {
@@ -229,26 +229,26 @@ class _GrpcMethod {
         '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
         '}', () {
       final requestStream =
-          _clientStreaming ? 'request' : 'new $_stream.fromIterable([request])';
+          _clientStreaming ? 'request' : '$_stream.fromIterable([request])';
       out.println(
           'final call = \$createCall(_\$$_dartName, $requestStream, options: options);');
       if (_serverStreaming) {
-        out.println('return new $_responseStream(call);');
+        out.println('return $_responseStream(call);');
       } else {
-        out.println('return new $_responseFuture(call);');
+        out.println('return $_responseFuture(call);');
       }
     });
   }
 
   void generateServiceMethodRegistration(IndentingWriter out) {
     out.println(
-        '\$addMethod(new $_serviceMethod<$_requestType, $_responseType>(');
+        '\$addMethod($_serviceMethod<$_requestType, $_responseType>(');
     out.println('    \'$_grpcName\',');
     out.println('    $_dartName${_clientStreaming ? '' : '_Pre'},');
     out.println('    $_clientStreaming,');
     out.println('    $_serverStreaming,');
     out.println(
-        '    ($_coreImportPrefix.List<$_coreImportPrefix.int> value) => new $_requestType.fromBuffer(value),');
+        '    ($_coreImportPrefix.List<$_coreImportPrefix.int> value) => $_requestType.fromBuffer(value),');
     out.println('    ($_responseType value) => value.writeToBuffer()));');
   }
 

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -17,8 +17,8 @@ class NamedLocation {
 
 /// A buffer for writing indented source code.
 class IndentingWriter {
-  final StringBuffer _buffer = new StringBuffer();
-  final GeneratedCodeInfo sourceLocationInfo = new GeneratedCodeInfo();
+  final StringBuffer _buffer = StringBuffer();
+  final GeneratedCodeInfo sourceLocationInfo = GeneratedCodeInfo();
   String _indent = "";
   bool _needIndent = true;
   // After writing any chunk, _previousOffset is the size of everything that was
@@ -127,7 +127,7 @@ class IndentingWriter {
     if (_sourceFile == null) {
       return;
     }
-    var annotation = new GeneratedCodeInfo_Annotation()
+    var annotation = GeneratedCodeInfo_Annotation()
       ..path.addAll(fieldPath)
       ..sourceFile = _sourceFile
       ..begin = _previousOffset + start

--- a/protoc_plugin/lib/linker.dart
+++ b/protoc_plugin/lib/linker.dart
@@ -6,7 +6,7 @@ part of protoc;
 
 /// Resolves all cross-references in a set of proto files.
 void link(GenerationOptions options, Iterable<FileGenerator> files) {
-  GenerationContext ctx = new GenerationContext(options);
+  GenerationContext ctx = GenerationContext(options);
 
   // Register the targets of cross-references.
   for (var f in files) {

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -114,12 +114,12 @@ class MessageGenerator extends ProtobufContainer {
     for (var i = 0; i < _descriptor.enumType.length; i++) {
       EnumDescriptorProto e = _descriptor.enumType[i];
       _enumGenerators
-          .add(new EnumGenerator.nested(e, this, _usedTopLevelNames, i));
+          .add(EnumGenerator.nested(e, this, _usedTopLevelNames, i));
     }
 
     for (var i = 0; i < _descriptor.nestedType.length; i++) {
       DescriptorProto n = _descriptor.nestedType[i];
-      _messageGenerators.add(new MessageGenerator.nested(
+      _messageGenerators.add(MessageGenerator.nested(
           n, this, declaredMixins, defaultMixin, _usedTopLevelNames, i));
     }
 
@@ -129,7 +129,7 @@ class MessageGenerator extends ProtobufContainer {
     for (var i = 0; i < _descriptor.extension.length; i++) {
       FieldDescriptorProto x = _descriptor.extension[i];
       _extensionGenerators
-          .add(new ExtensionGenerator.nested(x, this, usedExtensionNames, i));
+          .add(ExtensionGenerator.nested(x, this, usedExtensionNames, i));
     }
   }
 
@@ -165,7 +165,7 @@ class MessageGenerator extends ProtobufContainer {
   /// Throws an exception if [resolve] hasn't been called yet.
   void checkResolved() {
     if (_fieldList == null) {
-      throw new StateError("message not resolved: ${fullName}");
+      throw StateError("message not resolved: ${fullName}");
     }
   }
 
@@ -202,7 +202,7 @@ class MessageGenerator extends ProtobufContainer {
 
   // Creates fields and resolves extension targets.
   void resolve(GenerationContext ctx) {
-    if (_fieldList != null) throw new StateError("message already resolved");
+    if (_fieldList != null) throw StateError("message already resolved");
 
     var reserved = mixin?.findReservedNames() ?? const <String>[];
     MemberNames members = messageMemberNames(
@@ -211,7 +211,7 @@ class MessageGenerator extends ProtobufContainer {
 
     _fieldList = <ProtobufField>[];
     for (FieldNames names in members.fieldNames) {
-      ProtobufField field = new ProtobufField.message(names, this, ctx);
+      ProtobufField field = ProtobufField.message(names, this, ctx);
       if (field.descriptor.hasOneofIndex()) {
         _oneofFields[field.descriptor.oneofIndex].add(field);
       }
@@ -228,7 +228,7 @@ class MessageGenerator extends ProtobufContainer {
   }
 
   bool get needsFixnumImport {
-    if (_fieldList == null) throw new StateError("message not resolved");
+    if (_fieldList == null) throw StateError("message not resolved");
     for (var field in _fieldList) {
       if (field.needsFixnumImport) return true;
     }
@@ -247,7 +247,7 @@ class MessageGenerator extends ProtobufContainer {
   /// add its generator.
   void addImportsTo(
       Set<FileGenerator> imports, Set<FileGenerator> enumImports) {
-    if (_fieldList == null) throw new StateError("message not resolved");
+    if (_fieldList == null) throw StateError("message not resolved");
     for (var field in _fieldList) {
       var typeGen = field.baseType.generator;
       if (typeGen is EnumGenerator) {
@@ -278,7 +278,7 @@ class MessageGenerator extends ProtobufContainer {
   /// For each .pbjson.dart file that the generated code needs to import,
   /// add its generator.
   void addConstantImportsTo(Set<FileGenerator> imports) {
-    if (_fieldList == null) throw new StateError("message not resolved");
+    if (_fieldList == null) throw StateError("message not resolved");
     for (var m in _messageGenerators) {
       m.addConstantImportsTo(imports);
     }
@@ -314,7 +314,7 @@ class MessageGenerator extends ProtobufContainer {
     out.addAnnotatedBlock(
         'class ${classname} extends $_protobufImportPrefix.GeneratedMessage${mixinClause} {',
         '}', [
-      new NamedLocation(
+      NamedLocation(
           name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
     ], () {
       for (OneofNames oneof in _oneofNames) {
@@ -330,7 +330,7 @@ class MessageGenerator extends ProtobufContainer {
       }
       out.addBlock(
           'static final $_protobufImportPrefix.BuilderInfo _i = '
-          'new $_protobufImportPrefix.BuilderInfo(\'${messageName}\'$packageClause)',
+          '$_protobufImportPrefix.BuilderInfo(\'${messageName}\'$packageClause)',
           ';', () {
         for (ProtobufField field in _fieldList) {
           var dartFieldName = field.memberNames.fieldName;
@@ -347,7 +347,7 @@ class MessageGenerator extends ProtobufContainer {
         if (_descriptor.extensionRange.length > 0) {
           out.println('..hasExtensions = true');
         }
-        if (!_hasRequiredFields(this, new Set())) {
+        if (!_hasRequiredFields(this, Set())) {
           out.println('..hasRequiredFields = false');
         }
       });
@@ -369,7 +369,7 @@ class MessageGenerator extends ProtobufContainer {
           ' [$_protobufImportPrefix.ExtensionRegistry r = $_protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' : super.fromJson(i, r);');
       out.println('${classname} clone() =>'
-          ' new ${classname}()..mergeFromMessage(this);');
+          ' ${classname}()..mergeFromMessage(this);');
       out.println('$classname copyWith(void Function($classname) updates) =>'
           ' super.copyWith((message) => updates(message as $classname));');
 
@@ -377,12 +377,12 @@ class MessageGenerator extends ProtobufContainer {
 
       // Factory functions which can be used as default value closures.
       out.println('static ${classname} create() =>'
-          ' new ${classname}();');
+          ' ${classname}();');
       out.println('${classname} createEmptyInstance() => create();');
 
       out.println(
           'static $_protobufImportPrefix.PbList<${classname}> createRepeated() =>'
-          ' new $_protobufImportPrefix.PbList<${classname}>();');
+          ' $_protobufImportPrefix.PbList<${classname}>();');
       out.println(
           'static ${classname} getDefault() => _defaultInstance ??= create()..freeze();');
       out.println('static ${classname} _defaultInstance;');
@@ -399,7 +399,7 @@ class MessageGenerator extends ProtobufContainer {
   // already_seen is used to avoid checking the same type multiple times
   // (and also to protect against unbounded recursion).
   bool _hasRequiredFields(MessageGenerator type, Set alreadySeen) {
-    if (type._fieldList == null) throw new StateError("message not resolved");
+    if (type._fieldList == null) throw StateError("message not resolved");
 
     if (alreadySeen.contains(type.fullName)) {
       // The type is already in cache.  This means that either:
@@ -440,7 +440,7 @@ class MessageGenerator extends ProtobufContainer {
 
     for (var i = 0; i < _fieldList.length; i++) {
       out.println();
-      List<int> memberFieldPath = new List.from(fieldPath)
+      List<int> memberFieldPath = List.from(fieldPath)
         ..addAll([_messageFieldTag, i]);
       generateFieldAccessorsMutators(_fieldList[i], out, memberFieldPath);
     }

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -113,8 +113,7 @@ class MessageGenerator extends ProtobufContainer {
             List.generate(descriptor.oneofDecl.length, (int index) => []) {
     for (var i = 0; i < _descriptor.enumType.length; i++) {
       EnumDescriptorProto e = _descriptor.enumType[i];
-      _enumGenerators
-          .add(EnumGenerator.nested(e, this, _usedTopLevelNames, i));
+      _enumGenerators.add(EnumGenerator.nested(e, this, _usedTopLevelNames, i));
     }
 
     for (var i = 0; i < _descriptor.nestedType.length; i++) {

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -449,7 +449,7 @@ final List<String> forbiddenExtensionNames = <String>[]
 
 // List of Dart language reserved words in names which cannot be used in a
 // subclass of GeneratedMessage.
-const List<String> _dartReservedWords = const [
+const List<String> _dartReservedWords = [
   'assert',
   'bool',
   'break',
@@ -492,7 +492,7 @@ const List<String> _dartReservedWords = const [
 //
 // This is in addition to GeneratedMessage_reservedNames, which are names from
 // the base GeneratedMessage class determined by reflection.
-const _generatedMessageNames = const <String>[
+const _generatedMessageNames = <String>[
   'create',
   'createRepeated',
   'getDefault',
@@ -504,7 +504,7 @@ const _generatedMessageNames = const <String>[
 //
 // This is in addition to ProtobufEnum_reservedNames, which are names from the
 // base ProtobufEnum class determined by reflection.
-const _protobufEnumNames = const <String>[
+const _protobufEnumNames = <String>[
   'List',
   'valueOf',
   'values',

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -98,7 +98,7 @@ Iterable<String> extensionSuffixes() sync* {
 ///
 /// This function does not take care of leading underscores.
 String legalDartIdentifier(String imput) {
-  return imput.replaceAll(new RegExp(r'[^a-zA-Z0-9$_]'), '_');
+  return imput.replaceAll(RegExp(r'[^a-zA-Z0-9$_]'), '_');
 }
 
 /// Chooses the name of the Dart class holding top-level extensions.
@@ -111,7 +111,7 @@ String extensionClassName(
 }
 
 String _fileNameWithoutExtension(FileDescriptorProto descriptor) {
-  Uri path = new Uri.file(descriptor.name);
+  Uri path = Uri.file(descriptor.name);
   String fileName = path.pathSegments.last;
   int dot = fileName.lastIndexOf(".");
   return dot == -1 ? fileName : fileName.substring(0, dot);
@@ -190,7 +190,7 @@ String messageOrEnumClassName(String descriptorName, Set<String> usedNames,
 
 /// Returns the set of names reserved by the ProtobufEnum class and its
 /// generated subclasses.
-Set<String> get reservedEnumNames => new Set<String>()
+Set<String> get reservedEnumNames => Set<String>()
   ..addAll(ProtobufEnum_reservedNames)
   ..addAll(_protobufEnumNames);
 
@@ -215,7 +215,7 @@ Iterable<String> enumSuffixes() sync* {
 MemberNames messageMemberNames(DescriptorProto descriptor,
     String parentClassName, Set<String> usedTopLevelNames,
     {Iterable<String> reserved = const []}) {
-  var sorted = new List<FieldDescriptorProto>.from(descriptor.field)
+  var sorted = List<FieldDescriptorProto>.from(descriptor.field)
     ..sort((FieldDescriptorProto a, FieldDescriptorProto b) {
       if (a.number < b.number) return -1;
       if (a.number > b.number) return 1;
@@ -229,7 +229,7 @@ MemberNames messageMemberNames(DescriptorProto descriptor,
     indexes[field.name] = index;
   }
 
-  var existingNames = new Set<String>()
+  var existingNames = Set<String>()
     ..addAll(reservedMemberNames)
     ..addAll(reserved);
 
@@ -317,23 +317,23 @@ FieldNames _memberNamesFromOption(DescriptorProto message,
 
   void checkAvailable(String name) {
     if (existingNames.contains(name)) {
-      throw new DartNameOptionException(
+      throw DartNameOptionException(
           "$where: dart_name option is invalid: '$name' is already used");
     }
   }
 
   var name = _nameOption(field);
   if (name.isEmpty) {
-    throw new ArgumentError("field doesn't have dart_name option");
+    throw ArgumentError("field doesn't have dart_name option");
   }
   if (!_isDartFieldName(name)) {
-    throw new DartNameOptionException("$where: dart_name option is invalid: "
+    throw DartNameOptionException("$where: dart_name option is invalid: "
         "'$name' is not a valid Dart field name");
   }
   checkAvailable(name);
 
   if (_isRepeated(field)) {
-    return new FieldNames(field, index, name);
+    return FieldNames(field, index, name);
   }
 
   String hasMethod = "has${_capitalize(name)}";
@@ -342,7 +342,7 @@ FieldNames _memberNamesFromOption(DescriptorProto message,
   String clearMethod = "clear${_capitalize(name)}";
   checkAvailable(clearMethod);
 
-  return new FieldNames(field, index, name,
+  return FieldNames(field, index, name,
       hasMethodName: hasMethod, clearMethodName: clearMethod);
 }
 
@@ -357,7 +357,7 @@ Iterable<String> _memberNamesSuffix(int number) sync* {
 FieldNames _unusedMemberNames(
     FieldDescriptorProto field, int index, Set<String> existingNames) {
   if (_isRepeated(field)) {
-    return new FieldNames(
+    return FieldNames(
         field,
         index,
         disambiguateName(_defaultFieldName(_fieldMethodSuffix(field)),
@@ -375,7 +375,7 @@ FieldNames _unusedMemberNames(
   String name = disambiguateName(_fieldMethodSuffix(field), existingNames,
       _memberNamesSuffix(field.number),
       generateVariants: generateNameVariants);
-  return new FieldNames(field, index, _defaultFieldName(name),
+  return FieldNames(field, index, _defaultFieldName(name),
       hasMethodName: _defaultHasMethodName(name),
       clearMethodName: _defaultClearMethodName(name));
 }
@@ -427,7 +427,7 @@ String _nameOption(FieldDescriptorProto field) =>
 
 bool _isDartFieldName(name) => name.startsWith(_dartFieldNameExpr);
 
-final _dartFieldNameExpr = new RegExp(r'^[a-z]\w+$');
+final _dartFieldNameExpr = RegExp(r'^[a-z]\w+$');
 
 /// Names that would collide with capitalized core Dart names as top-level
 /// identifiers.

--- a/protoc_plugin/lib/options.dart
+++ b/protoc_plugin/lib/options.dart
@@ -98,13 +98,13 @@ GenerationOptions parseGenerationOptions(
   final newParsers = <String, SingleOptionParser>{};
   if (parsers != null) newParsers.addAll(parsers);
 
-  final grpcOptionParser = new GrpcOptionParser();
+  final grpcOptionParser = GrpcOptionParser();
   newParsers['grpc'] = grpcOptionParser;
-  final generateMetadataParser = new GenerateMetadataParser();
+  final generateMetadataParser = GenerateMetadataParser();
   newParsers['generate_kythe_info'] = generateMetadataParser;
 
   if (genericOptionsParser(request, response, newParsers)) {
-    return new GenerationOptions(
+    return GenerationOptions(
         useGrpc: grpcOptionParser.grpcEnabled,
         generateMetadata: generateMetadataParser.generateKytheInfo);
   }

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -6,13 +6,13 @@ part of protoc;
 
 class ProtobufField {
   static final RegExp HEX_LITERAL_REGEX =
-      new RegExp(r'^0x[0-9a-f]+$', multiLine: false, caseSensitive: false);
-  static final RegExp INTEGER_LITERAL_REGEX = new RegExp(r'^[+-]?[0-9]+$');
-  static final RegExp DECIMAL_LITERAL_REGEX_A = new RegExp(
+      RegExp(r'^0x[0-9a-f]+$', multiLine: false, caseSensitive: false);
+  static final RegExp INTEGER_LITERAL_REGEX = RegExp(r'^[+-]?[0-9]+$');
+  static final RegExp DECIMAL_LITERAL_REGEX_A = RegExp(
       r'^[+-]?([0-9]*)\.[0-9]+(e[+-]?[0-9]+)?$',
       multiLine: false,
       caseSensitive: false);
-  static final RegExp DECIMAL_LITERAL_REGEX_B = new RegExp(
+  static final RegExp DECIMAL_LITERAL_REGEX_B = RegExp(
       r'^[+-]?[0-9]+e[+-]?[0-9]+$',
       multiLine: false,
       caseSensitive: false);
@@ -38,7 +38,7 @@ class ProtobufField {
       : this.descriptor = descriptor,
         this.memberNames = dartNames,
         fullName = '${parent.fullName}.${descriptor.name}',
-        baseType = new BaseType(descriptor, ctx);
+        baseType = BaseType(descriptor, ctx);
 
   /// The index of this field in MessageGenerator.fieldList.
   ///
@@ -226,7 +226,7 @@ class ProtobufField {
   /// evaluated.
   String generateDefaultFunction(FileGenerator fileGen) {
     if (isRepeated) {
-      return '() => new $_protobufImportPrefix.PbList()';
+      return '() => $_protobufImportPrefix.PbList()';
     }
     bool sameProtoFile =
         fileGen.protoFileUri == baseType.generator?.fileGen?.protoFileUri;

--- a/protoc_plugin/lib/service_generator.dart
+++ b/protoc_plugin/lib/service_generator.dart
@@ -156,10 +156,10 @@ class ServiceGenerator {
       out.addBlock("switch (method) {", "}", () {
         for (MethodDescriptorProto m in _methodDescriptors) {
           var inputClass = _getDartClassName(m.inputType);
-          out.println("case '${m.name}': return new $inputClass();");
+          out.println("case '${m.name}': return $inputClass();");
         }
         out.println("default: "
-            "throw new $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
+            "throw $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
       });
     });
     out.println();
@@ -177,7 +177,7 @@ class ServiceGenerator {
               "case '${m.name}': return this.$methodName(ctx, request);");
         }
         out.println("default: "
-            "throw new $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
+            "throw $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
       });
     });
     out.println();

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -10,7 +10,7 @@ import 'dart:core' as $core show int, bool, double, String, List, Map, override;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class DartMixin extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('DartMixin',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DartMixin',
       package: const $pb.PackageName('dart_options'))
     ..aOS(1, 'name')
     ..aOS(2, 'importFrom')
@@ -24,13 +24,13 @@ class DartMixin extends $pb.GeneratedMessage {
   DartMixin.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  DartMixin clone() => new DartMixin()..mergeFromMessage(this);
+  DartMixin clone() => DartMixin()..mergeFromMessage(this);
   DartMixin copyWith(void Function(DartMixin) updates) =>
       super.copyWith((message) => updates(message as DartMixin));
   $pb.BuilderInfo get info_ => _i;
-  static DartMixin create() => new DartMixin();
+  static DartMixin create() => DartMixin();
   DartMixin createEmptyInstance() => create();
-  static $pb.PbList<DartMixin> createRepeated() => new $pb.PbList<DartMixin>();
+  static $pb.PbList<DartMixin> createRepeated() => $pb.PbList<DartMixin>();
   static DartMixin getDefault() => _defaultInstance ??= create()..freeze();
   static DartMixin _defaultInstance;
 
@@ -60,10 +60,10 @@ class DartMixin extends $pb.GeneratedMessage {
 }
 
 class Imports extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('Imports',
-      package: const $pb.PackageName('dart_options'))
-    ..pc<DartMixin>(1, 'mixins', $pb.PbFieldType.PM, DartMixin.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i =
+      $pb.BuilderInfo('Imports', package: const $pb.PackageName('dart_options'))
+        ..pc<DartMixin>(1, 'mixins', $pb.PbFieldType.PM, DartMixin.create)
+        ..hasRequiredFields = false;
 
   Imports() : super();
   Imports.fromBuffer($core.List<$core.int> i,
@@ -72,13 +72,13 @@ class Imports extends $pb.GeneratedMessage {
   Imports.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  Imports clone() => new Imports()..mergeFromMessage(this);
+  Imports clone() => Imports()..mergeFromMessage(this);
   Imports copyWith(void Function(Imports) updates) =>
       super.copyWith((message) => updates(message as Imports));
   $pb.BuilderInfo get info_ => _i;
-  static Imports create() => new Imports();
+  static Imports create() => Imports();
   Imports createEmptyInstance() => create();
-  static $pb.PbList<Imports> createRepeated() => new $pb.PbList<Imports>();
+  static $pb.PbList<Imports> createRepeated() => $pb.PbList<Imports>();
   static Imports getDefault() => _defaultInstance ??= create()..freeze();
   static Imports _defaultInstance;
 
@@ -86,39 +86,41 @@ class Imports extends $pb.GeneratedMessage {
 }
 
 class Dart_options {
-  static final $pb.Extension imports = new $pb.Extension<Imports>(
+  static final $pb.Extension imports = $pb.Extension<Imports>(
       'google.protobuf.FileOptions',
       'imports',
       28125061,
       $pb.PbFieldType.OM,
       Imports.getDefault,
       Imports.create);
-  static final $pb.Extension defaultMixin = new $pb.Extension<$core.String>(
+  static final $pb.Extension defaultMixin = $pb.Extension<$core.String>(
       'google.protobuf.FileOptions',
       'defaultMixin',
       96128839,
       $pb.PbFieldType.OS);
-  static final $pb.Extension mixin = new $pb.Extension<$core.String>(
+  static final $pb.Extension mixin = $pb.Extension<$core.String>(
       'google.protobuf.MessageOptions', 'mixin', 96128839, $pb.PbFieldType.OS);
-  static final $pb.Extension overrideGetter = new $pb.Extension<$core.bool>(
+  static final $pb.Extension overrideGetter = $pb.Extension<$core.bool>(
       'google.protobuf.FieldOptions',
       'overrideGetter',
       28205290,
       $pb.PbFieldType.OB);
-  static final $pb.Extension overrideSetter = new $pb.Extension<$core.bool>(
+  static final $pb.Extension overrideSetter = $pb.Extension<$core.bool>(
       'google.protobuf.FieldOptions',
       'overrideSetter',
       28937366,
       $pb.PbFieldType.OB);
-  static final $pb.Extension overrideHasMethod = new $pb.Extension<$core.bool>(
+  static final $pb.Extension overrideHasMethod = $pb.Extension<$core.bool>(
       'google.protobuf.FieldOptions',
       'overrideHasMethod',
       28937461,
       $pb.PbFieldType.OB);
-  static final $pb.Extension overrideClearMethod =
-      new $pb.Extension<$core.bool>('google.protobuf.FieldOptions',
-          'overrideClearMethod', 28907907, $pb.PbFieldType.OB);
-  static final $pb.Extension dartName = new $pb.Extension<$core.String>(
+  static final $pb.Extension overrideClearMethod = $pb.Extension<$core.bool>(
+      'google.protobuf.FieldOptions',
+      'overrideClearMethod',
+      28907907,
+      $pb.PbFieldType.OB);
+  static final $pb.Extension dartName = $pb.Extension<$core.String>(
       'google.protobuf.FieldOptions', 'dartName', 28700919, $pb.PbFieldType.OS);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
     registry.add(imports);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -15,7 +15,7 @@ import 'descriptor.pbenum.dart';
 export 'descriptor.pbenum.dart';
 
 class FileDescriptorSet extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FileDescriptorSet',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileDescriptorSet',
       package: const $pb.PackageName('google.protobuf'))
     ..pc<FileDescriptorProto>(
         1, 'file', $pb.PbFieldType.PM, FileDescriptorProto.create);
@@ -27,14 +27,14 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   FileDescriptorSet.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  FileDescriptorSet clone() => new FileDescriptorSet()..mergeFromMessage(this);
+  FileDescriptorSet clone() => FileDescriptorSet()..mergeFromMessage(this);
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorSet));
   $pb.BuilderInfo get info_ => _i;
-  static FileDescriptorSet create() => new FileDescriptorSet();
+  static FileDescriptorSet create() => FileDescriptorSet();
   FileDescriptorSet createEmptyInstance() => create();
   static $pb.PbList<FileDescriptorSet> createRepeated() =>
-      new $pb.PbList<FileDescriptorSet>();
+      $pb.PbList<FileDescriptorSet>();
   static FileDescriptorSet getDefault() =>
       _defaultInstance ??= create()..freeze();
   static FileDescriptorSet _defaultInstance;
@@ -43,7 +43,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
 }
 
 class FileDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FileDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..aOS(2, 'package')
@@ -71,15 +71,14 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   FileDescriptorProto.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  FileDescriptorProto clone() =>
-      new FileDescriptorProto()..mergeFromMessage(this);
+  FileDescriptorProto clone() => FileDescriptorProto()..mergeFromMessage(this);
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FileDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static FileDescriptorProto create() => new FileDescriptorProto();
+  static FileDescriptorProto create() => FileDescriptorProto();
   FileDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<FileDescriptorProto> createRepeated() =>
-      new $pb.PbList<FileDescriptorProto>();
+      $pb.PbList<FileDescriptorProto>();
   static FileDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static FileDescriptorProto _defaultInstance;
@@ -140,7 +139,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       'DescriptorProto.ExtensionRange',
       package: const $pb.PackageName('google.protobuf'))
     ..a<$core.int>(1, 'start', $pb.PbFieldType.O3)
@@ -155,17 +154,17 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   DescriptorProto_ExtensionRange clone() =>
-      new DescriptorProto_ExtensionRange()..mergeFromMessage(this);
+      DescriptorProto_ExtensionRange()..mergeFromMessage(this);
   DescriptorProto_ExtensionRange copyWith(
           void Function(DescriptorProto_ExtensionRange) updates) =>
       super.copyWith(
           (message) => updates(message as DescriptorProto_ExtensionRange));
   $pb.BuilderInfo get info_ => _i;
   static DescriptorProto_ExtensionRange create() =>
-      new DescriptorProto_ExtensionRange();
+      DescriptorProto_ExtensionRange();
   DescriptorProto_ExtensionRange createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto_ExtensionRange> createRepeated() =>
-      new $pb.PbList<DescriptorProto_ExtensionRange>();
+      $pb.PbList<DescriptorProto_ExtensionRange>();
   static DescriptorProto_ExtensionRange getDefault() =>
       _defaultInstance ??= create()..freeze();
   static DescriptorProto_ExtensionRange _defaultInstance;
@@ -188,7 +187,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
 }
 
 class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       'DescriptorProto.ReservedRange',
       package: const $pb.PackageName('google.protobuf'))
     ..a<$core.int>(1, 'start', $pb.PbFieldType.O3)
@@ -203,17 +202,17 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   DescriptorProto_ReservedRange clone() =>
-      new DescriptorProto_ReservedRange()..mergeFromMessage(this);
+      DescriptorProto_ReservedRange()..mergeFromMessage(this);
   DescriptorProto_ReservedRange copyWith(
           void Function(DescriptorProto_ReservedRange) updates) =>
       super.copyWith(
           (message) => updates(message as DescriptorProto_ReservedRange));
   $pb.BuilderInfo get info_ => _i;
   static DescriptorProto_ReservedRange create() =>
-      new DescriptorProto_ReservedRange();
+      DescriptorProto_ReservedRange();
   DescriptorProto_ReservedRange createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto_ReservedRange> createRepeated() =>
-      new $pb.PbList<DescriptorProto_ReservedRange>();
+      $pb.PbList<DescriptorProto_ReservedRange>();
   static DescriptorProto_ReservedRange getDefault() =>
       _defaultInstance ??= create()..freeze();
   static DescriptorProto_ReservedRange _defaultInstance;
@@ -236,7 +235,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
 }
 
 class DescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('DescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..pc<FieldDescriptorProto>(
@@ -264,14 +263,14 @@ class DescriptorProto extends $pb.GeneratedMessage {
   DescriptorProto.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  DescriptorProto clone() => new DescriptorProto()..mergeFromMessage(this);
+  DescriptorProto clone() => DescriptorProto()..mergeFromMessage(this);
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
       super.copyWith((message) => updates(message as DescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static DescriptorProto create() => new DescriptorProto();
+  static DescriptorProto create() => DescriptorProto();
   DescriptorProto createEmptyInstance() => create();
   static $pb.PbList<DescriptorProto> createRepeated() =>
-      new $pb.PbList<DescriptorProto>();
+      $pb.PbList<DescriptorProto>();
   static DescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static DescriptorProto _defaultInstance;
@@ -310,7 +309,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
 }
 
 class FieldDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FieldDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FieldDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..aOS(2, 'extendee')
@@ -344,14 +343,14 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   FieldDescriptorProto clone() =>
-      new FieldDescriptorProto()..mergeFromMessage(this);
+      FieldDescriptorProto()..mergeFromMessage(this);
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as FieldDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static FieldDescriptorProto create() => new FieldDescriptorProto();
+  static FieldDescriptorProto create() => FieldDescriptorProto();
   FieldDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<FieldDescriptorProto> createRepeated() =>
-      new $pb.PbList<FieldDescriptorProto>();
+      $pb.PbList<FieldDescriptorProto>();
   static FieldDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static FieldDescriptorProto _defaultInstance;
@@ -438,7 +437,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class OneofDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('OneofDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('OneofDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..a<OneofOptions>(2, 'options', $pb.PbFieldType.OM, OneofOptions.getDefault,
@@ -452,14 +451,14 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   OneofDescriptorProto clone() =>
-      new OneofDescriptorProto()..mergeFromMessage(this);
+      OneofDescriptorProto()..mergeFromMessage(this);
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as OneofDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static OneofDescriptorProto create() => new OneofDescriptorProto();
+  static OneofDescriptorProto create() => OneofDescriptorProto();
   OneofDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<OneofDescriptorProto> createRepeated() =>
-      new $pb.PbList<OneofDescriptorProto>();
+      $pb.PbList<OneofDescriptorProto>();
   static OneofDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static OneofDescriptorProto _defaultInstance;
@@ -482,7 +481,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class EnumDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('EnumDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..pc<EnumValueDescriptorProto>(
@@ -497,15 +496,14 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   EnumDescriptorProto.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  EnumDescriptorProto clone() =>
-      new EnumDescriptorProto()..mergeFromMessage(this);
+  EnumDescriptorProto clone() => EnumDescriptorProto()..mergeFromMessage(this);
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static EnumDescriptorProto create() => new EnumDescriptorProto();
+  static EnumDescriptorProto create() => EnumDescriptorProto();
   EnumDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<EnumDescriptorProto> createRepeated() =>
-      new $pb.PbList<EnumDescriptorProto>();
+      $pb.PbList<EnumDescriptorProto>();
   static EnumDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static EnumDescriptorProto _defaultInstance;
@@ -530,8 +528,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class EnumValueDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
-      'EnumValueDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumValueDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..a<$core.int>(2, 'number', $pb.PbFieldType.O3)
@@ -546,15 +543,15 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   EnumValueDescriptorProto clone() =>
-      new EnumValueDescriptorProto()..mergeFromMessage(this);
+      EnumValueDescriptorProto()..mergeFromMessage(this);
   EnumValueDescriptorProto copyWith(
           void Function(EnumValueDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as EnumValueDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static EnumValueDescriptorProto create() => new EnumValueDescriptorProto();
+  static EnumValueDescriptorProto create() => EnumValueDescriptorProto();
   EnumValueDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<EnumValueDescriptorProto> createRepeated() =>
-      new $pb.PbList<EnumValueDescriptorProto>();
+      $pb.PbList<EnumValueDescriptorProto>();
   static EnumValueDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static EnumValueDescriptorProto _defaultInstance;
@@ -585,8 +582,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class ServiceDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
-      'ServiceDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ServiceDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..pc<MethodDescriptorProto>(
@@ -602,15 +598,15 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   ServiceDescriptorProto clone() =>
-      new ServiceDescriptorProto()..mergeFromMessage(this);
+      ServiceDescriptorProto()..mergeFromMessage(this);
   ServiceDescriptorProto copyWith(
           void Function(ServiceDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as ServiceDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static ServiceDescriptorProto create() => new ServiceDescriptorProto();
+  static ServiceDescriptorProto create() => ServiceDescriptorProto();
   ServiceDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<ServiceDescriptorProto> createRepeated() =>
-      new $pb.PbList<ServiceDescriptorProto>();
+      $pb.PbList<ServiceDescriptorProto>();
   static ServiceDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static ServiceDescriptorProto _defaultInstance;
@@ -635,7 +631,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class MethodDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('MethodDescriptorProto',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MethodDescriptorProto',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'name')
     ..aOS(2, 'inputType')
@@ -653,15 +649,15 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   MethodDescriptorProto clone() =>
-      new MethodDescriptorProto()..mergeFromMessage(this);
+      MethodDescriptorProto()..mergeFromMessage(this);
   MethodDescriptorProto copyWith(
           void Function(MethodDescriptorProto) updates) =>
       super.copyWith((message) => updates(message as MethodDescriptorProto));
   $pb.BuilderInfo get info_ => _i;
-  static MethodDescriptorProto create() => new MethodDescriptorProto();
+  static MethodDescriptorProto create() => MethodDescriptorProto();
   MethodDescriptorProto createEmptyInstance() => create();
   static $pb.PbList<MethodDescriptorProto> createRepeated() =>
-      new $pb.PbList<MethodDescriptorProto>();
+      $pb.PbList<MethodDescriptorProto>();
   static MethodDescriptorProto getDefault() =>
       _defaultInstance ??= create()..freeze();
   static MethodDescriptorProto _defaultInstance;
@@ -716,7 +712,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class FileOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FileOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOS(1, 'javaPackage')
     ..aOS(8, 'javaOuterClassname')
@@ -752,14 +748,13 @@ class FileOptions extends $pb.GeneratedMessage {
   FileOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  FileOptions clone() => new FileOptions()..mergeFromMessage(this);
+  FileOptions clone() => FileOptions()..mergeFromMessage(this);
   FileOptions copyWith(void Function(FileOptions) updates) =>
       super.copyWith((message) => updates(message as FileOptions));
   $pb.BuilderInfo get info_ => _i;
-  static FileOptions create() => new FileOptions();
+  static FileOptions create() => FileOptions();
   FileOptions createEmptyInstance() => create();
-  static $pb.PbList<FileOptions> createRepeated() =>
-      new $pb.PbList<FileOptions>();
+  static $pb.PbList<FileOptions> createRepeated() => $pb.PbList<FileOptions>();
   static FileOptions getDefault() => _defaultInstance ??= create()..freeze();
   static FileOptions _defaultInstance;
 
@@ -903,7 +898,7 @@ class FileOptions extends $pb.GeneratedMessage {
 }
 
 class MessageOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('MessageOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MessageOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOB(1, 'messageSetWireFormat')
     ..aOB(2, 'noStandardDescriptorAccessor')
@@ -920,14 +915,14 @@ class MessageOptions extends $pb.GeneratedMessage {
   MessageOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  MessageOptions clone() => new MessageOptions()..mergeFromMessage(this);
+  MessageOptions clone() => MessageOptions()..mergeFromMessage(this);
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
       super.copyWith((message) => updates(message as MessageOptions));
   $pb.BuilderInfo get info_ => _i;
-  static MessageOptions create() => new MessageOptions();
+  static MessageOptions create() => MessageOptions();
   MessageOptions createEmptyInstance() => create();
   static $pb.PbList<MessageOptions> createRepeated() =>
-      new $pb.PbList<MessageOptions>();
+      $pb.PbList<MessageOptions>();
   static MessageOptions getDefault() => _defaultInstance ??= create()..freeze();
   static MessageOptions _defaultInstance;
 
@@ -967,7 +962,7 @@ class MessageOptions extends $pb.GeneratedMessage {
 }
 
 class FieldOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('FieldOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FieldOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..e<FieldOptions_CType>(
         1,
@@ -998,14 +993,14 @@ class FieldOptions extends $pb.GeneratedMessage {
   FieldOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  FieldOptions clone() => new FieldOptions()..mergeFromMessage(this);
+  FieldOptions clone() => FieldOptions()..mergeFromMessage(this);
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
       super.copyWith((message) => updates(message as FieldOptions));
   $pb.BuilderInfo get info_ => _i;
-  static FieldOptions create() => new FieldOptions();
+  static FieldOptions create() => FieldOptions();
   FieldOptions createEmptyInstance() => create();
   static $pb.PbList<FieldOptions> createRepeated() =>
-      new $pb.PbList<FieldOptions>();
+      $pb.PbList<FieldOptions>();
   static FieldOptions getDefault() => _defaultInstance ??= create()..freeze();
   static FieldOptions _defaultInstance;
 
@@ -1061,7 +1056,7 @@ class FieldOptions extends $pb.GeneratedMessage {
 }
 
 class OneofOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('OneofOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('OneofOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
         UninterpretedOption.create)
@@ -1074,14 +1069,14 @@ class OneofOptions extends $pb.GeneratedMessage {
   OneofOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  OneofOptions clone() => new OneofOptions()..mergeFromMessage(this);
+  OneofOptions clone() => OneofOptions()..mergeFromMessage(this);
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
       super.copyWith((message) => updates(message as OneofOptions));
   $pb.BuilderInfo get info_ => _i;
-  static OneofOptions create() => new OneofOptions();
+  static OneofOptions create() => OneofOptions();
   OneofOptions createEmptyInstance() => create();
   static $pb.PbList<OneofOptions> createRepeated() =>
-      new $pb.PbList<OneofOptions>();
+      $pb.PbList<OneofOptions>();
   static OneofOptions getDefault() => _defaultInstance ??= create()..freeze();
   static OneofOptions _defaultInstance;
 
@@ -1089,7 +1084,7 @@ class OneofOptions extends $pb.GeneratedMessage {
 }
 
 class EnumOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('EnumOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOB(2, 'allowAlias')
     ..aOB(3, 'deprecated')
@@ -1104,14 +1099,13 @@ class EnumOptions extends $pb.GeneratedMessage {
   EnumOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  EnumOptions clone() => new EnumOptions()..mergeFromMessage(this);
+  EnumOptions clone() => EnumOptions()..mergeFromMessage(this);
   EnumOptions copyWith(void Function(EnumOptions) updates) =>
       super.copyWith((message) => updates(message as EnumOptions));
   $pb.BuilderInfo get info_ => _i;
-  static EnumOptions create() => new EnumOptions();
+  static EnumOptions create() => EnumOptions();
   EnumOptions createEmptyInstance() => create();
-  static $pb.PbList<EnumOptions> createRepeated() =>
-      new $pb.PbList<EnumOptions>();
+  static $pb.PbList<EnumOptions> createRepeated() => $pb.PbList<EnumOptions>();
   static EnumOptions getDefault() => _defaultInstance ??= create()..freeze();
   static EnumOptions _defaultInstance;
 
@@ -1135,7 +1129,7 @@ class EnumOptions extends $pb.GeneratedMessage {
 }
 
 class EnumValueOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('EnumValueOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumValueOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOB(1, 'deprecated')
     ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
@@ -1149,14 +1143,14 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   EnumValueOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  EnumValueOptions clone() => new EnumValueOptions()..mergeFromMessage(this);
+  EnumValueOptions clone() => EnumValueOptions()..mergeFromMessage(this);
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
       super.copyWith((message) => updates(message as EnumValueOptions));
   $pb.BuilderInfo get info_ => _i;
-  static EnumValueOptions create() => new EnumValueOptions();
+  static EnumValueOptions create() => EnumValueOptions();
   EnumValueOptions createEmptyInstance() => create();
   static $pb.PbList<EnumValueOptions> createRepeated() =>
-      new $pb.PbList<EnumValueOptions>();
+      $pb.PbList<EnumValueOptions>();
   static EnumValueOptions getDefault() =>
       _defaultInstance ??= create()..freeze();
   static EnumValueOptions _defaultInstance;
@@ -1173,7 +1167,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 }
 
 class ServiceOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('ServiceOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ServiceOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOB(33, 'deprecated')
     ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
@@ -1187,14 +1181,14 @@ class ServiceOptions extends $pb.GeneratedMessage {
   ServiceOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  ServiceOptions clone() => new ServiceOptions()..mergeFromMessage(this);
+  ServiceOptions clone() => ServiceOptions()..mergeFromMessage(this);
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
       super.copyWith((message) => updates(message as ServiceOptions));
   $pb.BuilderInfo get info_ => _i;
-  static ServiceOptions create() => new ServiceOptions();
+  static ServiceOptions create() => ServiceOptions();
   ServiceOptions createEmptyInstance() => create();
   static $pb.PbList<ServiceOptions> createRepeated() =>
-      new $pb.PbList<ServiceOptions>();
+      $pb.PbList<ServiceOptions>();
   static ServiceOptions getDefault() => _defaultInstance ??= create()..freeze();
   static ServiceOptions _defaultInstance;
 
@@ -1210,7 +1204,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
 }
 
 class MethodOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('MethodOptions',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MethodOptions',
       package: const $pb.PackageName('google.protobuf'))
     ..aOB(33, 'deprecated')
     ..e<MethodOptions_IdempotencyLevel>(
@@ -1231,14 +1225,14 @@ class MethodOptions extends $pb.GeneratedMessage {
   MethodOptions.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  MethodOptions clone() => new MethodOptions()..mergeFromMessage(this);
+  MethodOptions clone() => MethodOptions()..mergeFromMessage(this);
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
       super.copyWith((message) => updates(message as MethodOptions));
   $pb.BuilderInfo get info_ => _i;
-  static MethodOptions create() => new MethodOptions();
+  static MethodOptions create() => MethodOptions();
   MethodOptions createEmptyInstance() => create();
   static $pb.PbList<MethodOptions> createRepeated() =>
-      new $pb.PbList<MethodOptions>();
+      $pb.PbList<MethodOptions>();
   static MethodOptions getDefault() => _defaultInstance ??= create()..freeze();
   static MethodOptions _defaultInstance;
 
@@ -1262,7 +1256,7 @@ class MethodOptions extends $pb.GeneratedMessage {
 }
 
 class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       'UninterpretedOption.NamePart',
       package: const $pb.PackageName('google.protobuf'))
     ..aQS(1, 'namePart')
@@ -1276,17 +1270,17 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   UninterpretedOption_NamePart clone() =>
-      new UninterpretedOption_NamePart()..mergeFromMessage(this);
+      UninterpretedOption_NamePart()..mergeFromMessage(this);
   UninterpretedOption_NamePart copyWith(
           void Function(UninterpretedOption_NamePart) updates) =>
       super.copyWith(
           (message) => updates(message as UninterpretedOption_NamePart));
   $pb.BuilderInfo get info_ => _i;
   static UninterpretedOption_NamePart create() =>
-      new UninterpretedOption_NamePart();
+      UninterpretedOption_NamePart();
   UninterpretedOption_NamePart createEmptyInstance() => create();
   static $pb.PbList<UninterpretedOption_NamePart> createRepeated() =>
-      new $pb.PbList<UninterpretedOption_NamePart>();
+      $pb.PbList<UninterpretedOption_NamePart>();
   static UninterpretedOption_NamePart getDefault() =>
       _defaultInstance ??= create()..freeze();
   static UninterpretedOption_NamePart _defaultInstance;
@@ -1309,7 +1303,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
 }
 
 class UninterpretedOption extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('UninterpretedOption',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('UninterpretedOption',
       package: const $pb.PackageName('google.protobuf'))
     ..pc<UninterpretedOption_NamePart>(
         2, 'name', $pb.PbFieldType.PM, UninterpretedOption_NamePart.create)
@@ -1327,15 +1321,14 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   UninterpretedOption.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  UninterpretedOption clone() =>
-      new UninterpretedOption()..mergeFromMessage(this);
+  UninterpretedOption clone() => UninterpretedOption()..mergeFromMessage(this);
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
       super.copyWith((message) => updates(message as UninterpretedOption));
   $pb.BuilderInfo get info_ => _i;
-  static UninterpretedOption create() => new UninterpretedOption();
+  static UninterpretedOption create() => UninterpretedOption();
   UninterpretedOption createEmptyInstance() => create();
   static $pb.PbList<UninterpretedOption> createRepeated() =>
-      new $pb.PbList<UninterpretedOption>();
+      $pb.PbList<UninterpretedOption>();
   static UninterpretedOption getDefault() =>
       _defaultInstance ??= create()..freeze();
   static UninterpretedOption _defaultInstance;
@@ -1392,8 +1385,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
 }
 
 class SourceCodeInfo_Location extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
-      'SourceCodeInfo.Location',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceCodeInfo.Location',
       package: const $pb.PackageName('google.protobuf'))
     ..p<$core.int>(1, 'path', $pb.PbFieldType.K3)
     ..p<$core.int>(2, 'span', $pb.PbFieldType.K3)
@@ -1410,15 +1402,15 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   SourceCodeInfo_Location clone() =>
-      new SourceCodeInfo_Location()..mergeFromMessage(this);
+      SourceCodeInfo_Location()..mergeFromMessage(this);
   SourceCodeInfo_Location copyWith(
           void Function(SourceCodeInfo_Location) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo_Location));
   $pb.BuilderInfo get info_ => _i;
-  static SourceCodeInfo_Location create() => new SourceCodeInfo_Location();
+  static SourceCodeInfo_Location create() => SourceCodeInfo_Location();
   SourceCodeInfo_Location createEmptyInstance() => create();
   static $pb.PbList<SourceCodeInfo_Location> createRepeated() =>
-      new $pb.PbList<SourceCodeInfo_Location>();
+      $pb.PbList<SourceCodeInfo_Location>();
   static SourceCodeInfo_Location getDefault() =>
       _defaultInstance ??= create()..freeze();
   static SourceCodeInfo_Location _defaultInstance;
@@ -1447,7 +1439,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
 }
 
 class SourceCodeInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('SourceCodeInfo',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceCodeInfo',
       package: const $pb.PackageName('google.protobuf'))
     ..pc<SourceCodeInfo_Location>(
         1, 'location', $pb.PbFieldType.PM, SourceCodeInfo_Location.create)
@@ -1460,14 +1452,14 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   SourceCodeInfo.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  SourceCodeInfo clone() => new SourceCodeInfo()..mergeFromMessage(this);
+  SourceCodeInfo clone() => SourceCodeInfo()..mergeFromMessage(this);
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
       super.copyWith((message) => updates(message as SourceCodeInfo));
   $pb.BuilderInfo get info_ => _i;
-  static SourceCodeInfo create() => new SourceCodeInfo();
+  static SourceCodeInfo create() => SourceCodeInfo();
   SourceCodeInfo createEmptyInstance() => create();
   static $pb.PbList<SourceCodeInfo> createRepeated() =>
-      new $pb.PbList<SourceCodeInfo>();
+      $pb.PbList<SourceCodeInfo>();
   static SourceCodeInfo getDefault() => _defaultInstance ??= create()..freeze();
   static SourceCodeInfo _defaultInstance;
 
@@ -1475,7 +1467,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
 }
 
 class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       'GeneratedCodeInfo.Annotation',
       package: const $pb.PackageName('google.protobuf'))
     ..p<$core.int>(1, 'path', $pb.PbFieldType.K3)
@@ -1492,17 +1484,17 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   GeneratedCodeInfo_Annotation clone() =>
-      new GeneratedCodeInfo_Annotation()..mergeFromMessage(this);
+      GeneratedCodeInfo_Annotation()..mergeFromMessage(this);
   GeneratedCodeInfo_Annotation copyWith(
           void Function(GeneratedCodeInfo_Annotation) updates) =>
       super.copyWith(
           (message) => updates(message as GeneratedCodeInfo_Annotation));
   $pb.BuilderInfo get info_ => _i;
   static GeneratedCodeInfo_Annotation create() =>
-      new GeneratedCodeInfo_Annotation();
+      GeneratedCodeInfo_Annotation();
   GeneratedCodeInfo_Annotation createEmptyInstance() => create();
   static $pb.PbList<GeneratedCodeInfo_Annotation> createRepeated() =>
-      new $pb.PbList<GeneratedCodeInfo_Annotation>();
+      $pb.PbList<GeneratedCodeInfo_Annotation>();
   static GeneratedCodeInfo_Annotation getDefault() =>
       _defaultInstance ??= create()..freeze();
   static GeneratedCodeInfo_Annotation _defaultInstance;
@@ -1535,7 +1527,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
 }
 
 class GeneratedCodeInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('GeneratedCodeInfo',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GeneratedCodeInfo',
       package: const $pb.PackageName('google.protobuf'))
     ..pc<GeneratedCodeInfo_Annotation>(1, 'annotation', $pb.PbFieldType.PM,
         GeneratedCodeInfo_Annotation.create)
@@ -1548,14 +1540,14 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   GeneratedCodeInfo.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  GeneratedCodeInfo clone() => new GeneratedCodeInfo()..mergeFromMessage(this);
+  GeneratedCodeInfo clone() => GeneratedCodeInfo()..mergeFromMessage(this);
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
       super.copyWith((message) => updates(message as GeneratedCodeInfo));
   $pb.BuilderInfo get info_ => _i;
-  static GeneratedCodeInfo create() => new GeneratedCodeInfo();
+  static GeneratedCodeInfo create() => GeneratedCodeInfo();
   GeneratedCodeInfo createEmptyInstance() => create();
   static $pb.PbList<GeneratedCodeInfo> createRepeated() =>
-      new $pb.PbList<GeneratedCodeInfo>();
+      $pb.PbList<GeneratedCodeInfo>();
   static GeneratedCodeInfo getDefault() =>
       _defaultInstance ??= create()..freeze();
   static GeneratedCodeInfo _defaultInstance;

--- a/protoc_plugin/lib/src/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/descriptor.pbenum.dart
@@ -10,44 +10,44 @@ import 'package:protobuf/protobuf.dart' as $pb;
 
 class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
   static const FieldDescriptorProto_Type TYPE_DOUBLE =
-      const FieldDescriptorProto_Type._(1, 'TYPE_DOUBLE');
+      FieldDescriptorProto_Type._(1, 'TYPE_DOUBLE');
   static const FieldDescriptorProto_Type TYPE_FLOAT =
-      const FieldDescriptorProto_Type._(2, 'TYPE_FLOAT');
+      FieldDescriptorProto_Type._(2, 'TYPE_FLOAT');
   static const FieldDescriptorProto_Type TYPE_INT64 =
-      const FieldDescriptorProto_Type._(3, 'TYPE_INT64');
+      FieldDescriptorProto_Type._(3, 'TYPE_INT64');
   static const FieldDescriptorProto_Type TYPE_UINT64 =
-      const FieldDescriptorProto_Type._(4, 'TYPE_UINT64');
+      FieldDescriptorProto_Type._(4, 'TYPE_UINT64');
   static const FieldDescriptorProto_Type TYPE_INT32 =
-      const FieldDescriptorProto_Type._(5, 'TYPE_INT32');
+      FieldDescriptorProto_Type._(5, 'TYPE_INT32');
   static const FieldDescriptorProto_Type TYPE_FIXED64 =
-      const FieldDescriptorProto_Type._(6, 'TYPE_FIXED64');
+      FieldDescriptorProto_Type._(6, 'TYPE_FIXED64');
   static const FieldDescriptorProto_Type TYPE_FIXED32 =
-      const FieldDescriptorProto_Type._(7, 'TYPE_FIXED32');
+      FieldDescriptorProto_Type._(7, 'TYPE_FIXED32');
   static const FieldDescriptorProto_Type TYPE_BOOL =
-      const FieldDescriptorProto_Type._(8, 'TYPE_BOOL');
+      FieldDescriptorProto_Type._(8, 'TYPE_BOOL');
   static const FieldDescriptorProto_Type TYPE_STRING =
-      const FieldDescriptorProto_Type._(9, 'TYPE_STRING');
+      FieldDescriptorProto_Type._(9, 'TYPE_STRING');
   static const FieldDescriptorProto_Type TYPE_GROUP =
-      const FieldDescriptorProto_Type._(10, 'TYPE_GROUP');
+      FieldDescriptorProto_Type._(10, 'TYPE_GROUP');
   static const FieldDescriptorProto_Type TYPE_MESSAGE =
-      const FieldDescriptorProto_Type._(11, 'TYPE_MESSAGE');
+      FieldDescriptorProto_Type._(11, 'TYPE_MESSAGE');
   static const FieldDescriptorProto_Type TYPE_BYTES =
-      const FieldDescriptorProto_Type._(12, 'TYPE_BYTES');
+      FieldDescriptorProto_Type._(12, 'TYPE_BYTES');
   static const FieldDescriptorProto_Type TYPE_UINT32 =
-      const FieldDescriptorProto_Type._(13, 'TYPE_UINT32');
+      FieldDescriptorProto_Type._(13, 'TYPE_UINT32');
   static const FieldDescriptorProto_Type TYPE_ENUM =
-      const FieldDescriptorProto_Type._(14, 'TYPE_ENUM');
+      FieldDescriptorProto_Type._(14, 'TYPE_ENUM');
   static const FieldDescriptorProto_Type TYPE_SFIXED32 =
-      const FieldDescriptorProto_Type._(15, 'TYPE_SFIXED32');
+      FieldDescriptorProto_Type._(15, 'TYPE_SFIXED32');
   static const FieldDescriptorProto_Type TYPE_SFIXED64 =
-      const FieldDescriptorProto_Type._(16, 'TYPE_SFIXED64');
+      FieldDescriptorProto_Type._(16, 'TYPE_SFIXED64');
   static const FieldDescriptorProto_Type TYPE_SINT32 =
-      const FieldDescriptorProto_Type._(17, 'TYPE_SINT32');
+      FieldDescriptorProto_Type._(17, 'TYPE_SINT32');
   static const FieldDescriptorProto_Type TYPE_SINT64 =
-      const FieldDescriptorProto_Type._(18, 'TYPE_SINT64');
+      FieldDescriptorProto_Type._(18, 'TYPE_SINT64');
 
   static const $core.List<FieldDescriptorProto_Type> values =
-      const <FieldDescriptorProto_Type>[
+      <FieldDescriptorProto_Type>[
     TYPE_DOUBLE,
     TYPE_FLOAT,
     TYPE_INT64,
@@ -77,14 +77,14 @@ class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
 
 class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
   static const FieldDescriptorProto_Label LABEL_OPTIONAL =
-      const FieldDescriptorProto_Label._(1, 'LABEL_OPTIONAL');
+      FieldDescriptorProto_Label._(1, 'LABEL_OPTIONAL');
   static const FieldDescriptorProto_Label LABEL_REQUIRED =
-      const FieldDescriptorProto_Label._(2, 'LABEL_REQUIRED');
+      FieldDescriptorProto_Label._(2, 'LABEL_REQUIRED');
   static const FieldDescriptorProto_Label LABEL_REPEATED =
-      const FieldDescriptorProto_Label._(3, 'LABEL_REPEATED');
+      FieldDescriptorProto_Label._(3, 'LABEL_REPEATED');
 
   static const $core.List<FieldDescriptorProto_Label> values =
-      const <FieldDescriptorProto_Label>[
+      <FieldDescriptorProto_Label>[
     LABEL_OPTIONAL,
     LABEL_REQUIRED,
     LABEL_REPEATED,
@@ -99,14 +99,14 @@ class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
 
 class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
   static const FileOptions_OptimizeMode SPEED =
-      const FileOptions_OptimizeMode._(1, 'SPEED');
+      FileOptions_OptimizeMode._(1, 'SPEED');
   static const FileOptions_OptimizeMode CODE_SIZE =
-      const FileOptions_OptimizeMode._(2, 'CODE_SIZE');
+      FileOptions_OptimizeMode._(2, 'CODE_SIZE');
   static const FileOptions_OptimizeMode LITE_RUNTIME =
-      const FileOptions_OptimizeMode._(3, 'LITE_RUNTIME');
+      FileOptions_OptimizeMode._(3, 'LITE_RUNTIME');
 
   static const $core.List<FileOptions_OptimizeMode> values =
-      const <FileOptions_OptimizeMode>[
+      <FileOptions_OptimizeMode>[
     SPEED,
     CODE_SIZE,
     LITE_RUNTIME,
@@ -120,14 +120,12 @@ class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
 }
 
 class FieldOptions_CType extends $pb.ProtobufEnum {
-  static const FieldOptions_CType STRING =
-      const FieldOptions_CType._(0, 'STRING');
-  static const FieldOptions_CType CORD = const FieldOptions_CType._(1, 'CORD');
+  static const FieldOptions_CType STRING = FieldOptions_CType._(0, 'STRING');
+  static const FieldOptions_CType CORD = FieldOptions_CType._(1, 'CORD');
   static const FieldOptions_CType STRING_PIECE =
-      const FieldOptions_CType._(2, 'STRING_PIECE');
+      FieldOptions_CType._(2, 'STRING_PIECE');
 
-  static const $core.List<FieldOptions_CType> values =
-      const <FieldOptions_CType>[
+  static const $core.List<FieldOptions_CType> values = <FieldOptions_CType>[
     STRING,
     CORD,
     STRING_PIECE,
@@ -142,14 +140,13 @@ class FieldOptions_CType extends $pb.ProtobufEnum {
 
 class FieldOptions_JSType extends $pb.ProtobufEnum {
   static const FieldOptions_JSType JS_NORMAL =
-      const FieldOptions_JSType._(0, 'JS_NORMAL');
+      FieldOptions_JSType._(0, 'JS_NORMAL');
   static const FieldOptions_JSType JS_STRING =
-      const FieldOptions_JSType._(1, 'JS_STRING');
+      FieldOptions_JSType._(1, 'JS_STRING');
   static const FieldOptions_JSType JS_NUMBER =
-      const FieldOptions_JSType._(2, 'JS_NUMBER');
+      FieldOptions_JSType._(2, 'JS_NUMBER');
 
-  static const $core.List<FieldOptions_JSType> values =
-      const <FieldOptions_JSType>[
+  static const $core.List<FieldOptions_JSType> values = <FieldOptions_JSType>[
     JS_NORMAL,
     JS_STRING,
     JS_NUMBER,
@@ -164,14 +161,14 @@ class FieldOptions_JSType extends $pb.ProtobufEnum {
 
 class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
   static const MethodOptions_IdempotencyLevel IDEMPOTENCY_UNKNOWN =
-      const MethodOptions_IdempotencyLevel._(0, 'IDEMPOTENCY_UNKNOWN');
+      MethodOptions_IdempotencyLevel._(0, 'IDEMPOTENCY_UNKNOWN');
   static const MethodOptions_IdempotencyLevel NO_SIDE_EFFECTS =
-      const MethodOptions_IdempotencyLevel._(1, 'NO_SIDE_EFFECTS');
+      MethodOptions_IdempotencyLevel._(1, 'NO_SIDE_EFFECTS');
   static const MethodOptions_IdempotencyLevel IDEMPOTENT =
-      const MethodOptions_IdempotencyLevel._(2, 'IDEMPOTENT');
+      MethodOptions_IdempotencyLevel._(2, 'IDEMPOTENT');
 
   static const $core.List<MethodOptions_IdempotencyLevel> values =
-      const <MethodOptions_IdempotencyLevel>[
+      <MethodOptions_IdempotencyLevel>[
     IDEMPOTENCY_UNKNOWN,
     NO_SIDE_EFFECTS,
     IDEMPOTENT,

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -12,7 +12,7 @@ import 'package:protobuf/protobuf.dart' as $pb;
 import 'descriptor.pb.dart' as $0;
 
 class Version extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('Version',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Version',
       package: const $pb.PackageName('google.protobuf.compiler'))
     ..a<$core.int>(1, 'major', $pb.PbFieldType.O3)
     ..a<$core.int>(2, 'minor', $pb.PbFieldType.O3)
@@ -27,13 +27,13 @@ class Version extends $pb.GeneratedMessage {
   Version.fromJson($core.String i,
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
-  Version clone() => new Version()..mergeFromMessage(this);
+  Version clone() => Version()..mergeFromMessage(this);
   Version copyWith(void Function(Version) updates) =>
       super.copyWith((message) => updates(message as Version));
   $pb.BuilderInfo get info_ => _i;
-  static Version create() => new Version();
+  static Version create() => Version();
   Version createEmptyInstance() => create();
-  static $pb.PbList<Version> createRepeated() => new $pb.PbList<Version>();
+  static $pb.PbList<Version> createRepeated() => $pb.PbList<Version>();
   static Version getDefault() => _defaultInstance ??= create()..freeze();
   static Version _defaultInstance;
 
@@ -71,7 +71,7 @@ class Version extends $pb.GeneratedMessage {
 }
 
 class CodeGeneratorRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('CodeGeneratorRequest',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CodeGeneratorRequest',
       package: const $pb.PackageName('google.protobuf.compiler'))
     ..pPS(1, 'fileToGenerate')
     ..aOS(2, 'parameter')
@@ -88,14 +88,14 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   CodeGeneratorRequest clone() =>
-      new CodeGeneratorRequest()..mergeFromMessage(this);
+      CodeGeneratorRequest()..mergeFromMessage(this);
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorRequest));
   $pb.BuilderInfo get info_ => _i;
-  static CodeGeneratorRequest create() => new CodeGeneratorRequest();
+  static CodeGeneratorRequest create() => CodeGeneratorRequest();
   CodeGeneratorRequest createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorRequest> createRepeated() =>
-      new $pb.PbList<CodeGeneratorRequest>();
+      $pb.PbList<CodeGeneratorRequest>();
   static CodeGeneratorRequest getDefault() =>
       _defaultInstance ??= create()..freeze();
   static CodeGeneratorRequest _defaultInstance;
@@ -122,7 +122,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
 }
 
 class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo(
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       'CodeGeneratorResponse.File',
       package: const $pb.PackageName('google.protobuf.compiler'))
     ..aOS(1, 'name')
@@ -138,17 +138,16 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   CodeGeneratorResponse_File clone() =>
-      new CodeGeneratorResponse_File()..mergeFromMessage(this);
+      CodeGeneratorResponse_File()..mergeFromMessage(this);
   CodeGeneratorResponse_File copyWith(
           void Function(CodeGeneratorResponse_File) updates) =>
       super.copyWith(
           (message) => updates(message as CodeGeneratorResponse_File));
   $pb.BuilderInfo get info_ => _i;
-  static CodeGeneratorResponse_File create() =>
-      new CodeGeneratorResponse_File();
+  static CodeGeneratorResponse_File create() => CodeGeneratorResponse_File();
   CodeGeneratorResponse_File createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorResponse_File> createRepeated() =>
-      new $pb.PbList<CodeGeneratorResponse_File>();
+      $pb.PbList<CodeGeneratorResponse_File>();
   static CodeGeneratorResponse_File getDefault() =>
       _defaultInstance ??= create()..freeze();
   static CodeGeneratorResponse_File _defaultInstance;
@@ -179,7 +178,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
 }
 
 class CodeGeneratorResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('CodeGeneratorResponse',
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CodeGeneratorResponse',
       package: const $pb.PackageName('google.protobuf.compiler'))
     ..aOS(1, 'error')
     ..pc<CodeGeneratorResponse_File>(
@@ -194,15 +193,15 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
       [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY])
       : super.fromJson(i, r);
   CodeGeneratorResponse clone() =>
-      new CodeGeneratorResponse()..mergeFromMessage(this);
+      CodeGeneratorResponse()..mergeFromMessage(this);
   CodeGeneratorResponse copyWith(
           void Function(CodeGeneratorResponse) updates) =>
       super.copyWith((message) => updates(message as CodeGeneratorResponse));
   $pb.BuilderInfo get info_ => _i;
-  static CodeGeneratorResponse create() => new CodeGeneratorResponse();
+  static CodeGeneratorResponse create() => CodeGeneratorResponse();
   CodeGeneratorResponse createEmptyInstance() => create();
   static $pb.PbList<CodeGeneratorResponse> createRepeated() =>
-      new $pb.PbList<CodeGeneratorResponse>();
+      $pb.PbList<CodeGeneratorResponse>();
   static CodeGeneratorResponse getDefault() =>
       _defaultInstance ??= create()..freeze();
   static CodeGeneratorResponse _defaultInstance;

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -25,7 +25,7 @@ class _Any extends WellKnownType {
   /// Throws a [InvalidProtocolBufferException] if [typeUrl] does not correspond
   /// to the type of [instance].
   ///
-  /// A typical usage would be `any.unpackInto(new Message())`.
+  /// A typical usage would be `any.unpackInto(Message())`.
   ///
   /// Returns [instance].
   T unpackInto<T extends $_protobufImportPrefix.GeneratedMessage>(T instance,
@@ -49,7 +49,7 @@ class _Any extends WellKnownType {
   /// the fully qualified name of the type of [message].
   static Any pack($_protobufImportPrefix.GeneratedMessage message,
       {$_coreImportPrefix.String typeUrlPrefix = 'type.googleapis.com'}) {
-    return new Any()
+    return Any()
       ..value = message.writeToBuffer()
       ..typeUrl = '\${typeUrlPrefix}/\${message.info_.qualifiedMessageName}';
   }''');
@@ -69,7 +69,7 @@ class _Timestamp extends WellKnownType {
   ///
   /// The result is in UTC time zone and has microsecond precision, as
   /// [DateTime] does not support nanosecond precision.
-  $_coreImportPrefix.DateTime toDateTime() => new $_coreImportPrefix.DateTime.fromMicrosecondsSinceEpoch(
+  $_coreImportPrefix.DateTime toDateTime() => $_coreImportPrefix.DateTime.fromMicrosecondsSinceEpoch(
       seconds.toInt() * $_coreImportPrefix.Duration.microsecondsPerSecond + nanos ~/ 1000,
       isUtc: true);
 
@@ -78,8 +78,8 @@ class _Timestamp extends WellKnownType {
   /// Time zone information will not be preserved.
   static Timestamp fromDateTime($_coreImportPrefix.DateTime dateTime) {
     $_coreImportPrefix.int micros = dateTime.microsecondsSinceEpoch;
-    return new Timestamp()
-      ..seconds = new Int64(micros ~/ $_coreImportPrefix.Duration.microsecondsPerSecond)
+    return Timestamp()
+      ..seconds = Int64(micros ~/ $_coreImportPrefix.Duration.microsecondsPerSecond)
       ..nanos = (micros % $_coreImportPrefix.Duration.microsecondsPerSecond).toInt() * 1000;
   }''');
   }

--- a/protoc_plugin/test/any_test.dart
+++ b/protoc_plugin/test/any_test.dart
@@ -33,10 +33,9 @@ void main() {
     expect(any.typeUrl, 'type.googleapis.com/google.protobuf.Any');
     expect(any.canUnpackInto(Any.getDefault()), true);
     expect(any.canUnpackInto(SearchRequest.getDefault()), false);
-    expect(any.unpackInto(Any()).canUnpackInto(SearchRequest.getDefault()),
-        true);
-    expect(any.unpackInto(Any()).unpackInto(SearchRequest()).query,
-        'hest');
+    expect(
+        any.unpackInto(Any()).canUnpackInto(SearchRequest.getDefault()), true);
+    expect(any.unpackInto(Any()).unpackInto(SearchRequest()).query, 'hest');
   });
 
   test('toplevel', () {
@@ -65,17 +64,13 @@ void main() {
       ..anyValue = any
       ..repeatedAnyValue.addAll(<Any>[any1, any2]);
     TestAny testAnyFromBuffer = TestAny.fromBuffer(testAny.writeToBuffer());
-    expect(testAnyFromBuffer.anyValue.unpackInto(SearchRequest()).query,
-        'hest');
     expect(
-        testAnyFromBuffer.repeatedAnyValue[0]
-            .unpackInto(SearchRequest())
-            .query,
+        testAnyFromBuffer.anyValue.unpackInto(SearchRequest()).query, 'hest');
+    expect(
+        testAnyFromBuffer.repeatedAnyValue[0].unpackInto(SearchRequest()).query,
         'hest1');
     expect(
-        testAnyFromBuffer.repeatedAnyValue[1]
-            .unpackInto(SearchRequest())
-            .query,
+        testAnyFromBuffer.repeatedAnyValue[1].unpackInto(SearchRequest()).query,
         'hest2');
   });
 }

--- a/protoc_plugin/test/any_test.dart
+++ b/protoc_plugin/test/any_test.dart
@@ -12,69 +12,69 @@ import '../out/protos/using_any.pb.dart';
 
 void main() {
   test('pack -> unpack', () {
-    Any any = Any.pack(new SearchRequest()..query = 'hest');
+    Any any = Any.pack(SearchRequest()..query = 'hest');
     expect(any.typeUrl, 'type.googleapis.com/SearchRequest');
-    Any any1 = Any.pack(new SearchRequest()..query = 'hest1',
+    Any any1 = Any.pack(SearchRequest()..query = 'hest1',
         typeUrlPrefix: 'example.com');
     expect(any1.typeUrl, 'example.com/SearchRequest');
     expect(any1.canUnpackInto(SearchRequest.getDefault()), true);
     expect(any1.canUnpackInto(SearchResponse.getDefault()), false);
-    SearchRequest searchRequest = any.unpackInto(new SearchRequest());
+    SearchRequest searchRequest = any.unpackInto(SearchRequest());
     expect(searchRequest.query, 'hest');
-    SearchRequest searchRequest1 = any1.unpackInto(new SearchRequest());
+    SearchRequest searchRequest1 = any1.unpackInto(SearchRequest());
     expect(searchRequest1.query, 'hest1');
     expect(() {
-      any.unpackInto(new SearchResponse());
+      any.unpackInto(SearchResponse());
     }, throwsA(const TypeMatcher<InvalidProtocolBufferException>()));
   });
 
   test('any inside any', () {
-    Any any = Any.pack(Any.pack(new SearchRequest()..query = 'hest'));
+    Any any = Any.pack(Any.pack(SearchRequest()..query = 'hest'));
     expect(any.typeUrl, 'type.googleapis.com/google.protobuf.Any');
     expect(any.canUnpackInto(Any.getDefault()), true);
     expect(any.canUnpackInto(SearchRequest.getDefault()), false);
-    expect(any.unpackInto(new Any()).canUnpackInto(SearchRequest.getDefault()),
+    expect(any.unpackInto(Any()).canUnpackInto(SearchRequest.getDefault()),
         true);
-    expect(any.unpackInto(new Any()).unpackInto(new SearchRequest()).query,
+    expect(any.unpackInto(Any()).unpackInto(SearchRequest()).query,
         'hest');
   });
 
   test('toplevel', () {
-    Any any = Any.pack(new toplevel.T()
+    Any any = Any.pack(toplevel.T()
       ..a = 127
       ..b = 'hest');
     expect(any.typeUrl, 'type.googleapis.com/T');
-    var t2 = any.unpackInto(new toplevel.T());
+    var t2 = any.unpackInto(toplevel.T());
     expect(t2.a, 127);
     expect(t2.b, 'hest');
   });
 
   test('nested message', () {
-    Any any = Any.pack(new Container_Nested()..int32Value = 127);
+    Any any = Any.pack(Container_Nested()..int32Value = 127);
     expect(
         any.typeUrl, 'type.googleapis.com/protobuf_unittest.Container.Nested');
-    var t2 = any.unpackInto(new Container_Nested());
+    var t2 = any.unpackInto(Container_Nested());
     expect(t2.int32Value, 127);
   });
 
   test('using any', () {
-    Any any = Any.pack(new SearchRequest()..query = 'hest');
-    Any any1 = Any.pack(new SearchRequest()..query = 'hest1');
-    Any any2 = Any.pack(new SearchRequest()..query = 'hest2');
+    Any any = Any.pack(SearchRequest()..query = 'hest');
+    Any any1 = Any.pack(SearchRequest()..query = 'hest1');
+    Any any2 = Any.pack(SearchRequest()..query = 'hest2');
     TestAny testAny = TestAny()
       ..anyValue = any
       ..repeatedAnyValue.addAll(<Any>[any1, any2]);
     TestAny testAnyFromBuffer = TestAny.fromBuffer(testAny.writeToBuffer());
-    expect(testAnyFromBuffer.anyValue.unpackInto(new SearchRequest()).query,
+    expect(testAnyFromBuffer.anyValue.unpackInto(SearchRequest()).query,
         'hest');
     expect(
         testAnyFromBuffer.repeatedAnyValue[0]
-            .unpackInto(new SearchRequest())
+            .unpackInto(SearchRequest())
             .query,
         'hest1');
     expect(
         testAnyFromBuffer.repeatedAnyValue[1]
-            .unpackInto(new SearchRequest())
+            .unpackInto(SearchRequest())
             .query,
         'hest2');
   });

--- a/protoc_plugin/test/bazel_test.dart
+++ b/protoc_plugin/test/bazel_test.dart
@@ -15,7 +15,7 @@ void main() {
 
     setUp(() {
       packages = {};
-      optionParser = new BazelOptionParser(packages);
+      optionParser = BazelOptionParser(packages);
       errors = [];
     });
 
@@ -116,12 +116,12 @@ void main() {
 
     setUp(() {
       packages = {
-        'foo/bar': new BazelPackage('a.b.c', 'foo/bar', 'baz/flob'),
-        'foo/bar/baz': new BazelPackage('d.e.f', 'foo/bar/baz', 'baz/flob/foo'),
+        'foo/bar': BazelPackage('a.b.c', 'foo/bar', 'baz/flob'),
+        'foo/bar/baz': BazelPackage('d.e.f', 'foo/bar/baz', 'baz/flob/foo'),
         'wibble/wobble':
-            new BazelPackage('wibble.wobble', 'wibble/wobble', 'womble/wumble'),
+            BazelPackage('wibble.wobble', 'wibble/wobble', 'womble/wumble'),
       };
-      config = new BazelOutputConfiguration(packages);
+      config = BazelOutputConfiguration(packages);
     });
 
     group('outputPathForUri', () {

--- a/protoc_plugin/test/client_generator_test.dart
+++ b/protoc_plugin/test/client_generator_test.dart
@@ -14,21 +14,21 @@ import 'service_util.dart';
 
 void main() {
   test('testClientGenerator', () {
-    var options = new GenerationOptions();
+    var options = GenerationOptions();
     var fd = buildFileDescriptor(
         "testpkg", "testpkg.proto", ["SomeRequest", "SomeReply"]);
     fd.service.add(buildServiceDescriptor());
-    var fg = new FileGenerator(fd, options);
+    var fg = FileGenerator(fd, options);
 
     var fd2 = buildFileDescriptor(
         "foo.bar", "foobar.proto", ["EmptyMessage", "AnotherReply"]);
-    var fg2 = new FileGenerator(fd2, options);
+    var fg2 = FileGenerator(fd2, options);
 
-    link(new GenerationOptions(), [fg, fg2]);
+    link(GenerationOptions(), [fg, fg2]);
 
     ClientApiGenerator cag = fg.clientApiGenerators[0];
 
-    IndentingWriter writer = new IndentingWriter();
+    IndentingWriter writer = IndentingWriter();
     cag.generate(writer);
     expectMatchesGoldenFile(writer.toString(), 'test/goldens/client');
   });

--- a/protoc_plugin/test/const_generator_test.dart
+++ b/protoc_plugin/test/const_generator_test.dart
@@ -10,7 +10,7 @@ import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:test/test.dart';
 
 String toConst(val) {
-  var out = new IndentingWriter();
+  var out = IndentingWriter();
   writeJsonConst(out, val);
   return out.toString();
 }

--- a/protoc_plugin/test/enum_generator_test.dart
+++ b/protoc_plugin/test/enum_generator_test.dart
@@ -14,26 +14,26 @@ import 'golden_file.dart';
 
 void main() {
   test('testEnumGenerator', () {
-    EnumDescriptorProto ed = new EnumDescriptorProto()
+    EnumDescriptorProto ed = EnumDescriptorProto()
       ..name = 'PhoneType'
       ..value.addAll([
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'MOBILE'
           ..number = 0,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'HOME'
           ..number = 1,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'WORK'
           ..number = 2,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'BUSINESS'
           ..number = 2
       ]);
-    IndentingWriter writer = new IndentingWriter(filename: 'sample.proto');
+    IndentingWriter writer = IndentingWriter(filename: 'sample.proto');
     FileGenerator fg =
-        new FileGenerator(new FileDescriptorProto(), new GenerationOptions());
-    EnumGenerator eg = new EnumGenerator.topLevel(ed, fg, new Set<String>(), 0);
+        FileGenerator(FileDescriptorProto(), GenerationOptions());
+    EnumGenerator eg = EnumGenerator.topLevel(ed, fg, Set<String>(), 0);
     eg.generate(writer);
     expectMatchesGoldenFile(writer.toString(), 'test/goldens/enum');
     expectMatchesGoldenFile(

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -24,20 +24,20 @@ throwsArgError(String expectedMessage) => throwsA(predicate((x) {
 
 void main() {
   test('can set all extension types', () {
-    TestAllExtensions message = new TestAllExtensions();
+    TestAllExtensions message = TestAllExtensions();
     setAllExtensions(message);
     assertAllExtensionsSet(message);
   });
 
   test('can modify all repeated extension types', () {
-    TestAllExtensions message = new TestAllExtensions();
+    TestAllExtensions message = TestAllExtensions();
     setAllExtensions(message);
     modifyRepeatedExtensions(message);
     assertRepeatedExtensionsModified(message);
   });
 
   test('unset extensions return default values', () {
-    assertExtensionsClear(new TestAllExtensions());
+    assertExtensionsClear(TestAllExtensions());
   });
 
   // void testExtensionReflectionGetters() {} // UNSUPPORTED -- reflection
@@ -49,21 +49,21 @@ void main() {
 
   test('can clear an optional extension', () {
     // clearExtension() is not actually used in test_util, so try it manually.
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
     message.setExtension(Unittest.optionalInt32Extension, 1);
     message.clearExtension(Unittest.optionalInt32Extension);
     expect(message.hasExtension(Unittest.optionalInt32Extension), isFalse);
   });
 
   test('can clear a repeated extension', () {
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
     message.addExtension(Unittest.repeatedInt32Extension, 1);
     message.clearExtension(Unittest.repeatedInt32Extension);
     expect(message.getExtension(Unittest.repeatedInt32Extension).length, 0);
   });
 
   test('can clone an extension field', () {
-    TestAllExtensions original = new TestAllExtensions();
+    TestAllExtensions original = TestAllExtensions();
     original.setExtension(Unittest.optionalInt32Extension, 1);
     TestAllExtensions clone = original.clone();
     expect(clone.hasExtension(Unittest.optionalInt32Extension), isTrue);
@@ -85,7 +85,7 @@ void main() {
     TestAllExtensions mergeDest = TestAllExtensions()
       ..setExtension(Unittest.optionalNestedMessageExtension, nestedMessage2);
 
-    TestAllExtensions result = new TestAllExtensions()
+    TestAllExtensions result = TestAllExtensions()
       ..mergeFromMessage(mergeSource)
       ..mergeFromMessage(mergeDest);
 
@@ -94,7 +94,7 @@ void main() {
   });
 
   test("throws if field number isn't allowed for extension", () {
-    var message = new TestAllTypes(); // does not allow extensions
+    var message = TestAllTypes(); // does not allow extensions
     expect(() {
       message.setExtension(Unittest.optionalInt32Extension, 0);
     },
@@ -109,7 +109,7 @@ void main() {
   });
 
   test("throws if an int32 extension is set to a bad value", () {
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
     expect(() {
       message.setExtension(Unittest.optionalInt32Extension, "hello");
     },
@@ -119,7 +119,7 @@ void main() {
   });
 
   test('throws if an int64 extension is set to a bad value', () {
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
     expect(() {
       message.setExtension(Unittest.optionalInt64Extension, 123);
     },
@@ -129,7 +129,7 @@ void main() {
   });
 
   test('throws if a message extension is set to a bad value', () {
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
 
     // For a non-repeated message, we only check for a GeneratedMessage.
     expect(() {
@@ -142,12 +142,12 @@ void main() {
     // For a repeated message, the type check is exact.
     expect(() {
       message.addExtension(
-          Unittest.repeatedNestedMessageExtension, new TestAllTypes());
+          Unittest.repeatedNestedMessageExtension, TestAllTypes());
     }, throwsATypeError);
   });
 
   test('throws if an enum extension is set to a bad value', () {
-    var message = new TestAllExtensions();
+    var message = TestAllExtensions();
 
     // For a non-repeated enum, we only check for a ProtobufEnum.
     expect(() {
@@ -165,7 +165,7 @@ void main() {
 
   test('can extend a message with a message field with a different type', () {
     expect(Non_nested_extension.nonNestedExtension.makeDefault(),
-        new TypeMatcher<MyNonNestedExtension>());
+        TypeMatcher<MyNonNestedExtension>());
     expect(Non_nested_extension.nonNestedExtension.name, 'nonNestedExtension');
   });
 
@@ -178,7 +178,7 @@ void main() {
   });
 
   test('can extend message with enum', () {
-    var msg = new Extendable();
+    var msg = Extendable();
     msg.setExtension(Enum_extension.animal, Animal.CAT);
   });
 
@@ -191,7 +191,7 @@ void main() {
   });
 
   test('to toDebugString', () {
-    TestAllExtensions value = new TestAllExtensions()
+    TestAllExtensions value = TestAllExtensions()
       ..setExtension(Unittest.optionalInt32Extension, 1)
       ..addExtension(Unittest.repeatedStringExtension, 'hello')
       ..addExtension(Unittest.repeatedStringExtension, 'world')

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -74,8 +74,8 @@ void main() {
   test('FileGenerator outputs a .pb.dart file for a proto with one message',
       () {
     FileDescriptorProto fd = buildFileDescriptor();
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
@@ -98,8 +98,8 @@ void main() {
   test('FileGenerator outputs a pbjson.dart file for a proto with one message',
       () {
     FileDescriptorProto fd = buildFileDescriptor();
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
@@ -109,8 +109,8 @@ void main() {
   test('FileGenerator generates files for a top-level enum', () {
     FileDescriptorProto fd =
         buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
@@ -138,8 +138,8 @@ void main() {
   test('FileGenerator generates a .pbjson.dart file for a top-level enum', () {
     FileDescriptorProto fd =
         buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
@@ -150,8 +150,8 @@ void main() {
   test('FileGenerator outputs library for a .proto in a package', () {
     FileDescriptorProto fd = buildFileDescriptor();
     fd.package = "pb_library";
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
@@ -174,8 +174,8 @@ void main() {
             ..type = FieldDescriptorProto_Type.TYPE_INT64
         ]));
 
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
@@ -201,8 +201,8 @@ void main() {
       ..messageType.add(empty)
       ..service.add(sd);
 
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -15,33 +15,33 @@ import 'golden_file.dart';
 
 FileDescriptorProto buildFileDescriptor(
     {phoneNumber = true, topLevelEnum = false}) {
-  FileDescriptorProto fd = new FileDescriptorProto()..name = 'test';
+  FileDescriptorProto fd = FileDescriptorProto()..name = 'test';
 
   if (topLevelEnum) {
-    fd.enumType.add(new EnumDescriptorProto()
+    fd.enumType.add(EnumDescriptorProto()
       ..name = 'PhoneType'
       ..value.addAll([
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'MOBILE'
           ..number = 0,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'HOME'
           ..number = 1,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'WORK'
           ..number = 2,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'BUSINESS'
           ..number = 2
       ]));
   }
 
   if (phoneNumber) {
-    fd.messageType.add(new DescriptorProto()
+    fd.messageType.add(DescriptorProto()
       ..name = 'PhoneNumber'
       ..field.addAll([
         // required string number = 1;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'number'
           ..number = 1
           ..label = FieldDescriptorProto_Label.LABEL_REQUIRED
@@ -49,7 +49,7 @@ FileDescriptorProto buildFileDescriptor(
         // optional int32 type = 2;
         // OR
         // optional PhoneType type = 2;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'type'
           ..number = 2
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
@@ -58,7 +58,7 @@ FileDescriptorProto buildFileDescriptor(
               : FieldDescriptorProto_Type.TYPE_INT32
           ..typeName = topLevelEnum ? '.PhoneType' : '',
         // optional string name = 3 [default = "$"];
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'name'
           ..number = 3
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
@@ -75,8 +75,8 @@ void main() {
       () {
     FileDescriptorProto fd = buildFileDescriptor();
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
-    FileGenerator fg = new FileGenerator(fd, options);
+        CodeGeneratorRequest(), CodeGeneratorResponse());
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/oneMessage.pb');
@@ -87,9 +87,9 @@ void main() {
       () {
     FileDescriptorProto fd = buildFileDescriptor();
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest()..parameter = 'generate_kythe_info',
-        new CodeGeneratorResponse());
-    FileGenerator fg = new FileGenerator(fd, options);
+        CodeGeneratorRequest()..parameter = 'generate_kythe_info',
+        CodeGeneratorResponse());
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(fg.generateMainFile().sourceLocationInfo.toString(),
         'test/goldens/oneMessage.pb.meta');
@@ -99,8 +99,8 @@ void main() {
       () {
     FileDescriptorProto fd = buildFileDescriptor();
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
-    FileGenerator fg = new FileGenerator(fd, options);
+        CodeGeneratorRequest(), CodeGeneratorResponse());
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateJsonFile(), 'test/goldens/oneMessage.pbjson');
@@ -110,9 +110,9 @@ void main() {
     FileDescriptorProto fd =
         buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/topLevelEnum.pb');
@@ -124,9 +124,9 @@ void main() {
     FileDescriptorProto fd =
         buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest()..parameter = 'generate_kythe_info',
-        new CodeGeneratorResponse());
-    FileGenerator fg = new FileGenerator(fd, options);
+        CodeGeneratorRequest()..parameter = 'generate_kythe_info',
+        CodeGeneratorResponse());
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
     expectMatchesGoldenFile(fg.generateMainFile().sourceLocationInfo.toString(),
@@ -139,9 +139,9 @@ void main() {
     FileDescriptorProto fd =
         buildFileDescriptor(phoneNumber: false, topLevelEnum: true);
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
     expectMatchesGoldenFile(
         fg.generateJsonFile(), 'test/goldens/topLevelEnum.pbjson');
@@ -151,63 +151,63 @@ void main() {
     FileDescriptorProto fd = buildFileDescriptor();
     fd.package = "pb_library";
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         writer.toString(), 'test/goldens/header_in_package.pb');
   });
 
   test('FileGenerator outputs a fixnum import when needed', () {
-    FileDescriptorProto fd = new FileDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto()
       ..name = 'test'
-      ..messageType.add(new DescriptorProto()
+      ..messageType.add(DescriptorProto()
         ..name = 'Count'
         ..field.addAll([
-          new FieldDescriptorProto()
+          FieldDescriptorProto()
             ..name = 'count'
             ..number = 1
             ..type = FieldDescriptorProto_Type.TYPE_INT64
         ]));
 
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         writer.toString(), 'test/goldens/header_with_fixnum.pb');
   });
 
   test('FileGenerator outputs files for a service', () {
-    DescriptorProto empty = new DescriptorProto()..name = "Empty";
+    DescriptorProto empty = DescriptorProto()..name = "Empty";
 
-    ServiceDescriptorProto sd = new ServiceDescriptorProto()
+    ServiceDescriptorProto sd = ServiceDescriptorProto()
       ..name = 'Test'
-      ..method.add(new MethodDescriptorProto()
+      ..method.add(MethodDescriptorProto()
         ..name = 'Ping'
         ..inputType = '.Empty'
         ..outputType = '.Empty');
 
-    FileDescriptorProto fd = new FileDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.add(empty)
       ..service.add(sd);
 
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/service.pb');
@@ -217,75 +217,75 @@ void main() {
 
   test('FileGenerator does not output legacy service stubs if gRPC is selected',
       () {
-    DescriptorProto empty = new DescriptorProto()..name = "Empty";
+    DescriptorProto empty = DescriptorProto()..name = "Empty";
 
-    ServiceDescriptorProto sd = new ServiceDescriptorProto()
+    ServiceDescriptorProto sd = ServiceDescriptorProto()
       ..name = 'Test'
-      ..method.add(new MethodDescriptorProto()
+      ..method.add(MethodDescriptorProto()
         ..name = 'Ping'
         ..inputType = '.Empty'
         ..outputType = '.Empty');
 
-    FileDescriptorProto fd = new FileDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.add(empty)
       ..service.add(sd);
 
-    var options = new GenerationOptions(useGrpc: true);
+    var options = GenerationOptions(useGrpc: true);
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/grpc_service.pb');
   });
 
   test('FileGenerator outputs gRPC stubs if gRPC is selected', () {
-    final input = new DescriptorProto()..name = 'Input';
-    final output = new DescriptorProto()..name = 'Output';
+    final input = DescriptorProto()..name = 'Input';
+    final output = DescriptorProto()..name = 'Output';
 
-    final unary = new MethodDescriptorProto()
+    final unary = MethodDescriptorProto()
       ..name = 'Unary'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = false
       ..serverStreaming = false;
-    final clientStreaming = new MethodDescriptorProto()
+    final clientStreaming = MethodDescriptorProto()
       ..name = 'ClientStreaming'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = true
       ..serverStreaming = false;
-    final serverStreaming = new MethodDescriptorProto()
+    final serverStreaming = MethodDescriptorProto()
       ..name = 'ServerStreaming'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = false
       ..serverStreaming = true;
-    final bidirectional = new MethodDescriptorProto()
+    final bidirectional = MethodDescriptorProto()
       ..name = 'Bidirectional'
       ..inputType = '.Input'
       ..outputType = '.Output'
       ..clientStreaming = true
       ..serverStreaming = true;
 
-    ServiceDescriptorProto sd = new ServiceDescriptorProto()
+    ServiceDescriptorProto sd = ServiceDescriptorProto()
       ..name = 'Test'
       ..method.addAll([unary, clientStreaming, serverStreaming, bidirectional]);
 
-    FileDescriptorProto fd = new FileDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto()
       ..name = 'test'
       ..messageType.addAll([input, output])
       ..service.add(sd);
 
-    var options = new GenerationOptions(useGrpc: true);
+    var options = GenerationOptions(useGrpc: true);
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options, [fg]);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     fg.writeMainHeader(writer);
     expectMatchesGoldenFile(
         fg.generateGrpcFile(), 'test/goldens/grpc_service.pbgrpc');
@@ -321,76 +321,76 @@ void main() {
     // }
 
     // Description of package1.proto.
-    DescriptorProto md1 = new DescriptorProto()
+    DescriptorProto md1 = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'm'
           ..number = 1
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = ".p1.M",
       ]);
-    FileDescriptorProto fd1 = new FileDescriptorProto()
+    FileDescriptorProto fd1 = FileDescriptorProto()
       ..package = 'p1'
       ..name = 'package1.proto'
       ..messageType.add(md1);
 
     // Description of package1.proto.
-    DescriptorProto md2 = new DescriptorProto()
+    DescriptorProto md2 = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'x'
           ..number = 1
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = ".p2.M",
       ]);
-    FileDescriptorProto fd2 = new FileDescriptorProto()
+    FileDescriptorProto fd2 = FileDescriptorProto()
       ..package = 'p2'
       ..name = 'package2.proto'
       ..messageType.add(md2);
 
     // Description of test.proto.
-    DescriptorProto md = new DescriptorProto()
+    DescriptorProto md = DescriptorProto()
       ..name = 'M'
       ..field.addAll([
         // optional M m = 1;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'm'
           ..number = 1
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = ".M",
         // optional p1.M m1 = 2;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'm1'
           ..number = 2
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = ".p1.M",
         // optional p2.M m2 = 3;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'm2'
           ..number = 3
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_MESSAGE
           ..typeName = ".p2.M",
       ]);
-    FileDescriptorProto fd = new FileDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto()
       ..name = 'test.proto'
       ..messageType.add(md);
     fd.dependency.addAll(['package1.proto', 'package2.proto']);
-    var request = new CodeGeneratorRequest();
-    var response = new CodeGeneratorResponse();
+    var request = CodeGeneratorRequest();
+    var response = CodeGeneratorResponse();
     var options = parseGenerationOptions(request, response);
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     link(options,
-        [fg, new FileGenerator(fd1, options), new FileGenerator(fd2, options)]);
+        [fg, FileGenerator(fd1, options), FileGenerator(fd2, options)]);
     expectMatchesGoldenFile(
         fg.generateMainFile().toString(), 'test/goldens/imports.pb');
     expectMatchesGoldenFile(

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -151,8 +151,7 @@ void main() {
     TestAllTypes message = TestAllTypes();
 
     expect(() {
-      message.repeatedForeignMessage
-          .addAll([ForeignMessage()..c = 12, null]);
+      message.repeatedForeignMessage.addAll([ForeignMessage()..c = 12, null]);
     }, throwsArgumentError);
 
     expect(() {
@@ -222,8 +221,7 @@ void main() {
   // void testReflectionDefaults() {} // UNSUPPORTED -- until reflection
 
   test('testEnumInterface', () {
-    expect(
-        TestAllTypes().defaultNestedEnum, TypeMatcher<ProtobufEnum>());
+    expect(TestAllTypes().defaultNestedEnum, TypeMatcher<ProtobufEnum>());
   });
 
   test('testEnumMap', () {
@@ -278,8 +276,7 @@ void main() {
     expect(TestOptionalOptimizedForSize().isInitialized(), isTrue);
 
     expect(
-        (TestOptionalOptimizedForSize()
-              ..o = TestRequiredOptimizedForSize())
+        (TestOptionalOptimizedForSize()..o = TestRequiredOptimizedForSize())
             .isInitialized(),
         isFalse);
 
@@ -313,8 +310,7 @@ void main() {
     TestAllTypes message = getAllSet();
     message.optionalBytes = blob;
 
-    TestAllTypes message2 =
-        TestAllTypes.fromBuffer(message.writeToBuffer());
+    TestAllTypes message2 = TestAllTypes.fromBuffer(message.writeToBuffer());
     expect(message2.optionalBytes, message.optionalBytes);
   });
 

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -24,12 +24,12 @@ import 'test_util.dart';
 
 void main() {
   final throwsInvalidProtocolBufferException =
-      throwsA(new TypeMatcher<InvalidProtocolBufferException>());
+      throwsA(TypeMatcher<InvalidProtocolBufferException>());
   test('testProtosShareRepeatedArraysIfDidntChange', () {
-    TestAllTypes value1 = new TestAllTypes()
+    TestAllTypes value1 = TestAllTypes()
       ..repeatedInt32.add(100)
       ..repeatedImportEnum.add(ImportEnum.IMPORT_BAR)
-      ..repeatedForeignMessage.add(new ForeignMessage());
+      ..repeatedForeignMessage.add(ForeignMessage());
 
     TestAllTypes value2 = value1.clone();
 
@@ -39,7 +39,7 @@ void main() {
   });
 
   test('testSettersRejectNull', () {
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
     expect(() {
       message.optionalString = null;
     }, throwsArgumentError);
@@ -73,7 +73,7 @@ void main() {
   });
 
   test('testDefaultMessageIsReadOnly', () {
-    var message = new TestAllTypes();
+    var message = TestAllTypes();
     expect(message.optionalNestedMessage,
         same(TestAllTypes_NestedMessage.getDefault()));
     expect(() {
@@ -108,7 +108,7 @@ void main() {
   });
 
   test('testRepeatedSettersRejectNull', () {
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
 
     message.repeatedString.addAll(['one', 'two']);
     expect(() {
@@ -121,8 +121,8 @@ void main() {
     }, throwsArgumentError);
 
     message.repeatedNestedMessage.addAll([
-      new TestAllTypes_NestedMessage()..bb = 318,
-      new TestAllTypes_NestedMessage()..bb = 456
+      TestAllTypes_NestedMessage()..bb = 318,
+      TestAllTypes_NestedMessage()..bb = 456
     ]);
     expect(() {
       message.repeatedNestedMessage[1] = null;
@@ -136,10 +136,10 @@ void main() {
   });
 
   test('testRepeatedAppend', () {
-    TestAllTypes message = new TestAllTypes()
+    TestAllTypes message = TestAllTypes()
       ..repeatedInt32.addAll([1, 2, 3, 4])
       ..repeatedForeignEnum.addAll([ForeignEnum.FOREIGN_BAZ])
-      ..repeatedForeignMessage.addAll([new ForeignMessage()..c = 12]);
+      ..repeatedForeignMessage.addAll([ForeignMessage()..c = 12]);
 
     expect(message.repeatedInt32, [1, 2, 3, 4]);
     expect(message.repeatedForeignEnum, [ForeignEnum.FOREIGN_BAZ]);
@@ -148,11 +148,11 @@ void main() {
   });
 
   test('testRepeatedAppendRejectsNull', () {
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
 
     expect(() {
       message.repeatedForeignMessage
-          .addAll([new ForeignMessage()..c = 12, null]);
+          .addAll([ForeignMessage()..c = 12, null]);
     }, throwsArgumentError);
 
     expect(() {
@@ -169,29 +169,29 @@ void main() {
   });
 
   test('testSettingForeignMessage', () {
-    TestAllTypes message = new TestAllTypes()
-      ..optionalForeignMessage = (new ForeignMessage()..c = 123);
+    TestAllTypes message = TestAllTypes()
+      ..optionalForeignMessage = (ForeignMessage()..c = 123);
 
-    TestAllTypes expectedMessage = new TestAllTypes()
-      ..optionalForeignMessage = (new ForeignMessage()..c = 123);
+    TestAllTypes expectedMessage = TestAllTypes()
+      ..optionalForeignMessage = (ForeignMessage()..c = 123);
 
     expect(message, expectedMessage);
   });
 
   test('testSettingRepeatedForeignMessage', () {
-    TestAllTypes message = new TestAllTypes()
-      ..repeatedForeignMessage.add(new ForeignMessage()..c = 456);
+    TestAllTypes message = TestAllTypes()
+      ..repeatedForeignMessage.add(ForeignMessage()..c = 456);
 
-    TestAllTypes expectedMessage = new TestAllTypes()
-      ..repeatedForeignMessage.add(new ForeignMessage()..c = 456);
+    TestAllTypes expectedMessage = TestAllTypes()
+      ..repeatedForeignMessage.add(ForeignMessage()..c = 456);
 
     expect(message, expectedMessage);
   });
 
   test('testDefaults', () {
-    assertClear(new TestAllTypes());
+    assertClear(TestAllTypes());
 
-    TestExtremeDefaultValues message = new TestExtremeDefaultValues();
+    TestExtremeDefaultValues message = TestExtremeDefaultValues();
 
     expect(message.utf8String, '\u1234');
     expect(message.infDouble, same(double.infinity));
@@ -206,7 +206,7 @@ void main() {
   });
 
   test('testClear', () {
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
 
     assertClear(message);
     setAllFields(message);
@@ -223,7 +223,7 @@ void main() {
 
   test('testEnumInterface', () {
     expect(
-        new TestAllTypes().defaultNestedEnum, new TypeMatcher<ProtobufEnum>());
+        TestAllTypes().defaultNestedEnum, TypeMatcher<ProtobufEnum>());
   });
 
   test('testEnumMap', () {
@@ -235,26 +235,26 @@ void main() {
 
   test('testParsePackedToUnpacked', () {
     TestUnpackedTypes message =
-        new TestUnpackedTypes.fromBuffer(getPackedSet().writeToBuffer());
+        TestUnpackedTypes.fromBuffer(getPackedSet().writeToBuffer());
     assertUnpackedFieldsSet(message);
   });
 
   test('testParseUnpackedToPacked', () {
     TestPackedTypes message =
-        new TestPackedTypes.fromBuffer(getUnpackedSet().writeToBuffer());
+        TestPackedTypes.fromBuffer(getUnpackedSet().writeToBuffer());
     assertPackedFieldsSet(message);
   });
 
   test('testIgnoreJavaMultipleFilesOption', () {
     // UNSUPPORTED getFile
     // We mostly just want to check that things compile.
-    MessageWithNoOuter message = new MessageWithNoOuter()
-      ..nested = (new MessageWithNoOuter_NestedMessage()..i = 1)
-      ..foreign.add(new TestAllTypes()..optionalInt32 = 1)
+    MessageWithNoOuter message = MessageWithNoOuter()
+      ..nested = (MessageWithNoOuter_NestedMessage()..i = 1)
+      ..foreign.add(TestAllTypes()..optionalInt32 = 1)
       ..nestedEnum = MessageWithNoOuter_NestedEnum.BAZ
       ..foreignEnum = EnumWithNoOuter.BAR;
 
-    expect(new MessageWithNoOuter.fromBuffer(message.writeToBuffer()), message);
+    expect(MessageWithNoOuter.fromBuffer(message.writeToBuffer()), message);
 
     // Not currently supported in Dart protobuf.
     // expect(MessageWithNoOuter.getDescriptor().getFile(),
@@ -269,23 +269,23 @@ void main() {
     //        MultipleFilesTestProto.getDescriptor());
 
     expect(
-        new TestAllExtensions()
+        TestAllExtensions()
             .hasExtension(Multiple_files_test.extensionWithOuter),
         isFalse);
   });
 
   test('testOptionalFieldWithRequiredSubfieldsOptimizedForSize', () {
-    expect(new TestOptionalOptimizedForSize().isInitialized(), isTrue);
+    expect(TestOptionalOptimizedForSize().isInitialized(), isTrue);
 
     expect(
-        (new TestOptionalOptimizedForSize()
-              ..o = new TestRequiredOptimizedForSize())
+        (TestOptionalOptimizedForSize()
+              ..o = TestRequiredOptimizedForSize())
             .isInitialized(),
         isFalse);
 
     expect(
-        (new TestOptionalOptimizedForSize()
-              ..o = (new TestRequiredOptimizedForSize()..x = 5))
+        (TestOptionalOptimizedForSize()
+              ..o = (TestRequiredOptimizedForSize()..x = 5))
             .isInitialized(),
         isTrue);
   });
@@ -299,12 +299,12 @@ void main() {
   test('testReadWholeMessage', () {
     TestAllTypes message = getAllSet();
     List<int> rawBytes = message.writeToBuffer();
-    assertAllFieldsSet(new TestAllTypes.fromBuffer(rawBytes));
+    assertAllFieldsSet(TestAllTypes.fromBuffer(rawBytes));
   });
 
   test('testReadHugeBlob', () {
     // Allocate and initialize a 1MB blob.
-    List<int> blob = new List<int>(1 << 20);
+    List<int> blob = List<int>(1 << 20);
     for (int i = 0; i < blob.length; i++) {
       blob[i] = i % 256;
     }
@@ -314,12 +314,12 @@ void main() {
     message.optionalBytes = blob;
 
     TestAllTypes message2 =
-        new TestAllTypes.fromBuffer(message.writeToBuffer());
+        TestAllTypes.fromBuffer(message.writeToBuffer());
     expect(message2.optionalBytes, message.optionalBytes);
   });
 
   test('testRecursiveMessageDefaultInstance', () {
-    TestRecursiveMessage message = new TestRecursiveMessage();
+    TestRecursiveMessage message = TestRecursiveMessage();
     expect(message.a, isNotNull);
     expect(message, message.a);
   });
@@ -327,8 +327,8 @@ void main() {
   test('testMaliciousRecursion', () {
     GeneratedMessage _makeRecursiveMessage(int depth) {
       return depth == 0
-          ? (new TestRecursiveMessage()..i = 5)
-          : (new TestRecursiveMessage()..a = _makeRecursiveMessage(depth - 1));
+          ? (TestRecursiveMessage()..i = 5)
+          : (TestRecursiveMessage()..a = _makeRecursiveMessage(depth - 1));
     }
 
     _assertMessageDepth(TestRecursiveMessage message, int depth) {
@@ -344,32 +344,32 @@ void main() {
     List<int> data64 = _makeRecursiveMessage(64).writeToBuffer();
     List<int> data65 = _makeRecursiveMessage(65).writeToBuffer();
 
-    _assertMessageDepth(new TestRecursiveMessage.fromBuffer(data64), 64);
+    _assertMessageDepth(TestRecursiveMessage.fromBuffer(data64), 64);
 
     expect(() {
-      new TestRecursiveMessage.fromBuffer(data65);
+      TestRecursiveMessage.fromBuffer(data65);
     }, throwsInvalidProtocolBufferException);
 
-    CodedBufferReader input = new CodedBufferReader(data64, recursionLimit: 8);
+    CodedBufferReader input = CodedBufferReader(data64, recursionLimit: 8);
     expect(() {
       // Uncomfortable alternative to below...
-      new TestRecursiveMessage().mergeFromCodedBufferReader(input);
+      TestRecursiveMessage().mergeFromCodedBufferReader(input);
     }, throwsInvalidProtocolBufferException);
   });
 
   test('testSizeLimit', () {
     CodedBufferReader input =
-        new CodedBufferReader(getAllSet().writeToBuffer(), sizeLimit: 16);
+        CodedBufferReader(getAllSet().writeToBuffer(), sizeLimit: 16);
 
     expect(() {
       // Uncomfortable alternative to below...
-      new TestAllTypes().mergeFromCodedBufferReader(input);
+      TestAllTypes().mergeFromCodedBufferReader(input);
     }, throwsInvalidProtocolBufferException);
   });
   test('testSerialize', () {
     TestAllTypes expected = getAllSet();
     List<int> out = expected.writeToBuffer();
-    TestAllTypes actual = new TestAllTypes.fromBuffer(out);
+    TestAllTypes actual = TestAllTypes.fromBuffer(out);
     expect(actual, expected);
   });
 
@@ -452,18 +452,18 @@ void main() {
   });
 
   test('testWriteMessageWithNegativeEnumValue', () {
-    SparseEnumMessage message = new SparseEnumMessage()
+    SparseEnumMessage message = SparseEnumMessage()
       ..sparseEnum = TestSparseEnum.SPARSE_E;
     expect(message.sparseEnum.value < 0, isTrue,
         reason: 'enum.value should be -53452');
     SparseEnumMessage message2 =
-        new SparseEnumMessage.fromBuffer(message.writeToBuffer());
+        SparseEnumMessage.fromBuffer(message.writeToBuffer());
     expect(message2.sparseEnum, TestSparseEnum.SPARSE_E,
         reason: 'should resolve back to SPARSE_E');
   });
 
   test('testReservedNamesOptional', () {
-    ReservedNamesOptional message = new ReservedNamesOptional();
+    ReservedNamesOptional message = ReservedNamesOptional();
     message.hashCode_1 = 1;
     expect(message.hashCode_1, 1);
     expect(message.hasHashCode_1(), isTrue);
@@ -506,7 +506,7 @@ void main() {
   });
 
   test('testReservedNamesRepeated', () {
-    ReservedNamesRepeated message = new ReservedNamesRepeated();
+    ReservedNamesRepeated message = ReservedNamesRepeated();
     message.hashCode_1.clear();
     message.noSuchMethod_2.clear();
     message.runtimeType_3.clear();
@@ -545,7 +545,7 @@ void main() {
   });
 
   test('testReservedNamesRequired', () {
-    ReservedNamesRequired message = new ReservedNamesRequired();
+    ReservedNamesRequired message = ReservedNamesRequired();
     message.hashCode_1 = 1;
     expect(message.hashCode_1, 1);
     expect(message.hasHashCode_1(), isTrue);
@@ -588,7 +588,7 @@ void main() {
   });
 
   test('testReservedWordsOptional', () {
-    ReservedWordsOptional message = new ReservedWordsOptional();
+    ReservedWordsOptional message = ReservedWordsOptional();
     message.assert_1 = 1;
     message.break_2 = 1;
     message.case_3 = 1;
@@ -625,7 +625,7 @@ void main() {
   });
 
   test('testReservedWordsRepeated', () {
-    ReservedWordsRepeated message = new ReservedWordsRepeated();
+    ReservedWordsRepeated message = ReservedWordsRepeated();
     message.assert_1.clear();
     message.break_2.clear();
     message.case_3.clear();
@@ -662,7 +662,7 @@ void main() {
   });
 
   test('testReservedWordsRequired', () {
-    ReservedWordsRequired message = new ReservedWordsRequired();
+    ReservedWordsRequired message = ReservedWordsRequired();
     message.assert_1 = 1;
     message.break_2 = 1;
     message.case_3 = 1;
@@ -699,23 +699,23 @@ void main() {
   });
 
   test('testImportDuplicatenames', () {
-    M message = new M();
-    message.m1 = new p1.M();
-    message.m1M = new p1.M_M();
-    message.m2 = new p2.M();
-    message.m2M = new p2.M_M();
-    message.m3 = new p3.M();
-    message.m3M = new p3.M_M();
+    M message = M();
+    message.m1 = p1.M();
+    message.m1M = p1.M_M();
+    message.m2 = p2.M();
+    message.m2M = p2.M_M();
+    message.m3 = p3.M();
+    message.m3M = p3.M_M();
   });
 
   test('testToplevel', () {
-    t.M message = new t.M();
-    message.t = new T();
-    new t.SApi(null);
+    t.M message = t.M();
+    message.t = T();
+    t.SApi(null);
   });
 
   test('to toDebugString', () {
-    TestAllTypes value1 = new TestAllTypes()..optionalString = "test 123";
+    TestAllTypes value1 = TestAllTypes()..optionalString = "test 123";
     expect(value1.toString(), 'optionalString: test 123\n');
   });
 }

--- a/protoc_plugin/test/goldens/client
+++ b/protoc_plugin/test/goldens/client
@@ -3,11 +3,11 @@ class TestApi {
   TestApi(this._client);
 
   $async.Future<SomeReply> aMethod($pb.ClientContext ctx, SomeRequest request) {
-    var emptyResponse = new SomeReply();
+    var emptyResponse = SomeReply();
     return _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, emptyResponse);
   }
   $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext ctx, $0.EmptyMessage request) {
-    var emptyResponse = new $0.AnotherReply();
+    var emptyResponse = $0.AnotherReply();
     return _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
   }
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -10,19 +10,19 @@ import 'dart:core' as $core show int, bool, double, String, List, Map, override;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('Empty')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Empty')
     ..hasRequiredFields = false
   ;
 
   Empty() : super();
   Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
   Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  Empty clone() => new Empty()..mergeFromMessage(this);
+  Empty clone() => Empty()..mergeFromMessage(this);
   Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty));
   $pb.BuilderInfo get info_ => _i;
-  static Empty create() => new Empty();
+  static Empty create() => Empty();
   Empty createEmptyInstance() => create();
-  static $pb.PbList<Empty> createRepeated() => new $pb.PbList<Empty>();
+  static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   static Empty getDefault() => _defaultInstance ??= create()..freeze();
   static Empty _defaultInstance;
 }

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -14,51 +14,51 @@ import 'test.pb.dart';
 export 'test.pb.dart';
 
 class TestClient extends $grpc.Client {
-  static final _$unary = new $grpc.ClientMethod<Input, Output>(
+  static final _$unary = $grpc.ClientMethod<Input, Output>(
       '/Test/Unary',
       (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => new Output.fromBuffer(value));
-  static final _$clientStreaming = new $grpc.ClientMethod<Input, Output>(
+      ($core.List<$core.int> value) => Output.fromBuffer(value));
+  static final _$clientStreaming = $grpc.ClientMethod<Input, Output>(
       '/Test/ClientStreaming',
       (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => new Output.fromBuffer(value));
-  static final _$serverStreaming = new $grpc.ClientMethod<Input, Output>(
+      ($core.List<$core.int> value) => Output.fromBuffer(value));
+  static final _$serverStreaming = $grpc.ClientMethod<Input, Output>(
       '/Test/ServerStreaming',
       (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => new Output.fromBuffer(value));
-  static final _$bidirectional = new $grpc.ClientMethod<Input, Output>(
+      ($core.List<$core.int> value) => Output.fromBuffer(value));
+  static final _$bidirectional = $grpc.ClientMethod<Input, Output>(
       '/Test/Bidirectional',
       (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => new Output.fromBuffer(value));
+      ($core.List<$core.int> value) => Output.fromBuffer(value));
 
   TestClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
   $grpc.ResponseFuture<Output> unary(Input request,
       {$grpc.CallOptions options}) {
-    final call = $createCall(_$unary, new $async.Stream.fromIterable([request]),
+    final call = $createCall(_$unary, $async.Stream.fromIterable([request]),
         options: options);
-    return new $grpc.ResponseFuture(call);
+    return $grpc.ResponseFuture(call);
   }
 
   $grpc.ResponseFuture<Output> clientStreaming($async.Stream<Input> request,
       {$grpc.CallOptions options}) {
     final call = $createCall(_$clientStreaming, request, options: options);
-    return new $grpc.ResponseFuture(call);
+    return $grpc.ResponseFuture(call);
   }
 
   $grpc.ResponseStream<Output> serverStreaming(Input request,
       {$grpc.CallOptions options}) {
     final call = $createCall(
-        _$serverStreaming, new $async.Stream.fromIterable([request]),
+        _$serverStreaming, $async.Stream.fromIterable([request]),
         options: options);
-    return new $grpc.ResponseStream(call);
+    return $grpc.ResponseStream(call);
   }
 
   $grpc.ResponseStream<Output> bidirectional($async.Stream<Input> request,
       {$grpc.CallOptions options}) {
     final call = $createCall(_$bidirectional, request, options: options);
-    return new $grpc.ResponseStream(call);
+    return $grpc.ResponseStream(call);
   }
 }
 
@@ -66,33 +66,33 @@ abstract class TestServiceBase extends $grpc.Service {
   $core.String get $name => 'Test';
 
   TestServiceBase() {
-    $addMethod(new $grpc.ServiceMethod<Input, Output>(
+    $addMethod($grpc.ServiceMethod<Input, Output>(
         'Unary',
         unary_Pre,
         false,
         false,
-        ($core.List<$core.int> value) => new Input.fromBuffer(value),
+        ($core.List<$core.int> value) => Input.fromBuffer(value),
         (Output value) => value.writeToBuffer()));
-    $addMethod(new $grpc.ServiceMethod<Input, Output>(
+    $addMethod($grpc.ServiceMethod<Input, Output>(
         'ClientStreaming',
         clientStreaming,
         true,
         false,
-        ($core.List<$core.int> value) => new Input.fromBuffer(value),
+        ($core.List<$core.int> value) => Input.fromBuffer(value),
         (Output value) => value.writeToBuffer()));
-    $addMethod(new $grpc.ServiceMethod<Input, Output>(
+    $addMethod($grpc.ServiceMethod<Input, Output>(
         'ServerStreaming',
         serverStreaming_Pre,
         false,
         true,
-        ($core.List<$core.int> value) => new Input.fromBuffer(value),
+        ($core.List<$core.int> value) => Input.fromBuffer(value),
         (Output value) => value.writeToBuffer()));
-    $addMethod(new $grpc.ServiceMethod<Input, Output>(
+    $addMethod($grpc.ServiceMethod<Input, Output>(
         'Bidirectional',
         bidirectional,
         true,
         true,
-        ($core.List<$core.int> value) => new Input.fromBuffer(value),
+        ($core.List<$core.int> value) => Input.fromBuffer(value),
         (Output value) => value.writeToBuffer()));
   }
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -13,7 +13,7 @@ import 'package1.pb.dart' as $0;
 import 'package2.pb.dart' as $1;
 
 class M extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('M')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('M')
     ..a<M>(1, 'm', $pb.PbFieldType.OM, M.getDefault, M.create)
     ..a<$0.M>(2, 'm1', $pb.PbFieldType.OM, $0.M.getDefault, $0.M.create)
     ..a<$1.M>(3, 'm2', $pb.PbFieldType.OM, $1.M.getDefault, $1.M.create)
@@ -23,12 +23,12 @@ class M extends $pb.GeneratedMessage {
   M() : super();
   M.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
   M.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  M clone() => new M()..mergeFromMessage(this);
+  M clone() => M()..mergeFromMessage(this);
   M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M));
   $pb.BuilderInfo get info_ => _i;
-  static M create() => new M();
+  static M create() => M();
   M createEmptyInstance() => create();
-  static $pb.PbList<M> createRepeated() => new $pb.PbList<M>();
+  static $pb.PbList<M> createRepeated() => $pb.PbList<M>();
   static M getDefault() => _defaultInstance ??= create()..freeze();
   static M _defaultInstance;
 

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -1,5 +1,5 @@
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('PhoneNumber')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PhoneNumber')
     ..aQS(1, 'number')
     ..e<PhoneNumber_PhoneType>(2, 'type', $pb.PbFieldType.OE, PhoneNumber_PhoneType.MOBILE, PhoneNumber_PhoneType.valueOf, PhoneNumber_PhoneType.values)
     ..a<$core.String>(3, 'name', $pb.PbFieldType.OS, '\$')
@@ -8,12 +8,12 @@ class PhoneNumber extends $pb.GeneratedMessage {
   PhoneNumber() : super();
   PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
   PhoneNumber.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  PhoneNumber clone() => new PhoneNumber()..mergeFromMessage(this);
+  PhoneNumber clone() => PhoneNumber()..mergeFromMessage(this);
   PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber));
   $pb.BuilderInfo get info_ => _i;
-  static PhoneNumber create() => new PhoneNumber();
+  static PhoneNumber create() => PhoneNumber();
   PhoneNumber createEmptyInstance() => create();
-  static $pb.PbList<PhoneNumber> createRepeated() => new $pb.PbList<PhoneNumber>();
+  static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   static PhoneNumber getDefault() => _defaultInstance ??= create()..freeze();
   static PhoneNumber _defaultInstance;
 

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 362
-  end: 373
+  begin: 358
+  end: 369
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1189
-  end: 1195
+  begin: 1173
+  end: 1179
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1220
-  end: 1226
+  begin: 1204
+  end: 1210
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1273
-  end: 1282
+  begin: 1257
+  end: 1266
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 1311
-  end: 1322
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: 
-  begin: 1372
-  end: 1376
+  begin: 1295
+  end: 1306
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1397
-  end: 1401
+  begin: 1356
+  end: 1360
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1454
-  end: 1461
+  begin: 1381
+  end: 1385
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1490
-  end: 1499
+  begin: 1438
+  end: 1445
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: 
+  begin: 1474
+  end: 1483
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1540
-  end: 1544
+  begin: 1524
+  end: 1528
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1571
-  end: 1575
+  begin: 1555
+  end: 1559
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1622
-  end: 1629
+  begin: 1606
+  end: 1613
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1658
-  end: 1667
+  begin: 1642
+  end: 1651
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -10,7 +10,7 @@ import 'dart:core' as $core show int, bool, double, String, List, Map, override;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('PhoneNumber')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PhoneNumber')
     ..aQS(1, 'number')
     ..a<$core.int>(2, 'type', $pb.PbFieldType.O3)
     ..a<$core.String>(3, 'name', $pb.PbFieldType.OS, '\$')
@@ -19,12 +19,12 @@ class PhoneNumber extends $pb.GeneratedMessage {
   PhoneNumber() : super();
   PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
   PhoneNumber.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  PhoneNumber clone() => new PhoneNumber()..mergeFromMessage(this);
+  PhoneNumber clone() => PhoneNumber()..mergeFromMessage(this);
   PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber));
   $pb.BuilderInfo get info_ => _i;
-  static PhoneNumber create() => new PhoneNumber();
+  static PhoneNumber create() => PhoneNumber();
   PhoneNumber createEmptyInstance() => create();
-  static $pb.PbList<PhoneNumber> createRepeated() => new $pb.PbList<PhoneNumber>();
+  static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   static PhoneNumber getDefault() => _defaultInstance ??= create()..freeze();
   static PhoneNumber _defaultInstance;
 

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 578
-  end: 589
+  begin: 574
+  end: 585
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1405
-  end: 1411
+  begin: 1389
+  end: 1395
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1436
-  end: 1442
+  begin: 1420
+  end: 1426
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1489
-  end: 1498
+  begin: 1473
+  end: 1482
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1527
-  end: 1538
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 1576
-  end: 1580
+  begin: 1511
+  end: 1522
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1603
-  end: 1607
+  begin: 1560
+  end: 1564
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1656
-  end: 1663
+  begin: 1587
+  end: 1591
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1692
-  end: 1701
+  begin: 1640
+  end: 1647
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 1676
+  end: 1685
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1742
-  end: 1746
+  begin: 1726
+  end: 1730
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1773
-  end: 1777
+  begin: 1757
+  end: 1761
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1824
-  end: 1831
+  begin: 1808
+  end: 1815
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1860
-  end: 1869
+  begin: 1844
+  end: 1853
 }

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -11,19 +11,19 @@ import 'dart:core' as $core show int, bool, double, String, List, Map, override;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = new $pb.BuilderInfo('Empty')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Empty')
     ..hasRequiredFields = false
   ;
 
   Empty() : super();
   Empty.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromBuffer(i, r);
   Empty.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) : super.fromJson(i, r);
-  Empty clone() => new Empty()..mergeFromMessage(this);
+  Empty clone() => Empty()..mergeFromMessage(this);
   Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty));
   $pb.BuilderInfo get info_ => _i;
-  static Empty create() => new Empty();
+  static Empty create() => Empty();
   Empty createEmptyInstance() => create();
-  static $pb.PbList<Empty> createRepeated() => new $pb.PbList<Empty>();
+  static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   static Empty getDefault() => _defaultInstance ??= create()..freeze();
   static Empty _defaultInstance;
 }
@@ -33,7 +33,7 @@ class TestApi {
   TestApi(this._client);
 
   $async.Future<Empty> ping($pb.ClientContext ctx, Empty request) {
-    var emptyResponse = new Empty();
+    var emptyResponse = Empty();
     return _client.invoke<Empty>(ctx, 'Test', 'Ping', request, emptyResponse);
   }
 }

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -19,15 +19,15 @@ abstract class TestServiceBase extends $pb.GeneratedService {
 
   $pb.GeneratedMessage createRequest($core.String method) {
     switch (method) {
-      case 'Ping': return new Empty();
-      default: throw new $core.ArgumentError('Unknown method: $method');
+      case 'Ping': return Empty();
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
   $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
     switch (method) {
       case 'Ping': return this.ping(ctx, request);
-      default: throw new $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 

--- a/protoc_plugin/test/goldens/serviceGenerator
+++ b/protoc_plugin/test/goldens/serviceGenerator
@@ -4,9 +4,9 @@ abstract class TestServiceBase extends $pb.GeneratedService {
 
   $pb.GeneratedMessage createRequest($core.String method) {
     switch (method) {
-      case 'AMethod': return new SomeRequest();
-      case 'AnotherMethod': return new $0.EmptyMessage();
-      default: throw new $core.ArgumentError('Unknown method: $method');
+      case 'AMethod': return SomeRequest();
+      case 'AnotherMethod': return $0.EmptyMessage();
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 
@@ -14,7 +14,7 @@ abstract class TestServiceBase extends $pb.GeneratedService {
     switch (method) {
       case 'AMethod': return this.aMethod(ctx, request);
       case 'AnotherMethod': return this.anotherMethod(ctx, request);
-      default: throw new $core.ArgumentError('Unknown method: $method');
+      default: throw $core.ArgumentError('Unknown method: $method');
     }
   }
 

--- a/protoc_plugin/test/hash_code_test.dart
+++ b/protoc_plugin/test/hash_code_test.dart
@@ -12,14 +12,14 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 
 void main() {
   test('testHashCodeEmptyMessage', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeOptionalInt32', () {
-    var m1 = new TestAllTypes()..optionalInt32 = 42;
-    var m2 = new TestAllTypes()..optionalInt32 = 42;
+    var m1 = TestAllTypes()..optionalInt32 = 42;
+    var m2 = TestAllTypes()..optionalInt32 = 42;
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalInt32 = 43;
@@ -30,20 +30,20 @@ void main() {
   });
 
   test('testHashCodeOptionalInt64', () {
-    var m1 = new TestAllTypes()..optionalInt64 = new Int64(42);
-    var m2 = new TestAllTypes()..optionalInt64 = new Int64(42);
+    var m1 = TestAllTypes()..optionalInt64 = Int64(42);
+    var m2 = TestAllTypes()..optionalInt64 = Int64(42);
     expect(m1.hashCode, m2.hashCode);
 
-    m1.optionalInt64 = new Int64(43);
+    m1.optionalInt64 = Int64(43);
     expect(m1.hashCode, isNot(m2.hashCode));
 
-    m2.optionalInt64 = new Int64(43);
+    m2.optionalInt64 = Int64(43);
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeOptionalString', () {
-    var m1 = new TestAllTypes()..optionalString = "Dart";
-    var m2 = new TestAllTypes()..optionalString = "Dart";
+    var m1 = TestAllTypes()..optionalString = "Dart";
+    var m2 = TestAllTypes()..optionalString = "Dart";
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalString = "JavaScript";
@@ -54,9 +54,9 @@ void main() {
   });
 
   test('testHashCodeOptionalEnum', () {
-    var m1 = new TestAllTypes()
+    var m1 = TestAllTypes()
       ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
-    var m2 = new TestAllTypes()
+    var m2 = TestAllTypes()
       ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
     expect(m1.hashCode, m2.hashCode);
 
@@ -68,16 +68,16 @@ void main() {
   });
 
   test('testHashCodeRepeatedInt32', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
     m1.repeatedInt32.add(42);
     m2.repeatedInt32.add(42);
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeRepeatedInt64', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
     m1.repeatedInt32.add(42);
     m2.repeatedInt32.add(42);
     expect(m1.hashCode, m2.hashCode);
@@ -96,8 +96,8 @@ void main() {
   });
 
   test('testHashCodeRepeatedString', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
     m1.repeatedString.add("Dart");
     m2.repeatedString.add("Dart");
     expect(m1.hashCode, m2.hashCode);
@@ -116,8 +116,8 @@ void main() {
   });
 
   test('testHashCodeRepeatedEnum', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
     m1.repeatedNestedEnum.add(TestAllTypes_NestedEnum.BAR);
     m2.repeatedNestedEnum.add(TestAllTypes_NestedEnum.BAR);
     expect(m1.hashCode, m2.hashCode);
@@ -130,30 +130,30 @@ void main() {
   });
 
   test('testHashCodeUnknownFields', () {
-    var m1 = new TestAllTypes();
-    var m2 = new TestAllTypes();
-    m1.unknownFields.mergeVarintField(12345, new Int64(123));
-    m2.unknownFields.mergeVarintField(12345, new Int64(123));
+    var m1 = TestAllTypes();
+    var m2 = TestAllTypes();
+    m1.unknownFields.mergeVarintField(12345, Int64(123));
+    m2.unknownFields.mergeVarintField(12345, Int64(123));
     expect(m1.hashCode, m2.hashCode);
   });
 
   test('testHashCodeCombined', () {
-    var m1 = new TestAllTypes()
+    var m1 = TestAllTypes()
       ..optionalInt32 = 42
-      ..optionalInt64 = new Int64(42)
+      ..optionalInt64 = Int64(42)
       ..optionalString = "Dart"
       ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
-    var m2 = new TestAllTypes()
+    var m2 = TestAllTypes()
       ..optionalInt32 = 42
-      ..optionalInt64 = new Int64(42)
+      ..optionalInt64 = Int64(42)
       ..optionalString = "Dart"
       ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
     expect(m1.hashCode, m2.hashCode);
 
     m1.repeatedInt32..add(42)..add(43);
     m2.repeatedInt32..add(42)..add(43);
-    m1.repeatedInt64..add(new Int64(42))..add(new Int64(43));
-    m2.repeatedInt64..add(new Int64(42))..add(new Int64(43));
+    m1.repeatedInt64..add(Int64(42))..add(Int64(43));
+    m2.repeatedInt64..add(Int64(42))..add(Int64(43));
     m1.repeatedString..add("Dart")..add("JavaScript");
     m2.repeatedString..add("Dart")..add("JavaScript");
     m1.repeatedNestedEnum
@@ -164,8 +164,8 @@ void main() {
       ..add(TestAllTypes_NestedEnum.BAZ);
     expect(m1.hashCode, m2.hashCode);
 
-    m1.unknownFields.mergeVarintField(12345, new Int64(123));
-    m2.unknownFields.mergeVarintField(12345, new Int64(123));
+    m1.unknownFields.mergeVarintField(12345, Int64(123));
+    m2.unknownFields.mergeVarintField(12345, Int64(123));
     expect(m1.hashCode, m2.hashCode);
     expect(m1.hashCode, m2.hashCode);
   });

--- a/protoc_plugin/test/hash_code_test.dart
+++ b/protoc_plugin/test/hash_code_test.dart
@@ -54,10 +54,8 @@ void main() {
   });
 
   test('testHashCodeOptionalEnum', () {
-    var m1 = TestAllTypes()
-      ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
-    var m2 = TestAllTypes()
-      ..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
+    var m1 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
+    var m2 = TestAllTypes()..optionalNestedEnum = TestAllTypes_NestedEnum.BAR;
     expect(m1.hashCode, m2.hashCode);
 
     m1.optionalNestedEnum = TestAllTypes_NestedEnum.BAZ;

--- a/protoc_plugin/test/import_test.dart
+++ b/protoc_plugin/test/import_test.dart
@@ -11,6 +11,6 @@ import '../out/protos/foo.pb.dart' as foo;
 
 void main() {
   test('Import prefixes in generated files do not clash with fields', () {
-    new pb.Clasher()..foo = new foo.Foo();
+    pb.Clasher()..foo = foo.Foo();
   });
 }

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('IndentingWriter can indent a block', () {
-    var out = new IndentingWriter(filename: '');
+    var out = IndentingWriter(filename: '');
     out.addBlock('class test {', '}', () {
       out.println('first;');
       out.println();
@@ -28,12 +28,12 @@ class test {
   });
 
   test('IndentingWriter annotation tracks previous output', () {
-    var out = new IndentingWriter(filename: 'sample.proto');
+    var out = IndentingWriter(filename: 'sample.proto');
     out.print('13 characters');
     out.printAnnotated('sample text', [
       NamedLocation(name: 'text', fieldPathSegment: [1, 2, 3], start: 7)
     ]);
-    GeneratedCodeInfo_Annotation expected = new GeneratedCodeInfo_Annotation()
+    GeneratedCodeInfo_Annotation expected = GeneratedCodeInfo_Annotation()
       ..path.addAll([1, 2, 3])
       ..sourceFile = 'sample.proto'
       ..begin = 20
@@ -44,7 +44,7 @@ class test {
   });
 
   test('IndentingWriter annotation counts indents correctly', () {
-    var out = new IndentingWriter(filename: '');
+    var out = IndentingWriter(filename: '');
     out.addBlock('34 characters including newline {', '}', () {
       out.printlnAnnotated('sample text',
           [NamedLocation(name: 'sample', fieldPathSegment: [], start: 0)]);
@@ -57,7 +57,7 @@ class test {
   });
 
   test('IndentingWriter annotations counts multiline output correctly', () {
-    var out = new IndentingWriter(filename: '');
+    var out = IndentingWriter(filename: '');
     out.print('20 characters\ntotal\n');
     out.printlnAnnotated('20 characters before this',
         [NamedLocation(name: 'ch', fieldPathSegment: [], start: 3)]);

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -85,8 +85,8 @@ void main() {
   test('testBase64Decode', () {
     optionalBytes(from, to) {
       String json = TEST_ALL_TYPES_JSON.replaceAll(from, to);
-      return new String.fromCharCodes(
-          new TestAllTypes.fromJson(json).optionalBytes);
+      return String.fromCharCodes(
+          TestAllTypes.fromJson(json).optionalBytes);
     }
 
     expect(optionalBytes(':"MTE2",', ':"SGVsbG8sIHdvcmxk",'), 'Hello, world');
@@ -107,7 +107,7 @@ void main() {
   });
 
   test('testParse', () {
-    expect(new TestAllTypes.fromJson(TEST_ALL_TYPES_JSON), getAllSet());
+    expect(TestAllTypes.fromJson(TEST_ALL_TYPES_JSON), getAllSet());
   });
 
   test('testExtensionsOutput', () {
@@ -116,25 +116,25 @@ void main() {
 
   test('testExtensionsParse', () {
     ExtensionRegistry registry = getExtensionRegistry();
-    expect(new TestAllExtensions.fromJson(TEST_ALL_TYPES_JSON, registry),
+    expect(TestAllExtensions.fromJson(TEST_ALL_TYPES_JSON, registry),
         getAllExtensionsSet());
   });
 
   test('testUnknownEnumValueInOptionalField', () {
     // optional NestedEnum optional_nested_enum = 21;
-    var message = new TestAllTypes.fromJson('{"21": 4}');
+    var message = TestAllTypes.fromJson('{"21": 4}');
     // 4 is an unknown value.
     expect(message.optionalNestedEnum, equals(TestAllTypes_NestedEnum.FOO));
   });
 
   test('testUnknownEnumValueInRepeatedField', () {
     // repeated NestedEnum repeated_nested_enum = 51;
-    var message = new TestAllTypes.fromJson('{"51": [4]}');
+    var message = TestAllTypes.fromJson('{"51": [4]}');
     // 4 is an unknown value.
     expect(message.repeatedNestedEnum, isEmpty);
 
     // 1 (FOO) and 2 (BAR) are known values.
-    message = new TestAllTypes.fromJson('{"51": [1, 4, 2, 4, 1, 4]}');
+    message = TestAllTypes.fromJson('{"51": [1, 4, 2, 4, 1, 4]}');
     expect(
         message.repeatedNestedEnum,
         equals([

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -85,8 +85,7 @@ void main() {
   test('testBase64Decode', () {
     optionalBytes(from, to) {
       String json = TEST_ALL_TYPES_JSON.replaceAll(from, to);
-      return String.fromCharCodes(
-          TestAllTypes.fromJson(json).optionalBytes);
+      return String.fromCharCodes(TestAllTypes.fromJson(json).optionalBytes);
     }
 
     expect(optionalBytes(':"MTE2",', ':"SGVsbG8sIHdvcmxk",'), 'Hello, world');

--- a/protoc_plugin/test/leading_underscores_test.dart
+++ b/protoc_plugin/test/leading_underscores_test.dart
@@ -10,7 +10,7 @@ import '../out/protos/_leading_underscores.pb.dart';
 
 void main() {
   test('can set, read and clear all fields and refer to types', () {
-    A_ message = new A_();
+    A_ message = A_();
     message.setExtension(Leading_underscores_.p, Int64(99));
     expect(message.getExtension(Leading_underscores_.p), Int64(99));
     message.f = 'foo';
@@ -23,7 +23,7 @@ void main() {
     expect(message.hasF_2(), false);
     expect(message.f, '');
     expect(message.f_2, '');
-    A messageA = new A();
+    A messageA = A();
     messageA.b = message;
     messageA.b_6 = message;
     expect(messageA.b_6, message);

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -15,45 +15,45 @@ throwsError(Type expectedType, String expectedMessage) =>
 
 void main() {
   test("message doesn't implement Map when turned off", () {
-    expect(new pb.NonMap(), predicate((x) => x is! Map));
-    expect(new pb2.NonMap2(), predicate((x) => x is! Map));
+    expect(pb.NonMap(), predicate((x) => x is! Map));
+    expect(pb2.NonMap2(), predicate((x) => x is! Map));
   });
 
   test("message implements Map when turned on", () {
-    expect(new pb.Rec(), predicate((x) => x is Map));
-    expect(new pb2.Rec2(), predicate((x) => x is Map));
+    expect(pb.Rec(), predicate((x) => x is Map));
+    expect(pb2.Rec2(), predicate((x) => x is Map));
   });
 
   test('operator [] returns null for unrecognized keys', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(rec["noSuchField"], null);
     expect(rec[1234], null);
     expect(rec[null], null);
   });
 
   test('operator [] returns default value when not set', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(rec["num"], 0);
     expect(rec["nums"], []);
     expect(rec["str"], "");
     expect(rec["msg"], predicate((x) => x is pb.NonMap));
   });
 
-  test('operator [] returns new value when set', () {
-    var rec = new pb.Rec();
+  test('operator [] returns value when set', () {
+    var rec = pb.Rec();
     rec.num = 42;
     expect(rec["num"], 42);
     rec.nums.add(123);
     expect(rec["nums"], [123]);
     rec.str = "hello";
     expect(rec["str"], "hello");
-    var msg = new pb.NonMap();
+    var msg = pb.NonMap();
     rec.msg = msg;
     expect(rec["msg"], same(msg));
   });
 
   test('operator []= throws exception for invalid key', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(() {
       rec["unknown"] = 123;
     },
@@ -63,14 +63,14 @@ void main() {
 
   test('operator []= throws exception for repeated field', () {
     // Copying the values would be confusing.
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(() {
       rec["nums"] = [1, 2];
     }, throwsArgumentError);
   });
 
   test('operator []= throws exception for invalid value type', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(() {
       rec["num"] = "hello";
     }, throwsArgumentError);
@@ -80,7 +80,7 @@ void main() {
   });
 
   test('operator []= sets the field', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     rec["num"] = 123;
     expect(rec.num, 123);
     rec["str"] = "hello";
@@ -88,12 +88,12 @@ void main() {
   });
 
   test('keys returns each field name (even when unset)', () {
-    var rec = new pb.Rec();
-    expect(new Set.from(rec.keys), new Set.from(["msg", "num", "nums", "str"]));
+    var rec = pb.Rec();
+    expect(Set.from(rec.keys), Set.from(["msg", "num", "nums", "str"]));
   });
 
   test('containsKey returns true for fields that exist (even when unset)', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(rec.containsKey("unknown"), false);
     expect(rec.containsKey("str"), true);
     expect(rec.containsKey("num"), true);
@@ -102,14 +102,14 @@ void main() {
   });
 
   test('length is constant', () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(rec.length, 4);
     rec.str = "hello";
     expect(rec.length, 4);
   });
 
   test("remove isn't supported", () {
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     rec.str = "hello";
     expect(() {
       rec.remove("str");
@@ -121,7 +121,7 @@ void main() {
 
   test("clear sets each field to its default value (unlike a regular Map)", () {
     // We have little choice here since the clear() method already existed.
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     rec.str = "hello";
     rec.num = 123;
     rec.nums.add(456);
@@ -132,8 +132,8 @@ void main() {
     expect(rec["nums"], []);
   });
 
-  test("addAll sets each field to a new value", () {
-    var rec = new pb.Rec();
+  test("addAll sets each field to a value", () {
+    var rec = pb.Rec();
     rec.addAll({"str": "hello", "num": 123});
     expect(rec["str"], "hello");
     expect(rec["num"], 123);
@@ -141,7 +141,7 @@ void main() {
 
   test("addAll doesn't work for repeated fields", () {
     // It would be confusing to copy the values.
-    var rec = new pb.Rec();
+    var rec = pb.Rec();
     expect(() {
       rec.addAll({
         "nums": [1, 2, 3]

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -16,40 +16,40 @@ import 'golden_file.dart';
 
 void main() {
   test('testMessageGenerator', () {
-    FileDescriptorProto fd = new FileDescriptorProto();
-    EnumDescriptorProto ed = new EnumDescriptorProto()
+    FileDescriptorProto fd = FileDescriptorProto();
+    EnumDescriptorProto ed = EnumDescriptorProto()
       ..name = 'PhoneType'
       ..value.addAll([
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'MOBILE'
           ..number = 0,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'HOME'
           ..number = 1,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'WORK'
           ..number = 2,
-        new EnumValueDescriptorProto()
+        EnumValueDescriptorProto()
           ..name = 'BUSINESS'
           ..number = 2
       ]);
-    DescriptorProto md = new DescriptorProto()
+    DescriptorProto md = DescriptorProto()
       ..name = 'PhoneNumber'
       ..field.addAll([
         // optional PhoneType type = 2 [default = HOME];
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'type'
           ..number = 2
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
           ..type = FieldDescriptorProto_Type.TYPE_ENUM
           ..typeName = '.PhoneNumber.PhoneType',
         // required string number = 1;
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'number'
           ..number = 1
           ..label = FieldDescriptorProto_Label.LABEL_REQUIRED
           ..type = FieldDescriptorProto_Type.TYPE_STRING,
-        new FieldDescriptorProto()
+        FieldDescriptorProto()
           ..name = 'name'
           ..number = 3
           ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
@@ -58,23 +58,23 @@ void main() {
       ])
       ..enumType.add(ed);
     var options = parseGenerationOptions(
-        new CodeGeneratorRequest(), new CodeGeneratorResponse());
+        CodeGeneratorRequest(), CodeGeneratorResponse());
 
-    FileGenerator fg = new FileGenerator(fd, options);
+    FileGenerator fg = FileGenerator(fd, options);
     MessageGenerator mg =
-        new MessageGenerator.topLevel(md, fg, {}, null, new Set<String>(), 0);
+        MessageGenerator.topLevel(md, fg, {}, null, Set<String>(), 0);
 
-    var ctx = new GenerationContext(options);
+    var ctx = GenerationContext(options);
     mg.register(ctx);
     mg.resolve(ctx);
 
-    var writer = new IndentingWriter(filename: '');
+    var writer = IndentingWriter(filename: '');
     mg.generate(writer);
     expectMatchesGoldenFile(writer.toString(), 'test/goldens/messageGenerator');
     expectMatchesGoldenFile(writer.sourceLocationInfo.toString(),
         'test/goldens/messageGenerator.meta');
 
-    writer = new IndentingWriter(filename: '');
+    writer = IndentingWriter(filename: '');
     mg.generateEnums(writer);
     expectMatchesGoldenFile(
         writer.toString(), 'test/goldens/messageGeneratorEnums');

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -57,8 +57,8 @@ void main() {
           ..defaultValue = r'$'
       ])
       ..enumType.add(ed);
-    var options = parseGenerationOptions(
-        CodeGeneratorRequest(), CodeGeneratorResponse());
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
     FileGenerator fg = FileGenerator(fd, options);
     MessageGenerator mg =

--- a/protoc_plugin/test/message_test.dart
+++ b/protoc_plugin/test/message_test.dart
@@ -14,27 +14,27 @@ import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/google/protobuf/unittest.pbjson.dart';
 
 void main() {
-  TestRequired TEST_REQUIRED_UNINITIALIZED = new TestRequired();
+  TestRequired TEST_REQUIRED_UNINITIALIZED = TestRequired();
 
-  TestRequired TEST_REQUIRED_INITIALIZED = new TestRequired()
+  TestRequired TEST_REQUIRED_INITIALIZED = TestRequired()
     ..a = 1
     ..b = 2
     ..c = 3;
 
   test('testMergeFrom', () {
-    TestAllTypes mergeSource = new TestAllTypes()
+    TestAllTypes mergeSource = TestAllTypes()
       ..optionalInt32 = 1
       ..optionalString = 'foo'
-      ..optionalForeignMessage = new ForeignMessage()
-      ..optionalNestedMessage = (new TestAllTypes_NestedMessage()..i = 42)
+      ..optionalForeignMessage = ForeignMessage()
+      ..optionalNestedMessage = (TestAllTypes_NestedMessage()..i = 42)
       ..repeatedString.add('bar');
 
-    TestAllTypes mergeDest = new TestAllTypes()
+    TestAllTypes mergeDest = TestAllTypes()
       ..optionalInt64 = make64(2)
       ..optionalString = 'baz'
-      ..optionalForeignMessage = new ForeignMessage()
-      ..optionalForeignMessage = (new ForeignMessage()..c = 3)
-      ..optionalNestedMessage = (new TestAllTypes_NestedMessage()..bb = 43)
+      ..optionalForeignMessage = ForeignMessage()
+      ..optionalForeignMessage = (ForeignMessage()..c = 3)
+      ..optionalNestedMessage = (TestAllTypes_NestedMessage()..bb = 43)
       ..repeatedString.add('qux');
 
     String mergeResultExpected = '''
@@ -52,7 +52,7 @@ repeatedString: bar
 repeatedString: qux
 ''';
 
-    TestAllTypes result = new TestAllTypes()
+    TestAllTypes result = TestAllTypes()
       ..mergeFromMessage(mergeSource)
       ..mergeFromMessage(mergeDest);
 
@@ -60,7 +60,7 @@ repeatedString: qux
   });
 
   test('testRequired', () {
-    TestRequired message = new TestRequired();
+    TestRequired message = TestRequired();
 
     expect(message.isInitialized(), isFalse, reason: 'no required fields set');
     message.a = 1;
@@ -74,7 +74,7 @@ repeatedString: qux
   });
 
   test('testRequiredForeign', () {
-    TestRequiredForeign message = new TestRequiredForeign();
+    TestRequiredForeign message = TestRequiredForeign();
     expect(message.isInitialized(), isTrue,
         reason: 'TestRequiredForeign without children should be initialized');
 
@@ -101,7 +101,7 @@ repeatedString: qux
   });
 
   test('testRequiredExtension', () {
-    TestAllExtensions message = new TestAllExtensions();
+    TestAllExtensions message = TestAllExtensions();
     expect(message.isInitialized(), isTrue);
 
     message.setExtension(TestRequired.single, TEST_REQUIRED_UNINITIALIZED);
@@ -119,7 +119,7 @@ repeatedString: qux
 
   test('testUninitializedException', () {
     try {
-      new TestRequired().check();
+      TestRequired().check();
       fail('Should have thrown an exception.');
     } on StateError catch (e) {
       expect(e.message, 'Message missing required fields: a, b, c');
@@ -128,13 +128,13 @@ repeatedString: qux
 
   test('testBuildPartial', () {
     // We're mostly testing that no exception is thrown.
-    TestRequired message = new TestRequired();
+    TestRequired message = TestRequired();
     expect(message.isInitialized(), isFalse);
   });
 
   test('testNestedUninitializedException', () {
     try {
-      TestRequiredForeign message = new TestRequiredForeign();
+      TestRequiredForeign message = TestRequiredForeign();
       message.optionalMessage = TEST_REQUIRED_UNINITIALIZED;
       message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
       message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
@@ -161,7 +161,7 @@ repeatedString: qux
 
   test('testBuildNestedPartial', () {
     // We're mostly testing that no exception is thrown.
-    TestRequiredForeign message = new TestRequiredForeign();
+    TestRequiredForeign message = TestRequiredForeign();
     message.optionalMessage = TEST_REQUIRED_UNINITIALIZED;
     message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
     message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
@@ -170,7 +170,7 @@ repeatedString: qux
 
   test('testParseUnititialized', () {
     try {
-      (new TestRequired.fromBuffer([])).check();
+      (TestRequired.fromBuffer([])).check();
       fail('Should have thrown an exception.');
     } on StateError catch (e) {
       expect(e.message, 'Message missing required fields: a, b, c');
@@ -178,14 +178,14 @@ repeatedString: qux
   });
 
   test('testParseNestedUnititialized', () {
-    TestRequiredForeign message = new TestRequiredForeign();
+    TestRequiredForeign message = TestRequiredForeign();
     message.optionalMessage = TEST_REQUIRED_UNINITIALIZED;
     message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
     message.repeatedMessage.add(TEST_REQUIRED_UNINITIALIZED);
     List<int> buffer = message.writeToBuffer();
 
     try {
-      (new TestRequiredForeign.fromBuffer(buffer)).check();
+      (TestRequiredForeign.fromBuffer(buffer)).check();
       fail('Should have thrown an exception.');
     } on StateError catch (e) {
       // NOTE: error message differs from Java in that
@@ -208,7 +208,7 @@ repeatedString: qux
 
   test('testClearField', () {
     int fieldNo;
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
 
     // Singular field with no default.
     fieldNo = 1;
@@ -254,7 +254,7 @@ repeatedString: qux
   });
 
   test('Can read JSON constant into DescriptorProto', () {
-    var d = new DescriptorProto()..mergeFromJsonMap(TestAllTypes$json);
+    var d = DescriptorProto()..mergeFromJsonMap(TestAllTypes$json);
     expect(d.name, "TestAllTypes");
     expect(d.field[0].name, "optional_int32");
     expect(d.nestedType[0].name, "NestedMessage");

--- a/protoc_plugin/test/mixin_test.dart
+++ b/protoc_plugin/test/mixin_test.dart
@@ -8,7 +8,7 @@ void main() {
     pb.Mixin1PB proto;
 
     setUp(() {
-      proto = new pb.Mixin1PB();
+      proto = pb.Mixin1PB();
     });
 
     test('is a Mixin1', () {
@@ -27,7 +27,7 @@ void main() {
     pb.Mixin2PB proto;
 
     setUp(() {
-      proto = new pb.Mixin2PB();
+      proto = pb.Mixin2PB();
     });
 
     test('overrides has method', () {
@@ -42,7 +42,7 @@ void main() {
     pb.NoMixinPB proto;
 
     setUp(() {
-      proto = new pb.NoMixinPB();
+      proto = pb.NoMixinPB();
     });
 
     test('is neither Mixin1 nor Mixin2', () {
@@ -55,7 +55,7 @@ void main() {
     pb.Mixin3PB proto;
 
     setUp(() {
-      proto = new pb.Mixin3PB();
+      proto = pb.Mixin3PB();
     });
 
     test('is both Mixin1 (from parent) and Mixin3', () {

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -219,8 +219,7 @@ FieldDescriptorProto stringField(String name, int number, String dartName) {
     ..number = number
     ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
     ..type = FieldDescriptorProto_Type.TYPE_STRING
-    ..options =
-        (FieldOptions()..setExtension(Dart_options.dartName, dartName));
+    ..options = (FieldOptions()..setExtension(Dart_options.dartName, dartName));
 }
 
 FieldDescriptorProto stringFieldOneof(String name, int number, int oneofIndex) {

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -11,7 +11,7 @@ import 'package:protoc_plugin/src/dart_options.pb.dart';
 
 import '../out/protos/dart_name.pb.dart' as pb;
 
-Matcher throwsMessage(String msg) => throwsA(new _ToStringMatcher(equals(msg)));
+Matcher throwsMessage(String msg) => throwsA(_ToStringMatcher(equals(msg)));
 
 class _ToStringMatcher extends CustomMatcher {
   _ToStringMatcher(Matcher matcher)
@@ -21,7 +21,7 @@ class _ToStringMatcher extends CustomMatcher {
 
 void main() {
   test('Can access a field that was renamed using dart_name option', () {
-    var msg = new pb.DartName();
+    var msg = pb.DartName();
     expect(msg.hasRenamedField(), false);
     msg.renamedField = 'test';
     expect(msg.hasRenamedField(), true);
@@ -31,7 +31,7 @@ void main() {
   });
 
   test('Can swap field names using dart_name option', () {
-    var msg = new pb.SwapNames();
+    var msg = pb.SwapNames();
     msg.first = "one";
     msg.second = "two";
     expect(msg.getField(1), "two");
@@ -39,7 +39,7 @@ void main() {
   });
 
   test("Can take another field's name using dart_name option", () {
-    var msg = new pb.TakeExistingName();
+    var msg = pb.TakeExistingName();
     msg.first = "one";
     expect(msg.getField(2), "one");
     msg.first_1 = "renamed";
@@ -47,7 +47,7 @@ void main() {
   });
 
   test('Throws exception for dart_name option containing a space', () {
-    var descriptor = new DescriptorProto()
+    var descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.add(stringField("first", 1, "hello world"));
     expect(() {
@@ -58,7 +58,7 @@ void main() {
   });
 
   test('Throws exception for dart_name option set to reserved word', () {
-    var descriptor = new DescriptorProto()
+    var descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.add(stringField("first", 1, "class"));
     expect(() {
@@ -69,7 +69,7 @@ void main() {
   });
 
   test('Throws exception for duplicate dart_name options', () {
-    var descriptor = new DescriptorProto()
+    var descriptor = DescriptorProto()
       ..name = 'Example'
       ..field.addAll([
         stringField("first", 1, "renamed"),
@@ -83,8 +83,8 @@ void main() {
   });
 
   test('message classes renamed to avoid Function keyword', () {
-    new pb.Function_()..fun = 'renamed';
-    new pb.Function__()..fun1 = 'also renamed';
+    pb.Function_()..fun = 'renamed';
+    pb.Function__()..fun1 = 'also renamed';
   });
 
   test('disambiguateName', () {
@@ -144,7 +144,7 @@ void main() {
 
   test('oneof names no disambiguation', () {
     OneofDescriptorProto oneofDescriptor = oneofField('foo');
-    DescriptorProto descriptor = new DescriptorProto()
+    DescriptorProto descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
@@ -167,7 +167,7 @@ void main() {
 
   test('oneof names disambiguate method names', () {
     OneofDescriptorProto oneofDescriptor = oneofField('foo');
-    DescriptorProto descriptor = new DescriptorProto()
+    DescriptorProto descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
@@ -191,7 +191,7 @@ void main() {
 
   test('oneof names disambiguate top level name', () {
     OneofDescriptorProto oneofDescriptor = oneofField('foo');
-    DescriptorProto descriptor = new DescriptorProto()
+    DescriptorProto descriptor = DescriptorProto()
       ..name = 'Parent'
       ..field.addAll([stringFieldOneof('first', 1, 0)])
       ..oneofDecl.add(oneofDescriptor);
@@ -214,17 +214,17 @@ void main() {
 }
 
 FieldDescriptorProto stringField(String name, int number, String dartName) {
-  return new FieldDescriptorProto()
+  return FieldDescriptorProto()
     ..name = name
     ..number = number
     ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL
     ..type = FieldDescriptorProto_Type.TYPE_STRING
     ..options =
-        (new FieldOptions()..setExtension(Dart_options.dartName, dartName));
+        (FieldOptions()..setExtension(Dart_options.dartName, dartName));
 }
 
 FieldDescriptorProto stringFieldOneof(String name, int number, int oneofIndex) {
-  return new FieldDescriptorProto()
+  return FieldDescriptorProto()
     ..name = name
     ..number = number
     ..label = FieldDescriptorProto_Label.LABEL_OPTIONAL

--- a/protoc_plugin/test/protoc_options_test.dart
+++ b/protoc_plugin/test/protoc_options_test.dart
@@ -12,11 +12,11 @@ import 'package:test/test.dart';
 void main() {
   test('testValidGeneratorOptions', () {
     checkValid(String parameter) {
-      var request = new CodeGeneratorRequest();
+      var request = CodeGeneratorRequest();
       if (parameter != null) request.parameter = parameter;
-      var response = new CodeGeneratorResponse();
+      var response = CodeGeneratorResponse();
       var options = parseGenerationOptions(request, response);
-      expect(options, new TypeMatcher<GenerationOptions>());
+      expect(options, TypeMatcher<GenerationOptions>());
       expect(response.error, '');
     }
 
@@ -29,9 +29,9 @@ void main() {
 
   test('testInvalidGeneratorOptions', () {
     checkInvalid(String parameter) {
-      var request = new CodeGeneratorRequest();
+      var request = CodeGeneratorRequest();
       if (parameter != null) request.parameter = parameter;
-      var response = new CodeGeneratorResponse();
+      var response = CodeGeneratorResponse();
       var options = parseGenerationOptions(request, response);
       expect(options, isNull);
     }

--- a/protoc_plugin/test/repeated_field_test.dart
+++ b/protoc_plugin/test/repeated_field_test.dart
@@ -15,7 +15,7 @@ cast(x) => x;
 
 void main() {
   test("check properties are initialized for repeated fields", () {
-    var msg = new TestAllTypes();
+    var msg = TestAllTypes();
     expect(
         (msg.info_.byName["repeatedNestedMessage"]
                 as FieldInfo<TestAllTypes_NestedMessage>)

--- a/protoc_plugin/test/service_generator_test.dart
+++ b/protoc_plugin/test/service_generator_test.dart
@@ -14,19 +14,19 @@ import 'golden_file.dart';
 
 void main() {
   test('testServiceGenerator', () {
-    var options = new GenerationOptions();
+    var options = GenerationOptions();
     var fd = buildFileDescriptor(
         "testpkg", "testpkg.proto", ["SomeRequest", "SomeReply"]);
     fd.service.add(buildServiceDescriptor());
-    var fg = new FileGenerator(fd, options);
+    var fg = FileGenerator(fd, options);
 
     var fd2 = buildFileDescriptor(
         "foo.bar", "foobar.proto", ["EmptyMessage", "AnotherReply"]);
-    var fg2 = new FileGenerator(fd2, options);
+    var fg2 = FileGenerator(fd2, options);
 
-    link(new GenerationOptions(), [fg, fg2]);
+    link(GenerationOptions(), [fg, fg2]);
 
-    var serviceWriter = new IndentingWriter();
+    var serviceWriter = IndentingWriter();
     fg.serviceGenerators[0].generate(serviceWriter);
     expectMatchesGoldenFile(
         serviceWriter.toString(), 'test/goldens/serviceGenerator');

--- a/protoc_plugin/test/service_test.dart
+++ b/protoc_plugin/test/service_test.dart
@@ -91,8 +91,7 @@ void main() {
   });
 
   test('can read service descriptor from JSON', () {
-    var descriptor = ServiceDescriptorProto()
-      ..mergeFromJsonMap(service.$json);
+    var descriptor = ServiceDescriptorProto()..mergeFromJsonMap(service.$json);
     expect(descriptor.name, "SearchService");
     var methodNames = descriptor.method.map((m) => m.name).toList();
     expect(methodNames, ["Search", "Search2"]);

--- a/protoc_plugin/test/service_test.dart
+++ b/protoc_plugin/test/service_test.dart
@@ -14,7 +14,7 @@ import '../out/protos/service3.pb.dart' as pb3;
 class SearchService extends pb.SearchServiceBase {
   Future<pb.SearchResponse> search(
       ServerContext ctx, pb.SearchRequest request) async {
-    var out = new pb.SearchResponse();
+    var out = pb.SearchResponse();
     if (request.query == 'hello' || request.query == 'world') {
       out.result.add('hello, world!');
     }
@@ -23,9 +23,9 @@ class SearchService extends pb.SearchServiceBase {
 
   Future<pb2.SearchResponse> search2(
       ServerContext ctx, pb2.SearchRequest request) async {
-    var out = new pb2.SearchResponse();
+    var out = pb2.SearchResponse();
     if (request.query == '2') {
-      var result = new pb3.SearchResult()
+      var result = pb3.SearchResult()
         ..url = 'http://example.com/'
         ..snippet = 'hello world (2)!';
       out.results.add(result);
@@ -43,7 +43,7 @@ class FakeJsonServer {
     if (serviceName == 'SearchService') {
       GeneratedMessage request = searchService.createRequest(methodName);
       request.mergeFromJson(requestJson);
-      var ctx = new ServerContext();
+      var ctx = ServerContext();
       var reply = await searchService.handleCall(ctx, methodName, request);
       return reply.writeToJson();
     } else {
@@ -72,26 +72,26 @@ class FakeJsonClient implements RpcClient {
 }
 
 void main() {
-  var service = new SearchService();
-  var server = new FakeJsonServer(service);
-  var api = new pb.SearchServiceApi(new FakeJsonClient(server));
+  var service = SearchService();
+  var server = FakeJsonServer(service);
+  var api = pb.SearchServiceApi(FakeJsonClient(server));
 
   test('end to end RPC using JSON', () async {
-    var request = new pb.SearchRequest()..query = 'hello';
-    var reply = await api.search(new ClientContext(), request);
+    var request = pb.SearchRequest()..query = 'hello';
+    var reply = await api.search(ClientContext(), request);
     expect(reply.result, ['hello, world!']);
   });
 
   test('end to end RPC using message from a different package', () async {
-    var request = new pb2.SearchRequest()..query = "2";
-    var reply = await api.search2(new ClientContext(), request);
+    var request = pb2.SearchRequest()..query = "2";
+    var reply = await api.search2(ClientContext(), request);
     expect(reply.results.length, 1);
     expect(reply.results[0].url, 'http://example.com/');
     expect(reply.results[0].snippet, 'hello world (2)!');
   });
 
   test('can read service descriptor from JSON', () {
-    var descriptor = new ServiceDescriptorProto()
+    var descriptor = ServiceDescriptorProto()
       ..mergeFromJsonMap(service.$json);
     expect(descriptor.name, "SearchService");
     var methodNames = descriptor.method.map((m) => m.name).toList();
@@ -110,7 +110,7 @@ void main() {
 
     String readMessageName(fqname) {
       var json = map[fqname];
-      var descriptor = new DescriptorProto()..mergeFromJsonMap(json);
+      var descriptor = DescriptorProto()..mergeFromJsonMap(json);
       return descriptor.name;
     }
 

--- a/protoc_plugin/test/service_util.dart
+++ b/protoc_plugin/test/service_util.dart
@@ -7,14 +7,14 @@ library service_util;
 import 'package:protoc_plugin/src/descriptor.pb.dart';
 
 ServiceDescriptorProto buildServiceDescriptor() {
-  ServiceDescriptorProto sd = new ServiceDescriptorProto()
+  ServiceDescriptorProto sd = ServiceDescriptorProto()
     ..name = 'Test'
     ..method.addAll([
-      new MethodDescriptorProto()
+      MethodDescriptorProto()
         ..name = 'AMethod'
         ..inputType = '.testpkg.SomeRequest'
         ..outputType = '.testpkg.SomeReply',
-      new MethodDescriptorProto()
+      MethodDescriptorProto()
         ..name = 'AnotherMethod'
         ..inputType = '.foo.bar.EmptyMessage'
         ..outputType = '.foo.bar.AnotherReply',
@@ -24,11 +24,11 @@ ServiceDescriptorProto buildServiceDescriptor() {
 
 FileDescriptorProto buildFileDescriptor(
     String package, String fileUri, List<String> messages) {
-  var fd = new FileDescriptorProto()
+  var fd = FileDescriptorProto()
     ..package = package
     ..name = fileUri;
   for (var name in messages) {
-    var md = new DescriptorProto()..name = name;
+    var md = DescriptorProto()..name = name;
 
     fd.messageType.add(md);
   }

--- a/protoc_plugin/test/test_util.dart
+++ b/protoc_plugin/test/test_util.dart
@@ -11,11 +11,11 @@ import 'package:test/test.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/google/protobuf/unittest_import.pb.dart';
 
-final Matcher throwsATypeError = throwsA(new TypeMatcher<TypeError>());
+final Matcher throwsATypeError = throwsA(TypeMatcher<TypeError>());
 
 Int64 make64(int lo, [int hi]) {
   if (hi == null) hi = lo < 0 ? -1 : 0;
-  return new Int64.fromInts(hi, lo);
+  return Int64.fromInts(hi, lo);
 }
 
 expect64(int lo, [int hi]) {
@@ -1271,7 +1271,7 @@ void assertUnpackedFieldsSet(TestUnpackedTypes message) {
 }
 
 TestAllExtensions getAllExtensionsSet() {
-  TestAllExtensions message = new TestAllExtensions();
+  TestAllExtensions message = TestAllExtensions();
   setAllExtensions(message);
   return message;
 }
@@ -1281,31 +1281,31 @@ TestAllExtensions getAllExtensionsSet() {
  * be by [setAllFields(TestAllTypes)].
  */
 TestAllTypes getAllSet() {
-  TestAllTypes message = new TestAllTypes();
+  TestAllTypes message = TestAllTypes();
   setAllFields(message);
   return message;
 }
 
 ExtensionRegistry getExtensionRegistry() {
-  ExtensionRegistry registry = new ExtensionRegistry();
+  ExtensionRegistry registry = ExtensionRegistry();
   registerAllExtensions(registry);
   return registry /*.getUnmodifiable()*/;
 }
 
 TestPackedExtensions getPackedExtensionsSet() {
-  TestPackedExtensions message = new TestPackedExtensions();
+  TestPackedExtensions message = TestPackedExtensions();
   setPackedExtensions(message);
   return message;
 }
 
 TestPackedTypes getPackedSet() {
-  TestPackedTypes message = new TestPackedTypes();
+  TestPackedTypes message = TestPackedTypes();
   setPackedFields(message);
   return message;
 }
 
 TestUnpackedTypes getUnpackedSet() {
-  TestUnpackedTypes message = new TestUnpackedTypes();
+  TestUnpackedTypes message = TestUnpackedTypes();
   setUnpackedFields(message);
   return message;
 }
@@ -1329,19 +1329,19 @@ void modifyRepeatedExtensions(TestAllExtensions message) {
 
   var msg;
 
-  msg = new RepeatedGroup_extension();
+  msg = RepeatedGroup_extension();
   msg.a = 517;
   message.getExtension(Unittest.repeatedGroupExtension)[1] = msg;
 
-  msg = new TestAllTypes_NestedMessage();
+  msg = TestAllTypes_NestedMessage();
   msg.bb = 518;
   message.getExtension(Unittest.repeatedNestedMessageExtension)[1] = msg;
 
-  msg = new ForeignMessage();
+  msg = ForeignMessage();
   msg.c = 519;
   message.getExtension(Unittest.repeatedForeignMessageExtension)[1] = msg;
 
-  msg = new ImportMessage();
+  msg = ImportMessage();
   msg.d = 520;
   message.getExtension(Unittest.repeatedImportMessageExtension)[1] = msg;
 
@@ -1377,20 +1377,20 @@ void modifyRepeatedFields(TestAllTypes message) {
   message.repeatedString[1] = '515';
   message.repeatedBytes[1] = '516'.codeUnits;
 
-  TestAllTypes_RepeatedGroup repeatedGroup = new TestAllTypes_RepeatedGroup();
+  TestAllTypes_RepeatedGroup repeatedGroup = TestAllTypes_RepeatedGroup();
   repeatedGroup.a = 517;
   message.repeatedGroup[1] = repeatedGroup;
 
   TestAllTypes_NestedMessage optionalNestedMessage =
-      new TestAllTypes_NestedMessage();
+      TestAllTypes_NestedMessage();
   optionalNestedMessage.bb = 518;
   message.repeatedNestedMessage[1] = optionalNestedMessage;
 
-  ForeignMessage optionalForeignMessage = new ForeignMessage();
+  ForeignMessage optionalForeignMessage = ForeignMessage();
   optionalForeignMessage.c = 519;
   message.repeatedForeignMessage[1] = optionalForeignMessage;
 
-  ImportMessage optionalImportMessage = new ImportMessage();
+  ImportMessage optionalImportMessage = ImportMessage();
   optionalImportMessage.d = 520;
   message.repeatedImportMessage[1] = optionalImportMessage;
 
@@ -1425,19 +1425,19 @@ void setAllExtensions(TestAllExtensions message) {
 
   var msg;
 
-  msg = new OptionalGroup_extension();
+  msg = OptionalGroup_extension();
   msg.a = 117;
   message.setExtension(Unittest.optionalGroupExtension, msg);
 
-  msg = new TestAllTypes_NestedMessage();
+  msg = TestAllTypes_NestedMessage();
   msg.bb = 118;
   message.setExtension(Unittest.optionalNestedMessageExtension, msg);
 
-  msg = new ForeignMessage();
+  msg = ForeignMessage();
   msg.c = 119;
   message.setExtension(Unittest.optionalForeignMessageExtension, msg);
 
-  msg = new ImportMessage();
+  msg = ImportMessage();
   msg.d = 120;
   message.setExtension(Unittest.optionalImportMessageExtension, msg);
 
@@ -1469,19 +1469,19 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '215');
   message.addExtension(Unittest.repeatedBytesExtension, '216'.codeUnits);
 
-  msg = new RepeatedGroup_extension();
+  msg = RepeatedGroup_extension();
   msg.a = 217;
   message.addExtension(Unittest.repeatedGroupExtension, msg);
 
-  msg = new TestAllTypes_NestedMessage();
+  msg = TestAllTypes_NestedMessage();
   msg.bb = 218;
   message.addExtension(Unittest.repeatedNestedMessageExtension, msg);
 
-  msg = new ForeignMessage();
+  msg = ForeignMessage();
   msg.c = 219;
   message.addExtension(Unittest.repeatedForeignMessageExtension, msg);
 
-  msg = new ImportMessage();
+  msg = ImportMessage();
   msg.d = 220;
   message.addExtension(Unittest.repeatedImportMessageExtension, msg);
 
@@ -1512,19 +1512,19 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '315');
   message.addExtension(Unittest.repeatedBytesExtension, '316'.codeUnits);
 
-  msg = new RepeatedGroup_extension();
+  msg = RepeatedGroup_extension();
   msg.a = 317;
   message.addExtension(Unittest.repeatedGroupExtension, msg);
 
-  msg = new TestAllTypes_NestedMessage();
+  msg = TestAllTypes_NestedMessage();
   msg.bb = 318;
   message.addExtension(Unittest.repeatedNestedMessageExtension, msg);
 
-  msg = new ForeignMessage();
+  msg = ForeignMessage();
   msg.c = 319;
   message.addExtension(Unittest.repeatedForeignMessageExtension, msg);
 
-  msg = new ImportMessage();
+  msg = ImportMessage();
   msg.d = 320;
   message.addExtension(Unittest.repeatedImportMessageExtension, msg);
 
@@ -1588,20 +1588,20 @@ void setAllFields(TestAllTypes message) {
   message.optionalString = '115';
   message.optionalBytes = '116'.codeUnits;
 
-  TestAllTypes_OptionalGroup optionalGroup = new TestAllTypes_OptionalGroup();
+  TestAllTypes_OptionalGroup optionalGroup = TestAllTypes_OptionalGroup();
   optionalGroup.a = 117;
   message.optionalGroup = optionalGroup;
 
   TestAllTypes_NestedMessage optionalNestedMessage =
-      new TestAllTypes_NestedMessage();
+      TestAllTypes_NestedMessage();
   optionalNestedMessage.bb = 118;
   message.optionalNestedMessage = optionalNestedMessage;
 
-  ForeignMessage optionalForeignMessage = new ForeignMessage();
+  ForeignMessage optionalForeignMessage = ForeignMessage();
   optionalForeignMessage.c = 119;
   message.optionalForeignMessage = optionalForeignMessage;
 
-  ImportMessage optionalImportMessage = new ImportMessage();
+  ImportMessage optionalImportMessage = ImportMessage();
   optionalImportMessage.d = 120;
   message.optionalImportMessage = optionalImportMessage;
 
@@ -1630,19 +1630,19 @@ void setAllFields(TestAllTypes message) {
   message.repeatedString.add('215');
   message.repeatedBytes.add('216'.codeUnits);
 
-  TestAllTypes_RepeatedGroup repeatedGroup = new TestAllTypes_RepeatedGroup();
+  TestAllTypes_RepeatedGroup repeatedGroup = TestAllTypes_RepeatedGroup();
   repeatedGroup.a = 217;
   message.repeatedGroup.add(repeatedGroup);
 
-  TestAllTypes_NestedMessage repeatedNested = new TestAllTypes_NestedMessage();
+  TestAllTypes_NestedMessage repeatedNested = TestAllTypes_NestedMessage();
   repeatedNested.bb = 218;
   message.repeatedNestedMessage.add(repeatedNested);
 
-  ForeignMessage repeatedForeignMessage = new ForeignMessage();
+  ForeignMessage repeatedForeignMessage = ForeignMessage();
   repeatedForeignMessage.c = 219;
   message.repeatedForeignMessage.add(repeatedForeignMessage);
 
-  ImportMessage repeatedImportMessage = new ImportMessage();
+  ImportMessage repeatedImportMessage = ImportMessage();
   repeatedImportMessage.d = 220;
   message.repeatedImportMessage.add(repeatedImportMessage);
 
@@ -1670,19 +1670,19 @@ void setAllFields(TestAllTypes message) {
   message.repeatedString.add('315');
   message.repeatedBytes.add('316'.codeUnits);
 
-  repeatedGroup = new TestAllTypes_RepeatedGroup();
+  repeatedGroup = TestAllTypes_RepeatedGroup();
   repeatedGroup.a = 317;
   message.repeatedGroup.add(repeatedGroup);
 
-  repeatedNested = new TestAllTypes_NestedMessage();
+  repeatedNested = TestAllTypes_NestedMessage();
   repeatedNested.bb = 318;
   message.repeatedNestedMessage.add(repeatedNested);
 
-  repeatedForeignMessage = new ForeignMessage();
+  repeatedForeignMessage = ForeignMessage();
   repeatedForeignMessage.c = 319;
   message.repeatedForeignMessage.add(repeatedForeignMessage);
 
-  repeatedImportMessage = new ImportMessage();
+  repeatedImportMessage = ImportMessage();
   repeatedImportMessage.d = 320;
   message.repeatedImportMessage.add(repeatedImportMessage);
 

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -9,14 +9,14 @@ import '../out/protos/google/protobuf/timestamp.pb.dart';
 
 void main() {
   test('timestamp -> datetime -> timestamp', () {
-    Timestamp timestamp = new Timestamp()
-      ..seconds = new Int64(1550225928)
+    Timestamp timestamp = Timestamp()
+      ..seconds = Int64(1550225928)
       ..nanos = 12345000;
     expect(Timestamp.fromDateTime(timestamp.toDateTime()), timestamp);
   });
 
   test('utc datetime -> timestamp -> datetime', () {
-    DateTime dateTime = new DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
+    DateTime dateTime = DateTime.utc(2019, 02, 15, 10, 21, 25, 5, 5);
     DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
     expect(fromProto.isUtc, true, reason: "$fromProto is not a UTC time.");
@@ -24,7 +24,7 @@ void main() {
   });
 
   test('local datetime -> timestamp -> datetime', () {
-    DateTime dateTime = new DateTime(2019, 02, 15, 10, 21, 25, 5, 5);
+    DateTime dateTime = DateTime(2019, 02, 15, 10, 21, 25, 5, 5);
     DateTime fromProto = Timestamp.fromDateTime(dateTime).toDateTime();
 
     expect(fromProto.isUtc, true, reason: "$fromProto is not a UTC time.");

--- a/protoc_plugin/test/unknown_field_set_test.dart
+++ b/protoc_plugin/test/unknown_field_set_test.dart
@@ -16,7 +16,7 @@ void main() {
   TestAllTypes testAllTypes = getAllSet();
   List<int> allFieldsData = testAllTypes.writeToBuffer();
   TestEmptyMessage emptyMessage =
-      new TestEmptyMessage.fromBuffer(allFieldsData);
+      TestEmptyMessage.fromBuffer(allFieldsData);
   UnknownFieldSet unknownFields = emptyMessage.unknownFields;
 
   UnknownFieldSetField getField(String name) {
@@ -77,7 +77,7 @@ void main() {
   });
 
   test('testGroup', () {
-    int tagNumberA = new TestAllTypes_OptionalGroup().getTagNumber('a');
+    int tagNumberA = TestAllTypes_OptionalGroup().getTagNumber('a');
     expect(tagNumberA != null, isTrue);
 
     UnknownFieldSetField optionalGroupField = getField('optionalGroup');
@@ -100,19 +100,19 @@ void main() {
 
   test('testMergeFrom', () {
     // Source.
-    UnknownFieldSet sourceFieldSet = new UnknownFieldSet()
-      ..addField(2, new UnknownFieldSetField()..addVarint(make64(2)))
-      ..addField(3, new UnknownFieldSetField()..addVarint(make64(3)));
+    UnknownFieldSet sourceFieldSet = UnknownFieldSet()
+      ..addField(2, UnknownFieldSetField()..addVarint(make64(2)))
+      ..addField(3, UnknownFieldSetField()..addVarint(make64(3)));
 
-    TestEmptyMessage source = new TestEmptyMessage()
+    TestEmptyMessage source = TestEmptyMessage()
       ..mergeUnknownFields(sourceFieldSet);
 
     // Destination.
-    UnknownFieldSet destinationFieldSet = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addVarint(make64(1)))
-      ..addField(3, new UnknownFieldSetField()..addVarint(make64(4)));
+    UnknownFieldSet destinationFieldSet = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addVarint(make64(1)))
+      ..addField(3, UnknownFieldSetField()..addVarint(make64(4)));
 
-    TestEmptyMessage destination = new TestEmptyMessage()
+    TestEmptyMessage destination = TestEmptyMessage()
       ..mergeUnknownFields(destinationFieldSet)
       ..mergeFromMessage(source);
 
@@ -130,7 +130,7 @@ void main() {
   });
 
   test('testEmpty', () {
-    expect(new UnknownFieldSet().asMap(), isEmpty);
+    expect(UnknownFieldSet().asMap(), isEmpty);
   });
 
   test('testClearMessage', () {
@@ -142,12 +142,12 @@ void main() {
   test('testParseKnownAndUnknown', () {
     // Test mixing known and unknown fields when parsing.
     UnknownFieldSet fields = unknownFields.clone()
-      ..addField(123456, new UnknownFieldSetField()..addVarint(make64(654321)));
+      ..addField(123456, UnknownFieldSetField()..addVarint(make64(654321)));
 
-    CodedBufferWriter writer = new CodedBufferWriter();
+    CodedBufferWriter writer = CodedBufferWriter();
     fields.writeToCodedBufferWriter(writer);
 
-    TestAllTypes destination = new TestAllTypes.fromBuffer(writer.toBuffer());
+    TestAllTypes destination = TestAllTypes.fromBuffer(writer.toBuffer());
 
     assertAllFieldsSet(destination);
     expect(destination.unknownFields.asMap().length, 1);
@@ -161,12 +161,12 @@ void main() {
   // numbers as allFieldsData except that each field is some other wire
   // type.
   List<int> getBizarroData() {
-    UnknownFieldSet bizarroFields = new UnknownFieldSet();
+    UnknownFieldSet bizarroFields = UnknownFieldSet();
 
-    UnknownFieldSetField varintField = new UnknownFieldSetField()
+    UnknownFieldSetField varintField = UnknownFieldSetField()
       ..addVarint(make64(1));
 
-    UnknownFieldSetField fixed32Field = new UnknownFieldSetField()
+    UnknownFieldSetField fixed32Field = UnknownFieldSetField()
       ..addFixed32(1);
 
     unknownFields.asMap().forEach((int tag, UnknownFieldSetField value) {
@@ -178,7 +178,7 @@ void main() {
         bizarroFields.addField(tag, fixed32Field);
       }
     });
-    CodedBufferWriter writer = new CodedBufferWriter();
+    CodedBufferWriter writer = CodedBufferWriter();
     bizarroFields.writeToCodedBufferWriter(writer);
     return writer.toBuffer();
   }
@@ -187,9 +187,9 @@ void main() {
     // Test that fields of the wrong wire type are treated like unknown fields
     // when parsing.
     List<int> bizarroData = getBizarroData();
-    TestAllTypes allTypesMessage = new TestAllTypes.fromBuffer(bizarroData);
+    TestAllTypes allTypesMessage = TestAllTypes.fromBuffer(bizarroData);
     TestEmptyMessage emptyMessage_ =
-        new TestEmptyMessage.fromBuffer(bizarroData);
+        TestEmptyMessage.fromBuffer(bizarroData);
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
     expect(allTypesMessage.toString(), emptyMessage_.toString());
@@ -199,7 +199,7 @@ void main() {
     // Make sure fields are properly parsed to the UnknownFieldSet even when
     // they are declared as extension numbers.
     TestEmptyMessageWithExtensions message =
-        new TestEmptyMessageWithExtensions.fromBuffer(allFieldsData);
+        TestEmptyMessageWithExtensions.fromBuffer(allFieldsData);
 
     expect(message.unknownFields.asMap().length, unknownFields.asMap().length);
     expect(message.writeToBuffer(), allFieldsData);
@@ -211,9 +211,9 @@ void main() {
 
     List<int> bizarroData = getBizarroData();
     TestAllExtensions allExtensionsMessage =
-        new TestAllExtensions.fromBuffer(bizarroData);
+        TestAllExtensions.fromBuffer(bizarroData);
     TestEmptyMessage emptyMessage_ =
-        new TestEmptyMessage.fromBuffer(bizarroData);
+        TestEmptyMessage.fromBuffer(bizarroData);
 
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
@@ -226,24 +226,24 @@ void main() {
     expect(singularFieldNum, isNotNull);
     expect(repeatedFieldNum, isNotNull);
 
-    UnknownFieldSet fieldSet = new UnknownFieldSet()
+    UnknownFieldSet fieldSet = UnknownFieldSet()
       ..addField(
           singularFieldNum,
-          new UnknownFieldSetField()
+          UnknownFieldSetField()
             ..addVarint(make64(TestAllTypes_NestedEnum.BAR.value))
             ..addVarint(make64(5)))
       ..addField(
           repeatedFieldNum,
-          new UnknownFieldSetField()
+          UnknownFieldSetField()
             ..addVarint(make64(TestAllTypes_NestedEnum.FOO.value))
             ..addVarint(make64(4))
             ..addVarint(make64(TestAllTypes_NestedEnum.BAZ.value))
             ..addVarint(make64(6)));
 
-    CodedBufferWriter writer = new CodedBufferWriter();
+    CodedBufferWriter writer = CodedBufferWriter();
     fieldSet.writeToCodedBufferWriter(writer);
     {
-      TestAllTypes message = new TestAllTypes.fromBuffer(writer.toBuffer());
+      TestAllTypes message = TestAllTypes.fromBuffer(writer.toBuffer());
       expect(message.optionalNestedEnum, TestAllTypes_NestedEnum.BAR);
       expect(message.repeatedNestedEnum,
           [TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAZ]);
@@ -258,7 +258,7 @@ void main() {
       expect(repeatedVarints[1], expect64(6));
     }
     {
-      TestAllExtensions message = new TestAllExtensions.fromBuffer(
+      TestAllExtensions message = TestAllExtensions.fromBuffer(
           writer.toBuffer(), getExtensionRegistry());
       expect(message.getExtension(Unittest.optionalNestedEnumExtension),
           TestAllTypes_NestedEnum.BAR);
@@ -278,36 +278,36 @@ void main() {
   });
 
   test('testLargeVarint', () {
-    UnknownFieldSet unknownFieldSet = new UnknownFieldSet()
+    UnknownFieldSet unknownFieldSet = UnknownFieldSet()
       ..addField(
           1,
-          new UnknownFieldSetField()
+          UnknownFieldSetField()
             ..addVarint(make64(0x7FFFFFFF, 0xFFFFFFFF)));
-    CodedBufferWriter writer = new CodedBufferWriter();
+    CodedBufferWriter writer = CodedBufferWriter();
     unknownFieldSet.writeToCodedBufferWriter(writer);
 
-    var parsed = new UnknownFieldSet()
-      ..mergeFromCodedBufferReader(new CodedBufferReader(writer.toBuffer()));
+    var parsed = UnknownFieldSet()
+      ..mergeFromCodedBufferReader(CodedBufferReader(writer.toBuffer()));
     var field = parsed.getField(1);
     expect(field.varints.length, 1);
     expect(field.varints[0], expect64(0x7FFFFFFF, 0xFFFFFFFFF));
   });
 
   test('testEquals', () {
-    UnknownFieldSet a = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addFixed32(1));
+    UnknownFieldSet a = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addFixed32(1));
 
-    UnknownFieldSet b = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addFixed64(make64(1)));
+    UnknownFieldSet b = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addFixed64(make64(1)));
 
-    UnknownFieldSet c = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addVarint(make64(1)));
+    UnknownFieldSet c = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addVarint(make64(1)));
 
-    UnknownFieldSet d = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addLengthDelimited([]));
+    UnknownFieldSet d = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addLengthDelimited([]));
 
-    UnknownFieldSet e = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addGroup(unknownFields));
+    UnknownFieldSet e = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addGroup(unknownFields));
 
     _checkEqualsIsConsistent(a);
     _checkEqualsIsConsistent(b);
@@ -326,10 +326,10 @@ void main() {
     _checkNotEqual(c, e);
     _checkNotEqual(d, e);
 
-    UnknownFieldSet f1 = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addLengthDelimited([1, 2]));
-    UnknownFieldSet f2 = new UnknownFieldSet()
-      ..addField(1, new UnknownFieldSetField()..addLengthDelimited([2, 1]));
+    UnknownFieldSet f1 = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addLengthDelimited([1, 2]));
+    UnknownFieldSet f2 = UnknownFieldSet()
+      ..addField(1, UnknownFieldSetField()..addLengthDelimited([2, 1]));
 
     _checkEqualsIsConsistent(f1);
     _checkEqualsIsConsistent(f2);

--- a/protoc_plugin/test/unknown_field_set_test.dart
+++ b/protoc_plugin/test/unknown_field_set_test.dart
@@ -15,8 +15,7 @@ import 'test_util.dart';
 void main() {
   TestAllTypes testAllTypes = getAllSet();
   List<int> allFieldsData = testAllTypes.writeToBuffer();
-  TestEmptyMessage emptyMessage =
-      TestEmptyMessage.fromBuffer(allFieldsData);
+  TestEmptyMessage emptyMessage = TestEmptyMessage.fromBuffer(allFieldsData);
   UnknownFieldSet unknownFields = emptyMessage.unknownFields;
 
   UnknownFieldSetField getField(String name) {
@@ -166,8 +165,7 @@ void main() {
     UnknownFieldSetField varintField = UnknownFieldSetField()
       ..addVarint(make64(1));
 
-    UnknownFieldSetField fixed32Field = UnknownFieldSetField()
-      ..addFixed32(1);
+    UnknownFieldSetField fixed32Field = UnknownFieldSetField()..addFixed32(1);
 
     unknownFields.asMap().forEach((int tag, UnknownFieldSetField value) {
       if (value.varints.isEmpty) {
@@ -188,8 +186,7 @@ void main() {
     // when parsing.
     List<int> bizarroData = getBizarroData();
     TestAllTypes allTypesMessage = TestAllTypes.fromBuffer(bizarroData);
-    TestEmptyMessage emptyMessage_ =
-        TestEmptyMessage.fromBuffer(bizarroData);
+    TestEmptyMessage emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
     expect(allTypesMessage.toString(), emptyMessage_.toString());
@@ -212,8 +209,7 @@ void main() {
     List<int> bizarroData = getBizarroData();
     TestAllExtensions allExtensionsMessage =
         TestAllExtensions.fromBuffer(bizarroData);
-    TestEmptyMessage emptyMessage_ =
-        TestEmptyMessage.fromBuffer(bizarroData);
+    TestEmptyMessage emptyMessage_ = TestEmptyMessage.fromBuffer(bizarroData);
 
     // All fields should have been interpreted as unknown, so the debug strings
     // should be the same.
@@ -280,9 +276,7 @@ void main() {
   test('testLargeVarint', () {
     UnknownFieldSet unknownFieldSet = UnknownFieldSet()
       ..addField(
-          1,
-          UnknownFieldSetField()
-            ..addVarint(make64(0x7FFFFFFF, 0xFFFFFFFF)));
+          1, UnknownFieldSetField()..addVarint(make64(0x7FFFFFFF, 0xFFFFFFFF)));
     CodedBufferWriter writer = CodedBufferWriter();
     unknownFieldSet.writeToCodedBufferWriter(writer);
 

--- a/protoc_plugin/test/validate_fail_test.dart
+++ b/protoc_plugin/test/validate_fail_test.dart
@@ -19,7 +19,7 @@ cast(x) => x;
 
 void main() {
   test('testValidationFailureMessages', () {
-    TestAllTypes builder = new TestAllTypes();
+    TestAllTypes builder = TestAllTypes();
 
     expect(() {
       builder.optionalInt32 = null;
@@ -171,7 +171,7 @@ void main() {
     }, throwsArgumentError);
 
     expect(() {
-      new TestAllExtensions()
+      TestAllExtensions()
           .setExtension(Unittest.optionalInt32Extension, '101');
     }, throwsArgumentError);
   });

--- a/protoc_plugin/test/validate_fail_test.dart
+++ b/protoc_plugin/test/validate_fail_test.dart
@@ -171,8 +171,7 @@ void main() {
     }, throwsArgumentError);
 
     expect(() {
-      TestAllExtensions()
-          .setExtension(Unittest.optionalInt32Extension, '101');
+      TestAllExtensions().setExtension(Unittest.optionalInt32Extension, '101');
     }, throwsArgumentError);
   });
 }

--- a/protoc_plugin/test/wire_format_test.dart
+++ b/protoc_plugin/test/wire_format_test.dart
@@ -15,17 +15,17 @@ import 'test_util.dart';
 void main() {
   test('testSerialization', () {
     assertAllFieldsSet(
-        new TestAllTypes.fromBuffer(getAllSet().writeToBuffer()));
+        TestAllTypes.fromBuffer(getAllSet().writeToBuffer()));
   });
 
   test('testSerializationPacked', () {
     assertPackedFieldsSet(
-        new TestPackedTypes.fromBuffer(getPackedSet().writeToBuffer()));
+        TestPackedTypes.fromBuffer(getPackedSet().writeToBuffer()));
   });
 
   test('testSerializeExtensions', () {
     assertAllFieldsSet(
-        new TestAllTypes.fromBuffer(getAllExtensionsSet().writeToBuffer()));
+        TestAllTypes.fromBuffer(getAllExtensionsSet().writeToBuffer()));
   });
 
   test('testSerializePackedExtensions', () {
@@ -41,7 +41,7 @@ void main() {
     ExtensionRegistry registry = getExtensionRegistry();
 
     assertAllExtensionsSet(
-        new TestAllExtensions.fromBuffer(rawBytes, registry));
+        TestAllExtensions.fromBuffer(rawBytes, registry));
   });
 
   test('testParsePackedExtensions', () {
@@ -50,7 +50,7 @@ void main() {
     ExtensionRegistry registry = getExtensionRegistry();
 
     assertPackedExtensionsSet(
-        new TestPackedExtensions.fromBuffer(rawBytes, registry));
+        TestPackedExtensions.fromBuffer(rawBytes, registry));
   });
 
   test('testExtensionsSerialized', () {
@@ -60,19 +60,19 @@ void main() {
   test('testParseMultipleExtensionRanges', () {
     // Make sure we can parse a message that contains multiple extensions
     // ranges.
-    TestFieldOrderings source = new TestFieldOrderings()
+    TestFieldOrderings source = TestFieldOrderings()
       ..myInt = make64(1)
       ..myString = 'foo'
       ..myFloat = 1.0
       ..setExtension(Unittest.myExtensionInt, 23)
       ..setExtension(Unittest.myExtensionString, 'bar');
 
-    ExtensionRegistry registry = new ExtensionRegistry()
+    ExtensionRegistry registry = ExtensionRegistry()
       ..add(Unittest.myExtensionInt)
       ..add(Unittest.myExtensionString);
 
     TestFieldOrderings dest =
-        new TestFieldOrderings.fromBuffer(source.writeToBuffer(), registry);
+        TestFieldOrderings.fromBuffer(source.writeToBuffer(), registry);
 
     expect(dest, source);
   });

--- a/protoc_plugin/test/wire_format_test.dart
+++ b/protoc_plugin/test/wire_format_test.dart
@@ -14,8 +14,7 @@ import 'test_util.dart';
 
 void main() {
   test('testSerialization', () {
-    assertAllFieldsSet(
-        TestAllTypes.fromBuffer(getAllSet().writeToBuffer()));
+    assertAllFieldsSet(TestAllTypes.fromBuffer(getAllSet().writeToBuffer()));
   });
 
   test('testSerializationPacked', () {
@@ -40,8 +39,7 @@ void main() {
     List<int> rawBytes = getAllSet().writeToBuffer();
     ExtensionRegistry registry = getExtensionRegistry();
 
-    assertAllExtensionsSet(
-        TestAllExtensions.fromBuffer(rawBytes, registry));
+    assertAllExtensionsSet(TestAllExtensions.fromBuffer(rawBytes, registry));
   });
 
   test('testParsePackedExtensions', () {

--- a/query_benchmark/lib/readfile_d8.dart
+++ b/query_benchmark/lib/readfile_d8.dart
@@ -12,8 +12,8 @@ Uint8List readfile(String path) {
   js.JsObject jsArrayBuffer = js.context.callMethod('readbuffer', [path]);
   int length = jsArrayBuffer['byteLength'];
   js.JsObject jsInt8View =
-      new js.JsObject(js.context['Int8Array'], [jsArrayBuffer]);
-  Uint8List result = new Uint8List(length);
+      js.JsObject(js.context['Int8Array'], [jsArrayBuffer]);
+  Uint8List result = Uint8List(length);
   for (int i = 0; i < length; i++) {
     result[i] = jsInt8View[i];
   }

--- a/query_benchmark/lib/readfile_vm.dart
+++ b/query_benchmark/lib/readfile_vm.dart
@@ -5,5 +5,5 @@
 import 'dart:io';
 
 List<int> readfile(String path) {
-  return new File(path).readAsBytesSync();
+  return File(path).readAsBytesSync();
 }


### PR DESCRIPTION
I also added this as a lint check for protoc_plugin because the easiest
thing to fix this was to run a sed -i 's/new //g' on all files.

I checked it manually but worst case scenario there's a missing "new"
word on a comment.

Fixes one of the warnings from #135