### PR TITLE
Preserve the original order of proto fields when generating metadata.

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 16.0.6
+
+* Track the original order of proto fields and include it in metadata
+  to ensure the correct fields are being referenced.
+
 ## 16.0.5
 
 * Fix generation of invalid Dart code for oneof enums

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -439,11 +439,11 @@ class MessageGenerator extends ProtobufContainer {
     _oneofNames
         .forEach((OneofNames oneof) => generateoneOfAccessors(out, oneof));
 
-    for (var i = 0; i < _fieldList.length; i++) {
+    for (var field in _fieldList) {
       out.println();
       List<int> memberFieldPath = List.from(fieldPath)
-        ..addAll([_messageFieldTag, i]);
-      generateFieldAccessorsMutators(_fieldList[i], out, memberFieldPath);
+        ..addAll([_messageFieldTag, field.sourcePosition]);
+      generateFieldAccessorsMutators(field, out, memberFieldPath);
     }
   }
 
@@ -524,7 +524,7 @@ class MessageGenerator extends ProtobufContainer {
             NamedLocation(
                 name: names.hasMethodName,
                 fieldPathSegment: memberFieldPath,
-                start: 'bool '.length)
+                start: '$_coreImportPrefix.bool '.length)
           ]);
       _emitDeprecatedIf(field.isDeprecated, out);
       _emitOverrideIf(field.overridesClearMethod, out);

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -45,6 +45,9 @@ class ProtobufField {
   /// `null` for an extension.
   int get index => memberNames?.index;
 
+  /// The position of this field as it appeared in the original DescriptorProto.
+  int get sourcePosition => memberNames.sourcePosition;
+
   /// True if the field is to be encoded with [deprecated = true] encoding.
   bool get isDeprecated => descriptor.options?.deprecated;
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 16.0.5-dev-1
+version: 16.0.6
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -16,7 +16,7 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 0
+  path: 1
   sourceFile: 
   begin: 1205
   end: 1211
@@ -25,7 +25,7 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 0
+  path: 1
   sourceFile: 
   begin: 1236
   end: 1242
@@ -34,16 +34,16 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 0
+  path: 1
   sourceFile: 
-  begin: 1289
-  end: 1298
+  begin: 1295
+  end: 1304
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 0
+  path: 1
   sourceFile: 
   begin: 1327
   end: 1338
@@ -52,7 +52,7 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: 
   begin: 1388
   end: 1392
@@ -61,7 +61,7 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: 
   begin: 1413
   end: 1417
@@ -70,16 +70,16 @@ annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: 
-  begin: 1470
-  end: 1477
+  begin: 1476
+  end: 1483
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: 
   begin: 1506
   end: 1515
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 1638
-  end: 1645
+  begin: 1644
+  end: 1651
 }
 annotation: {
   path: 4
@@ -144,8 +144,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 1973
-  end: 1991
+  begin: 1979
+  end: 1997
 }
 annotation: {
   path: 4

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 1474
-  end: 1483
+  begin: 1480
+  end: 1489
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 1641
-  end: 1648
+  begin: 1647
+  end: 1654
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 1809
-  end: 1816
+  begin: 1815
+  end: 1822
 }
 annotation: {
   path: 4

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -110,7 +110,7 @@ void main() {
     mg.generate(writer);
 
     var eq = ListEquality();
-    var fieldStringsMap = new HashMap(
+    var fieldStringsMap = HashMap(
         equals: eq.equals, hashCode: eq.hash, isValidKey: eq.isValidKey);
     fieldStringsMap[[4, 0]] = ['PhoneNumber'];
     fieldStringsMap[[4, 0, 2, 0]] = ['type', 'hasType', 'clearType'];
@@ -124,7 +124,6 @@ void main() {
 
     String generatedContents = writer.toString();
     GeneratedCodeInfo metadata = writer.sourceLocationInfo;
-    var comparator = IterableEquality();
     for (var annotation in metadata.annotation) {
       String annotatedName =
           generatedContents.substring(annotation.begin, annotation.end);

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -5,6 +5,8 @@
 
 library message_generator_test;
 
+import 'dart:collection';
+import 'package:collection/collection.dart';
 import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:protoc_plugin/protoc.dart';
 import 'package:test/test.dart';
@@ -15,9 +17,12 @@ import 'package:protoc_plugin/src/plugin.pb.dart';
 import 'golden_file.dart';
 
 void main() {
-  test('testMessageGenerator', () {
-    FileDescriptorProto fd = FileDescriptorProto();
-    EnumDescriptorProto ed = EnumDescriptorProto()
+  FileDescriptorProto fd;
+  EnumDescriptorProto ed;
+  DescriptorProto md;
+  setUp(() async {
+    fd = FileDescriptorProto();
+    ed = EnumDescriptorProto()
       ..name = 'PhoneType'
       ..value.addAll([
         EnumValueDescriptorProto()
@@ -33,7 +38,7 @@ void main() {
           ..name = 'BUSINESS'
           ..number = 2
       ]);
-    DescriptorProto md = DescriptorProto()
+    md = DescriptorProto()
       ..name = 'PhoneNumber'
       ..field.addAll([
         // optional PhoneType type = 2 [default = HOME];
@@ -63,6 +68,8 @@ void main() {
           ..options = (FieldOptions()..deprecated = true),
       ])
       ..enumType.add(ed);
+  });
+  test('testMessageGenerator', () {
     var options =
         parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
 
@@ -86,5 +93,47 @@ void main() {
         writer.toString(), 'test/goldens/messageGeneratorEnums');
     expectMatchesGoldenFile(writer.sourceLocationInfo.toString(),
         'test/goldens/messageGeneratorEnums.meta');
+  });
+
+  test('testMetadataIndices', () {
+    var options =
+        parseGenerationOptions(CodeGeneratorRequest(), CodeGeneratorResponse());
+    FileGenerator fg = FileGenerator(fd, options);
+    MessageGenerator mg =
+        MessageGenerator.topLevel(md, fg, {}, null, Set<String>(), 0);
+
+    var ctx = GenerationContext(options);
+    mg.register(ctx);
+    mg.resolve(ctx);
+
+    var writer = IndentingWriter(filename: '');
+    mg.generate(writer);
+
+    var eq = ListEquality();
+    var fieldStringsMap = new HashMap(
+        equals: eq.equals, hashCode: eq.hash, isValidKey: eq.isValidKey);
+    fieldStringsMap[[4, 0]] = ['PhoneNumber'];
+    fieldStringsMap[[4, 0, 2, 0]] = ['type', 'hasType', 'clearType'];
+    fieldStringsMap[[4, 0, 2, 1]] = ['number', 'hasNumber', 'clearNumber'];
+    fieldStringsMap[[4, 0, 2, 2]] = ['name', 'hasName', 'clearName'];
+    fieldStringsMap[[4, 0, 2, 3]] = [
+      'deprecatedField',
+      'hasDeprecatedField',
+      'clearDeprecatedField'
+    ];
+
+    String generatedContents = writer.toString();
+    GeneratedCodeInfo metadata = writer.sourceLocationInfo;
+    var comparator = IterableEquality();
+    for (var annotation in metadata.annotation) {
+      String annotatedName =
+          generatedContents.substring(annotation.begin, annotation.end);
+      var expectedStrings = fieldStringsMap[annotation.path];
+      if (expectedStrings == null) {
+        fail('The field path ${annotation.path} '
+            'did not match any expected field path.');
+      }
+      expect(annotatedName, isIn(expectedStrings));
+    }
   });
 }


### PR DESCRIPTION
This corrects metadata edges pointing to the wrong field if the fields were not originally sorted by tag number. This should fix #240.