### PR TITLE
Make mapEntryBuilderInfo public

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.2
+
+*  Expose `mapEntryBuilderInfo` in `MapFieldInfo`.
+
 ## 0.14.1
 
 * Support for `import public`.

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -199,7 +199,7 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
   /// `null` if the value type is not a Message type.
   final CreateBuilderFunc valueCreator;
 
-  final BuilderInfo _mapEntryBuilderInfo;
+  final BuilderInfo mapEntryBuilderInfo;
 
   MapFieldInfo(
       String name,
@@ -208,12 +208,12 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
       int type,
       this.keyFieldType,
       this.valueFieldType,
-      this._mapEntryBuilderInfo,
+      this.mapEntryBuilderInfo,
       this.valueCreator,
       {String protoName})
       : super(name, tagNumber, index, type,
             defaultOrMaker: () =>
-                PbMap<K, V>(keyFieldType, valueFieldType, _mapEntryBuilderInfo),
+                PbMap<K, V>(keyFieldType, valueFieldType, mapEntryBuilderInfo),
             protoName: protoName) {
     assert(name != null);
     assert(tagNumber != null);
@@ -222,7 +222,7 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
   }
 
   FieldInfo get valueFieldInfo =>
-      _mapEntryBuilderInfo.fieldInfo[PbMap._valueFieldNumber];
+      mapEntryBuilderInfo.fieldInfo[PbMap._valueFieldNumber];
 
   Map<K, V> _ensureMapField(_FieldSet fs) {
     return fs._ensureMapField<K, V>(this);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -209,7 +209,7 @@ class _FieldSet {
 
     if (_isReadOnly)
       return PbMap<K, V>.unmodifiable(PbMap<K, V>(
-          fi.keyFieldType, fi.valueFieldType, fi._mapEntryBuilderInfo));
+          fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo));
 
     var value = fi._createMapField(_message);
     _setNonExtensionFieldUnchecked(fi, value);

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -325,7 +325,7 @@ abstract class GeneratedMessage {
   /// Creates a Map representing a map field.
   Map<K, V> createMapField<K, V>(int tagNumber, MapFieldInfo<K, V> fi) {
     return PbMap<K, V>(
-        fi.keyFieldType, fi.valueFieldType, fi._mapEntryBuilderInfo);
+        fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo);
   }
 
   /// Returns the value of a field, ignoring any defaults.

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 0.14.1
+version: 0.14.2
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.


### PR DESCRIPTION
This change exposes the private `BuilderInfo` variable `mapEntryBuilderInfo` as a public variable.

The benefits are described in the issue, but I will restate/refine here:
  1. Allows accessing `enumValues` for map values that are enums (was not possible before)
  2. Also allows general access to the FieldInfo of map key/values (developer flexibility)
  3. Exposing the `BuilderInfo` allows the direct use of the `PbMap` constructor as opposed to needing to call `createMapField` on an instance of a `GeneratedMessage`


Fixes #276