### PR TITLE
remove unnecessary_cast

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.0.5
+
+* Remove unnecessary cast from generated grpc stubs. 
+
 ## 17.0.4
 
 * Output [language versioning](https://github.com/dart-lang/language/blob/7eeb67b0d29b696b3c3ec8f9fe322334a2d5d87a/accepted/future-releases/language-versioning/feature-specification.md)

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -254,8 +254,7 @@ class _GrpcMethod {
         '$_serverReturnType ${_dartName}_Pre($_serviceCall call, $_future<$_requestType> request) async${_serverStreaming ? '*' : ''} {',
         '}', () {
       if (_serverStreaming) {
-        out.println(
-            'yield* $_dartName(call, (await request) as $_requestType);');
+        out.println('yield* $_dartName(call, await request);');
       } else {
         out.println('return $_dartName(call, await request);');
       }

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 17.0.4
+version: 17.0.5
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -104,7 +104,7 @@ abstract class TestServiceBase extends $grpc.Service {
 
   $async.Stream<$0.Output> serverStreaming_Pre(
       $grpc.ServiceCall call, $async.Future<$0.Input> request) async* {
-    yield* serverStreaming(call, (await request) as $0.Input);
+    yield* serverStreaming(call, await request);
   }
 
   $async.Future<$0.Output> unary($grpc.ServiceCall call, $0.Input request);


### PR DESCRIPTION
The analyzer triggers hints `unnecessary_cast` on generated code with streams.

```diff
  $async.Stream<$0.Output> serverStreaming_Pre(
      $grpc.ServiceCall call, $async.Future<$0.Input> request) async* {
-    yield* serverStreaming(call, (await request) as $0.Input);
+    yield* serverStreaming(call, await request);
  }

  $async.Stream<$0.Output> serverStreaming(
      $grpc.ServiceCall call, $0.Input request);
```