### PR TITLE
Avoid needless copy when reading from a Uint8List buffer.

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.14
+
+* Avoid needless copy when reading from a Uint8List buffer.
+
 ## 0.13.13
 
 * `Added `ExtensionRegistry.reparseMessage()` for decoding extensions from unknown fields after the initial

--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -19,8 +19,7 @@ class CodedBufferReader {
   CodedBufferReader(List<int> buffer,
       {int recursionLimit = DEFAULT_RECURSION_LIMIT,
       int sizeLimit = DEFAULT_SIZE_LIMIT})
-      : _buffer = buffer is Uint8List ? buffer : Uint8List(buffer.length)
-          ..setRange(0, buffer.length, buffer),
+      : _buffer = buffer is Uint8List ? buffer : Uint8List.fromList(buffer),
         _recursionLimit = recursionLimit,
         _sizeLimit = math.min(sizeLimit, buffer.length) {
     _currentLimit = _sizeLimit;

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.13.13
+version: 0.13.14
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.

--- a/protobuf/test/coded_buffer_reader_test.dart
+++ b/protobuf/test/coded_buffer_reader_test.dart
@@ -17,7 +17,7 @@ void main() {
       throwsA(TypeMatcher<InvalidProtocolBufferException>());
 
   group('testCodedBufferReader', () {
-    List<int> inputBuffer = <int>[
+    final inputBuffer = List<int>.unmodifiable([
       0xb8, 0x06, 0x20, // 103 int32 = 32
       0xc0, 0x06, 0x40, // 104 int64 = 64
       0xc8, 0x06, 0x20, // 105 uint32 = 32
@@ -37,10 +37,10 @@ void main() {
       0x9a, 0x07, 0x0e, 0x6f, 0x70, 0x74, 0x69, 0x6f,
       0x6e, 0x61, 0x6c, 0x5f, 0x62, 0x79, 0x74,
       0x65, 0x73 // 115 bytes 14 optional_bytes
-    ];
+    ]);
 
     testWithList(List<int> inputBuffer) {
-      CodedBufferReader cis = CodedBufferReader(inputBuffer);
+      final cis = CodedBufferReader(inputBuffer);
 
       expect(cis.readTag(), makeTag(103, WIRETYPE_VARINT));
       expect(cis.readInt32(), 32);
@@ -83,22 +83,21 @@ void main() {
     }
 
     test('normal-list', () {
-      testWithList(inputBuffer);
+      testWithList(Uint8List.fromList(inputBuffer));
     });
 
-    test('uint8-list', () {
-      var uint8List = Uint8List.fromList(inputBuffer);
-      testWithList(uint8List);
+    test('unmodifiable-uint8-list-view', () {
+      testWithList(UnmodifiableUint8ListView(Uint8List.fromList(inputBuffer)));
     });
 
     test('uint8-list-view', () {
-      var uint8List = Uint8List(inputBuffer.length + 4);
+      final uint8List = Uint8List(inputBuffer.length + 4);
       uint8List[0] = 0xc0;
       uint8List[1] = 0xc8;
       uint8List.setRange(2, 2 + inputBuffer.length, inputBuffer);
       uint8List[inputBuffer.length + 2] = 0xe0;
       uint8List[inputBuffer.length + 3] = 0xed;
-      var view = Uint8List.view(uint8List.buffer, 2, inputBuffer.length);
+      final view = Uint8List.view(uint8List.buffer, 2, inputBuffer.length);
       testWithList(view);
     });
   });


### PR DESCRIPTION
This is an export of internal commit: cl/256674003 .
