### PR TITLE
Fix 29-bit tagnumbers in unknown fields

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.1
 
 * Fix issue with the non-json name of a field (`protoName`) not being set correctly.
+* Fix: Allow decoding tagnumbers of unknown fields of up to 29 bits.
 
 ## 1.0.0
 

--- a/protobuf/lib/src/protobuf/wire_format.dart
+++ b/protobuf/lib/src/protobuf/wire_format.dart
@@ -14,7 +14,7 @@ const int WIRETYPE_START_GROUP = 3;
 const int WIRETYPE_END_GROUP = 4;
 const int WIRETYPE_FIXED32 = 5;
 
-int getTagFieldNumber(int tag) => (tag & 0x7fffffff) >> TAG_TYPE_BITS;
+int getTagFieldNumber(int tag) => tag >> TAG_TYPE_BITS;
 
 int getTagWireType(int tag) => tag & TAG_TYPE_MASK;
 

--- a/protoc_plugin/test/high_tagnumber_test.dart
+++ b/protoc_plugin/test/high_tagnumber_test.dart
@@ -17,9 +17,10 @@ main() {
     expect(M.fromJson((M()..b = 43).writeToJson()), M()..b = 43);
   });
   test('unknown fields', () {
-    final empty = Empty.fromBuffer((M()..a=44).writeToBuffer());
+    final empty = Empty.fromBuffer((M()..a = 44).writeToBuffer());
     expect(empty.unknownFields.isEmpty, false);
-    expect(empty.unknownFields.getField(M().info_.tagNumber('a')).varints, [Int64(44)]);
+    expect(empty.unknownFields.getField(M().info_.tagNumber('a')).varints,
+        [Int64(44)]);
     expect(M.fromBuffer(empty.writeToBuffer()).a, 44);
   });
 }

--- a/protoc_plugin/test/high_tagnumber_test.dart
+++ b/protoc_plugin/test/high_tagnumber_test.dart
@@ -3,7 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../out/protos/high_tagnumber.pb.dart';
+import '../out/protos/google/protobuf/empty.pb.dart';
 import 'package:test/test.dart';
+import 'package:fixnum/fixnum.dart';
 
 main() {
   test('round trip 29 bit tag number, binary encoding', () {
@@ -13,5 +15,11 @@ main() {
   test('round trip 29 bit tag number, jspblite2', () {
     expect(M.fromJson((M()..a = 43).writeToJson()), M()..a = 43);
     expect(M.fromJson((M()..b = 43).writeToJson()), M()..b = 43);
+  });
+  test('unknown fields', () {
+    final empty = Empty.fromBuffer((M()..a=44).writeToBuffer());
+    expect(empty.unknownFields.isEmpty, false);
+    expect(empty.unknownFields.getField(M().info_.tagNumber('a')).varints, [Int64(44)]);
+    expect(M.fromBuffer(empty.writeToBuffer()).a, 44);
   });
 }


### PR DESCRIPTION
It is not clear to me why we ever had the field mask in the first place.