### PR TITLE
Fix recursive merging of repeated fields.

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.9
+
+* Fix recursive merging of repeated elements.
+
 ## 0.13.8
 
 * Fix JSON serialization of unsigned 64-bit fields.

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -695,8 +695,11 @@ class _FieldSet {
           ? _ensureExtensions()._getFieldOrNull(fi)
           : _values[fi.index];
 
-      fieldValue = currentFi == null ? _cloneMessage(fieldValue) : currentFi
-        ..mergeFromMessage(fieldValue);
+      if (currentFi == null) {
+        fieldValue = _cloneMessage(fieldValue);
+      } else {
+        fieldValue = currentFi..mergeFromMessage(fieldValue);
+      }
     }
 
     if (isExtension) {

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.13.8
+version: 0.13.9
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   fixnum: ^0.10.9
   path: ^1.0.0
-  protobuf: ^0.13.8
+  protobuf: ^0.13.9
   dart_style: ^1.0.6
 
 dev_dependencies:

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.5
+version: 16.0.5-dev-1
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -19,6 +19,7 @@ import 'import_test.dart' as import_prefix;
 import 'json_test.dart' as json;
 import 'leading_underscores_test.dart' as leading_underscores;
 import 'map_test.dart' as map;
+import 'merge_test.dart' as merge;
 import 'message_generator_test.dart' as message_generator;
 import 'message_test.dart' as message;
 import 'mixin_test.dart' as mixin_test;
@@ -46,6 +47,7 @@ void main() {
   json.main();
   leading_underscores.main();
   map.main();
+  merge.main();
   message_generator.main();
   message.main();
   mixin_test.main();

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -1,3 +1,8 @@
+#!/usr/bin/env dart
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 library map_test;
 
 import 'package:test/test.dart'

--- a/protoc_plugin/test/merge_test.dart
+++ b/protoc_plugin/test/merge_test.dart
@@ -1,0 +1,71 @@
+#!/usr/bin/env dart
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library merge_test;
+
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart' show test, expect;
+
+import '../out/protos/foo.pb.dart' as pb;
+
+void main() {
+  test('merges child message', () {
+    final top = pb.Outer()
+      ..id = Int64(1)
+      ..value = 'sss'
+      ..strings.addAll(['s1', 's2'])
+      ..inner = (pb.Inner()
+        ..id = Int64(2)
+        ..value = 'sub'
+        ..strings.addAll(['sub1', 'sub2']));
+
+    final update = pb.Outer()
+      ..id = Int64(1)
+      ..value = 'new'
+      ..inner = (pb.Inner()..id = Int64(3));
+
+    top.mergeFromMessage(update);
+
+    final expected = pb.Outer()
+      ..id = Int64(1)
+      ..value = 'new'
+      ..strings.addAll(['s1', 's2'])
+      // This is properly merged.
+      ..inner = (pb.Inner()
+        ..id = Int64(3)
+        ..value = 'sub'
+        ..strings.addAll(['sub1', 'sub2']));
+
+    expect(top, expected);
+  });
+
+  test('merges grandchild message', () {
+    final empty = pb.Outer();
+    final mergeMe1 = pb.Outer()
+      ..inner = (pb.Inner()..inner = (pb.Inner()..id = Int64(1)));
+    final mergeMe2 = pb.Outer()
+      ..inner = (pb.Inner()..inner = (pb.Inner()..value = 'new'));
+
+    empty.mergeFromMessage(mergeMe1);
+    empty.mergeFromMessage(mergeMe2);
+
+    final expected = pb.Outer()
+      ..inner = (pb.Inner()
+        ..inner = (pb.Inner()
+          ..id = Int64(1)
+          ..value = 'new'));
+    expect(empty, expected);
+  });
+
+  test('merges repeated element of child', () {
+    final empty = pb.Outer();
+    final mergeMe = pb.Outer()..inner = (pb.Inner()..strings.add('one'));
+
+    empty.mergeFromMessage(mergeMe);
+
+    final expected = pb.Outer()..inner = (pb.Inner()..strings.add('one'));
+    expect(empty, expected);
+  });
+}

--- a/protoc_plugin/test/protos/foo.proto
+++ b/protoc_plugin/test/protos/foo.proto
@@ -10,9 +10,12 @@ message Foo {
 }
 
 message Outer {
-  optional Inner inner = 1;
-  repeated Inner inners = 2;
-  extensions 3 to 4;
+  optional string value = 1;
+  repeated string strings = 2;
+  optional int64 id = 3;
+  optional Inner inner = 4;
+  repeated Inner inners = 5;
+  extensions 6 to 7;
 }
 
 message OuterWithMap {
@@ -21,9 +24,12 @@ message OuterWithMap {
 
 message Inner {
   optional string value = 1;
+  optional int64 id = 2;
+  repeated string strings = 3;
+  optional Inner inner = 4;
 }
 
 extend Outer {
-  optional Inner inner = 3;
-  repeated Inner inners = 4;
+  optional Inner inner = 6;
+  repeated Inner inners = 7;
 }


### PR DESCRIPTION
This was caused by some tricky behavior of the cascading operator, combined with a ternary operator. The ternary was executed first, then mergeFromMessage was called on the result. Since _cloneMessage creates an empty message then uses mergeFromMessage, the repeated fields were being merged twice.

We could simply add a pair of parens around currentFi..mergeFromMessage(fieldValue) to fix, but the lesson learned is to keep the syntax simpler here.

This should fix #234 .