### PR TITLE
Fix JSON serialization of unsigned 64-bit fields.

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.8
+
+* Fix JSON serialization of unsigned 64-bit fields.
+
 ## 0.13.7
 
 * Override `operator ==` and `hashCode` in `PbMap` so that two `PbMap`s are equal if they have equal key/value pairs.

--- a/protobuf/lib/src/protobuf/json.dart
+++ b/protobuf/lib/src/protobuf/json.dart
@@ -30,10 +30,11 @@ Map<String, dynamic> _writeToJsonMap(_FieldSet fs) {
         return fieldValue.value; // assume |value| < 2^52
       case PbFieldType._INT64_BIT:
       case PbFieldType._SINT64_BIT:
-      case PbFieldType._UINT64_BIT:
-      case PbFieldType._FIXED64_BIT:
       case PbFieldType._SFIXED64_BIT:
         return fieldValue.toString();
+      case PbFieldType._UINT64_BIT:
+      case PbFieldType._FIXED64_BIT:
+        return fieldValue.toStringUnsigned();
       case PbFieldType._GROUP_BIT:
       case PbFieldType._MESSAGE_BIT:
         return fieldValue.writeToJsonMap();

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://github.com/dart-lang/protobuf
 environment:
   sdk: '>=2.0.0-dev.17.0 <3.0.0'
 dependencies:
-  fixnum: '>=0.10.9 <0.11.0'
+  fixnum: ^0.10.9
 dev_dependencies:
   test: '>=1.2.0'
   benchmark_harness: any

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.13.7
+version: 0.13.8
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.
@@ -8,7 +8,7 @@ homepage: https://github.com/dart-lang/protobuf
 environment:
   sdk: '>=2.0.0-dev.17.0 <3.0.0'
 dependencies:
-  fixnum: '>=0.9.0 <0.11.0'
+  fixnum: '>=0.10.9 <0.11.0'
 dev_dependencies:
   test: '>=1.2.0'
   benchmark_harness: any

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.4
+version: 16.0.4-dev-1
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
@@ -10,7 +10,7 @@ environment:
 dependencies:
   fixnum: ^0.10.5
   path: ^1.0.0
-  protobuf: ^0.13.7
+  protobuf: ^0.13.8
   dart_style: ^1.0.6
 
 dev_dependencies:

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.5
+  fixnum: ^0.10.9
   path: ^1.0.0
   protobuf: ^0.13.8
   dart_style: ^1.0.6

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -5,6 +5,7 @@
 
 library json_test;
 
+import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
@@ -38,6 +39,20 @@ void main() {
     return predicate(
         (message) => message.writeToJson() == expectedJson, 'Incorrect output');
   }
+
+  test('testUnsignedOutput', () {
+    TestAllTypes message = new TestAllTypes();
+    // These values selected because:
+    // (1) large enough to set the sign bit
+    // (2) don't set all of the first 10 bits under the sign bit
+    // (3) are near each other
+    message.optionalUint64 = Int64.parseHex("f0000000ffff0000");
+    message.optionalFixed64 = Int64.parseHex("f0000000ffff0001");
+
+    String expectedJsonValue =
+        '{"4":"17293822573397606400","8":"17293822573397606401"}';
+    expect(message.writeToJson(), expectedJsonValue);
+  });
 
   test('testOutput', () {
     expect(getAllSet().writeToJson(), TEST_ALL_TYPES_JSON);
@@ -103,6 +118,26 @@ void main() {
     expect(optionalBytes(':"MTE2",', ':"",'), isEmpty);
 
     expect(optionalBytes(':"MTE2",', ':"YQ==",'), 'a');
+  });
+
+  test('testParseUnsigned', () {
+    TestAllTypes parsed = new TestAllTypes.fromJson(
+        '{"4":"17293822573397606400","8":"17293822573397606401"}');
+    TestAllTypes expected = new TestAllTypes();
+    expected.optionalUint64 = Int64.parseHex("f0000000ffff0000");
+    expected.optionalFixed64 = Int64.parseHex("f0000000ffff0001");
+
+    expect(parsed, expected);
+  });
+
+  test('testParseUnsignedLegacy', () {
+    TestAllTypes parsed = new TestAllTypes.fromJson(
+        '{"4":"-1152921500311945216","8":"-1152921500311945215"}');
+    TestAllTypes expected = new TestAllTypes();
+    expected.optionalUint64 = Int64.parseHex("f0000000ffff0000");
+    expected.optionalFixed64 = Int64.parseHex("f0000000ffff0001");
+
+    expect(parsed, expected);
   });
 
   test('testParse', () {

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -41,7 +41,7 @@ void main() {
   }
 
   test('testUnsignedOutput', () {
-    TestAllTypes message = new TestAllTypes();
+    TestAllTypes message = TestAllTypes();
     // These values selected because:
     // (1) large enough to set the sign bit
     // (2) don't set all of the first 10 bits under the sign bit
@@ -121,9 +121,9 @@ void main() {
   });
 
   test('testParseUnsigned', () {
-    TestAllTypes parsed = new TestAllTypes.fromJson(
+    TestAllTypes parsed = TestAllTypes.fromJson(
         '{"4":"17293822573397606400","8":"17293822573397606401"}');
-    TestAllTypes expected = new TestAllTypes();
+    TestAllTypes expected = TestAllTypes();
     expected.optionalUint64 = Int64.parseHex("f0000000ffff0000");
     expected.optionalFixed64 = Int64.parseHex("f0000000ffff0001");
 
@@ -131,9 +131,9 @@ void main() {
   });
 
   test('testParseUnsignedLegacy', () {
-    TestAllTypes parsed = new TestAllTypes.fromJson(
+    TestAllTypes parsed = TestAllTypes.fromJson(
         '{"4":"-1152921500311945216","8":"-1152921500311945215"}');
-    TestAllTypes expected = new TestAllTypes();
+    TestAllTypes expected = TestAllTypes();
     expected.optionalUint64 = Int64.parseHex("f0000000ffff0000");
     expected.optionalFixed64 = Int64.parseHex("f0000000ffff0001");
 


### PR DESCRIPTION
The current behavior treats signed and unsigned 64-bit fields the same, which relies on users needing to know to flip the negative appropriately. With the introduction of `toStringUnsigned` in fixnum v 0.10.9, we can handle this correctly.

This should fix #44.