### PR TITLE
add missed `protoName` population in BuilderInfo class

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Fix issue with the non-json name of a field (`protoName`) not being set correctly.
+
 ## 1.0.0
 
 * Graduate package to 1.0. No functional changes.

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -102,34 +102,34 @@ class BuilderInfo {
       List<ProtobufEnum> enumValues,
       String protoName}) {
     add<T>(tagNumber, name, fieldType, defaultOrMaker, subBuilder, valueOf,
-        enumValues);
+        enumValues, protoName: protoName);
   }
 
   /// Adds PbFieldType.OS String with no default value to reduce generated
   /// code size.
   void aOS(int tagNumber, String name, {String protoName}) {
-    add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null);
+    add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null, protoName: protoName);
   }
 
   /// Adds PbFieldType.PS String with no default value.
   void pPS(int tagNumber, String name, {String protoName}) {
     addRepeated<String>(tagNumber, name, PbFieldType.PS,
-        getCheckFunction(PbFieldType.PS), null, null, null);
+        getCheckFunction(PbFieldType.PS), null, null, null, protoName: protoName);
   }
 
   /// Adds PbFieldType.QS String with no default value.
   void aQS(int tagNumber, String name, {String protoName}) {
-    add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null);
+    add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null, protoName: protoName);
   }
 
   /// Adds Int64 field with Int64.ZERO default.
   void aInt64(int tagNumber, String name, {String protoName}) {
-    add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null);
+    add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null, protoName: protoName);
   }
 
   /// Adds a boolean with no default value.
   void aOB(int tagNumber, String name, {String protoName}) {
-    add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null);
+    add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null, protoName: protoName);
   }
 
   // Enum.
@@ -139,14 +139,14 @@ class BuilderInfo {
       List<ProtobufEnum> enumValues,
       String protoName}) {
     add<T>(
-        tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues);
+        tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues, protoName: protoName);
   }
 
   // Repeated, not a message, group, or enum.
   void p<T>(int tagNumber, String name, int fieldType, {String protoName}) {
     assert(!_isGroupOrMessage(fieldType) && !_isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, getCheckFunction(fieldType),
-        null, null, null);
+        null, null, null, protoName: protoName);
   }
 
   // Repeated message, group, or enum.
@@ -157,7 +157,7 @@ class BuilderInfo {
       String protoName}) {
     assert(_isGroupOrMessage(fieldType) || _isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, _checkNotNull, subBuilder,
-        valueOf, enumValues);
+        valueOf, enumValues, protoName: protoName);
   }
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,
@@ -169,7 +169,8 @@ class BuilderInfo {
         GeneratedMessage._defaultMakerFor<T>(subBuilder),
         subBuilder,
         null,
-        null);
+        null,
+        protoName: protoName);
   }
 
   void aQM<T extends GeneratedMessage>(int tagNumber, String name,
@@ -181,7 +182,8 @@ class BuilderInfo {
         GeneratedMessage._defaultMakerFor<T>(subBuilder),
         subBuilder,
         null,
-        null);
+        null,
+        protoName: protoName);
   }
 
   // oneof declarations.

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -102,34 +102,40 @@ class BuilderInfo {
       List<ProtobufEnum> enumValues,
       String protoName}) {
     add<T>(tagNumber, name, fieldType, defaultOrMaker, subBuilder, valueOf,
-        enumValues, protoName: protoName);
+        enumValues,
+        protoName: protoName);
   }
 
   /// Adds PbFieldType.OS String with no default value to reduce generated
   /// code size.
   void aOS(int tagNumber, String name, {String protoName}) {
-    add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null, protoName: protoName);
+    add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null,
+        protoName: protoName);
   }
 
   /// Adds PbFieldType.PS String with no default value.
   void pPS(int tagNumber, String name, {String protoName}) {
     addRepeated<String>(tagNumber, name, PbFieldType.PS,
-        getCheckFunction(PbFieldType.PS), null, null, null, protoName: protoName);
+        getCheckFunction(PbFieldType.PS), null, null, null,
+        protoName: protoName);
   }
 
   /// Adds PbFieldType.QS String with no default value.
   void aQS(int tagNumber, String name, {String protoName}) {
-    add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null, protoName: protoName);
+    add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null,
+        protoName: protoName);
   }
 
   /// Adds Int64 field with Int64.ZERO default.
   void aInt64(int tagNumber, String name, {String protoName}) {
-    add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null, protoName: protoName);
+    add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null,
+        protoName: protoName);
   }
 
   /// Adds a boolean with no default value.
   void aOB(int tagNumber, String name, {String protoName}) {
-    add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null, protoName: protoName);
+    add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null,
+        protoName: protoName);
   }
 
   // Enum.
@@ -139,14 +145,16 @@ class BuilderInfo {
       List<ProtobufEnum> enumValues,
       String protoName}) {
     add<T>(
-        tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues, protoName: protoName);
+        tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues,
+        protoName: protoName);
   }
 
   // Repeated, not a message, group, or enum.
   void p<T>(int tagNumber, String name, int fieldType, {String protoName}) {
     assert(!_isGroupOrMessage(fieldType) && !_isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, getCheckFunction(fieldType),
-        null, null, null, protoName: protoName);
+        null, null, null,
+        protoName: protoName);
   }
 
   // Repeated message, group, or enum.
@@ -157,7 +165,8 @@ class BuilderInfo {
       String protoName}) {
     assert(_isGroupOrMessage(fieldType) || _isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, _checkNotNull, subBuilder,
-        valueOf, enumValues, protoName: protoName);
+        valueOf, enumValues,
+        protoName: protoName);
   }
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 1.0.0
+version: 1.0.1
 author: Dart Team <misc@dartlang.org>
 description: >
   Runtime library for protocol buffers support.

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -219,6 +219,11 @@ void main() {
     expect(json_name.JsonNamedMessage().getTagNumber('barName'), 1);
   });
 
+  test('The proto name is set correctly', () {
+    expect(json_name.JsonNamedMessage().info_.byName['barName'].protoName,
+        'foo_name');
+  });
+
   test('Invalid characters are escaped from json_name', () {
     expect(json_name.JsonNamedMessage().getTagNumber('\$name'), 2);
   });


### PR DESCRIPTION
Hey.

The issue is described here: https://github.com/dart-lang/protobuf/issues/312