### PR TITLE
29 bits tag

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_reader.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_reader.dart
@@ -138,7 +138,7 @@ class CodedBufferReader {
       return 0;
     }
 
-    _lastTag = readInt32();
+    _lastTag = readUint32();
     if (getTagFieldNumber(_lastTag) == 0) {
       throw InvalidProtocolBufferException.invalidTag();
     }

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 18.0.3
+
+* Fix: Allow decoding tagnumbers of up to 29 bits. Would fail before with more than 28 bits.
+
 ## 18.0.2
 
 * Fix mangling of extension names, message type names, and enum names that are Dart keywords.

--- a/protoc_plugin/Makefile
+++ b/protoc_plugin/Makefile
@@ -31,6 +31,7 @@ TEST_PROTO_LIST = \
 	ExtensionEnumNameConflict \
 	ExtensionNameConflict \
 	foo \
+	high_tagnumber \
 	import_clash \
 	import_public \
 	json_name \

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 18.0.2
+version: 18.0.3
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/high_tagnumber_test.dart
+++ b/protoc_plugin/test/high_tagnumber_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../out/protos/high_tagnumber.pb.dart';
+import 'package:test/test.dart';
+
+main() {
+  test('round trip 29 bit tag number, binary encoding', () {
+    expect(M.fromBuffer((M()..a = 42).writeToBuffer()), M()..a = 42);
+    expect(M.fromBuffer((M()..b = 42).writeToBuffer()), M()..b = 42);
+  });
+  test('round trip 29 bit tag number, jspblite2', () {
+    expect(M.fromJson((M()..a = 43).writeToJson()), M()..a = 43);
+    expect(M.fromJson((M()..b = 43).writeToJson()), M()..b = 43);
+  });
+}

--- a/protoc_plugin/test/protos/high_tagnumber.proto
+++ b/protoc_plugin/test/protos/high_tagnumber.proto
@@ -1,0 +1,13 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+syntax = "proto2";
+
+message M {
+  // Make sure that we handle 29 bits of tagnumber.
+  // (1 << 28) + 1
+  optional int32 a = 268435457;
+  // (1 << 29) - 1
+  optional int32 b = 536870911;
+}


### PR DESCRIPTION
We were reading the tag as a signed value leading to issues when the tagnumber is bigger than: 268435456.