### PR TITLE
Remove the lines about proto3 compatibility in the README file

### DIFF
--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -9,11 +9,6 @@ It generates Dart files for working with data in protocol buffers format.
 Requirements
 ------------
 
-We only support the full [proto2](https://developers.google.com/protocol-buffers/docs/proto)
-schema. Proto3 should work due to backwards compatibility. See
-[this issue list](https://github.com/dart-lang/protobuf/issues?q=is%3Aissue+is%3Aopen+label%3Aproto3)
-for proto3 schema features which are currently missing.
-
 To compile a .proto file, you must use the 'protoc' command which is [installed
 separately](https://developers.google.com/protocol-buffers/docs/downloads).
 Protobuf 3.0.0 or above is required.


### PR DESCRIPTION
This commit removes the lines about the proto3 compatibility since there isn't open issues about it.