### PR TITLE
Prefix class names in .pb.dart imports in .pbserver, .pb.json, .pbgrpc

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.0.1
+
+* Fix: Actually use prefixed imports from .pbserver, .pb.json, .pbgrpc files.
+
 ## 17.0.0
 
 * Breaking change: seal protobuf message classes by using an internal

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -489,9 +489,9 @@ class FileGenerator extends ProtobufContainer {
 
     out.println(_asyncImport);
     out.println();
-    out.println(_grpcImport);
-    out.println();
     out.println("$_coreImport show int, String, List;\n");
+    out.println();
+    out.println(_grpcImport);
 
     // Import .pb.dart files needed for requests and responses.
     var imports = Set<FileGenerator>();

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -96,10 +96,6 @@ class GrpcServiceGenerator {
       // TODO(nichite): Throw more actionable error.
       throw 'FAILURE: Unknown type reference (${fqname}) for ${location}';
     }
-    if (fileGen.protoFileUri == mg.fileGen.protoFileUri) {
-      // If it's the same file, we import it without using "as".
-      return mg.classname;
-    }
     return mg.fileImportPrefix + '.' + mg.classname;
   }
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 17.0.0
+version: 17.0.1
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -6,48 +6,48 @@
 
 import 'dart:async' as $async;
 
-import 'package:grpc/service_api.dart' as $grpc;
-
 import 'dart:core' as $core show int, String, List;
 
+import 'package:grpc/service_api.dart' as $grpc;
 import 'test.pb.dart' as $0;
 export 'test.pb.dart';
 
 class TestClient extends $grpc.Client {
-  static final _$unary = $grpc.ClientMethod<Input, Output>(
+  static final _$unary = $grpc.ClientMethod<$0.Input, $0.Output>(
       '/Test/Unary',
-      (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => Output.fromBuffer(value));
-  static final _$clientStreaming = $grpc.ClientMethod<Input, Output>(
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
+  static final _$clientStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
       '/Test/ClientStreaming',
-      (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => Output.fromBuffer(value));
-  static final _$serverStreaming = $grpc.ClientMethod<Input, Output>(
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
+  static final _$serverStreaming = $grpc.ClientMethod<$0.Input, $0.Output>(
       '/Test/ServerStreaming',
-      (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => Output.fromBuffer(value));
-  static final _$bidirectional = $grpc.ClientMethod<Input, Output>(
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
+  static final _$bidirectional = $grpc.ClientMethod<$0.Input, $0.Output>(
       '/Test/Bidirectional',
-      (Input value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => Output.fromBuffer(value));
+      ($0.Input value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
 
   TestClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
       : super(channel, options: options);
 
-  $grpc.ResponseFuture<Output> unary(Input request,
+  $grpc.ResponseFuture<$0.Output> unary($0.Input request,
       {$grpc.CallOptions options}) {
     final call = $createCall(_$unary, $async.Stream.fromIterable([request]),
         options: options);
     return $grpc.ResponseFuture(call);
   }
 
-  $grpc.ResponseFuture<Output> clientStreaming($async.Stream<Input> request,
+  $grpc.ResponseFuture<$0.Output> clientStreaming(
+      $async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
     final call = $createCall(_$clientStreaming, request, options: options);
     return $grpc.ResponseFuture(call);
   }
 
-  $grpc.ResponseStream<Output> serverStreaming(Input request,
+  $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
       {$grpc.CallOptions options}) {
     final call = $createCall(
         _$serverStreaming, $async.Stream.fromIterable([request]),
@@ -55,7 +55,7 @@ class TestClient extends $grpc.Client {
     return $grpc.ResponseStream(call);
   }
 
-  $grpc.ResponseStream<Output> bidirectional($async.Stream<Input> request,
+  $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
     final call = $createCall(_$bidirectional, request, options: options);
     return $grpc.ResponseStream(call);
@@ -66,50 +66,51 @@ abstract class TestServiceBase extends $grpc.Service {
   $core.String get $name => 'Test';
 
   TestServiceBase() {
-    $addMethod($grpc.ServiceMethod<Input, Output>(
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
         'Unary',
         unary_Pre,
         false,
         false,
-        ($core.List<$core.int> value) => Input.fromBuffer(value),
-        (Output value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<Input, Output>(
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
         'ClientStreaming',
         clientStreaming,
         true,
         false,
-        ($core.List<$core.int> value) => Input.fromBuffer(value),
-        (Output value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<Input, Output>(
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
         'ServerStreaming',
         serverStreaming_Pre,
         false,
         true,
-        ($core.List<$core.int> value) => Input.fromBuffer(value),
-        (Output value) => value.writeToBuffer()));
-    $addMethod($grpc.ServiceMethod<Input, Output>(
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.Input, $0.Output>(
         'Bidirectional',
         bidirectional,
         true,
         true,
-        ($core.List<$core.int> value) => Input.fromBuffer(value),
-        (Output value) => value.writeToBuffer()));
+        ($core.List<$core.int> value) => $0.Input.fromBuffer(value),
+        ($0.Output value) => value.writeToBuffer()));
   }
 
-  $async.Future<Output> unary_Pre(
+  $async.Future<$0.Output> unary_Pre(
       $grpc.ServiceCall call, $async.Future request) async {
     return unary(call, await request);
   }
 
-  $async.Stream<Output> serverStreaming_Pre(
+  $async.Stream<$0.Output> serverStreaming_Pre(
       $grpc.ServiceCall call, $async.Future request) async* {
-    yield* serverStreaming(call, (await request) as Input);
+    yield* serverStreaming(call, (await request) as $0.Input);
   }
 
-  $async.Future<Output> unary($grpc.ServiceCall call, Input request);
-  $async.Future<Output> clientStreaming(
-      $grpc.ServiceCall call, $async.Stream<Input> request);
-  $async.Stream<Output> serverStreaming($grpc.ServiceCall call, Input request);
-  $async.Stream<Output> bidirectional(
-      $grpc.ServiceCall call, $async.Stream<Input> request);
+  $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);
+  $async.Future<$0.Output> clientStreaming(
+      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
+  $async.Stream<$0.Output> serverStreaming(
+      $grpc.ServiceCall call, $0.Input request);
+  $async.Stream<$0.Output> bidirectional(
+      $grpc.ServiceCall call, $async.Stream<$0.Input> request);
 }


### PR DESCRIPTION
This fixes https://github.com/dart-lang/protobuf/issues/254

Also fixes the import order in .pbgrpc.dart files, to make dart: libraries imported before package libraries.