### PR TITLE
Escape the special character '$' in proto json_name.

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 19.0.2
+
+* Fix: escape the special character `$` in descriptor's `json_name`.
+
 ## 19.0.1
 
 * Fix: avoid naming collisions with `Int64` and enum names beginning with digits

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -149,7 +149,9 @@ class ProtobufField {
   /// [fileGen] represents the .proto file where the code will be evaluated.
   String generateBuilderInfoCall(FileGenerator fileGen, String package) {
     assert(descriptor.hasJsonName());
-    String quotedName = "'${descriptor.jsonName}'";
+    // JSON names should be serialized as-is, but '$' can cause Dart to try to
+    // perform string interpolation on non-existent variables.
+    String quotedName = "'${descriptor.jsonName.replaceAll(r'$', r'\$')}'";
 
     String type = baseType.getDartType(fileGen);
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 19.0.1
+version: 19.0.2
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -218,6 +218,10 @@ void main() {
   test('The field name is the json_name as given by protoc', () {
     expect(json_name.JsonNamedMessage().getTagNumber('barName'), 1);
   });
+
+  test('Invalid characters are escaped from json_name', () {
+    expect(json_name.JsonNamedMessage().getTagNumber('\$name'), 2);
+  });
 }
 
 FieldDescriptorProto stringField(String name, int number, String dartName) {

--- a/protoc_plugin/test/protos/json_name.proto
+++ b/protoc_plugin/test/protos/json_name.proto
@@ -6,4 +6,6 @@ syntax = "proto3";
 
 message JsonNamedMessage {
   int32 foo_name = 1 [json_name = "barName"];
+
+  int32 invalid_name = 2 [json_name = "$name"];
 }


### PR DESCRIPTION
This fixes an edge case where the `json_name` option for a proto field contains `$` . Basically when we're generating the `BuilderInfo` call the resulting Dart code looks like it's referencing a variable inside the string. This causes build to break. 