### PR TITLE
Avoid using `extension` as an import prefix.

### DIFF
--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -10,7 +10,7 @@ import 'any_test.dart' as any;
 import 'client_generator_test.dart' as client_generator;
 import 'const_generator_test.dart' as const_generator;
 import 'enum_generator_test.dart' as enum_generator;
-import 'extension_test.dart' as extension;
+import 'extension_test.dart' as extension_test;
 import 'file_generator_test.dart' as file_generator;
 import 'generated_message_test.dart' as generated_message;
 import 'hash_code_test.dart' as hash_code;
@@ -41,7 +41,7 @@ void main() {
   client_generator.main();
   const_generator.main();
   enum_generator.main();
-  extension.main();
+  extension_test.main();
   file_generator.main();
   generated_message.main();
   hash_code.main();


### PR DESCRIPTION
It is a built-in-identifier with the new static extension methods. Leading this test to fail.

https://github.com/dart-lang/language/blob/master/accepted/future-releases/static-extension-methods/feature-specification.md
