### PR TITLE
Explain how to use "pub run protoc_plugin"

### DIFF
--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -27,7 +27,7 @@ includes generated files should add "protobuf" to its pubspec.yaml file.
 How to build and use
 --------------------
 
-Add `protoc_plugin: any` to your dependencies (this way it the pub version
+Add `protoc_plugin: any` to your dependencies (this way the pub version
 resolution will match up with your version of `protobuf`).
 
 Run `pub get`.

--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -27,32 +27,14 @@ includes generated files should add "protobuf" to its pubspec.yaml file.
 How to build and use
 --------------------
 
-*Note:* currently the workflow is POSIX-oriented.
+Add `protoc_plugin: any` to your dependencies (this way it the pub version
+resolution will match up with your version of `protobuf`).
 
-To build standalone `protoc` plugin:
-- run `pub install` to install all dependencies
-- Now you can use the plugin either by adding the `bin` directory to your `PATH`,
-  or passing it directly with `protoc`'s `--plugin` option.
+Run `pub get`.
 
-Please, remember that the plugin is pure Dart script and requires the presence
-of `dart` executable in your `PATH`.
+Now you can compile your proto files like this:
 
-When both the `dart` executable and `bin/protoc-gen-dart` are in the
-`PATH` the protocol buffer compiler can be invoked to generate like this:
-
-    $ protoc --dart_out=. test.proto
-
-### Optionally using `pub global`
-
-    $ pub global activate protoc_plugin
-
-And then add `.pub-cache/bin` in your home dir to your `PATH` if you haven't already.
-
-This will activate the latest published version of the plugin. If you wish to use a
-local working copy, use
-
-    $ pub global activate -s path <path/to/your/dart-protoc-plugin>
-
+    $ protoc --dart_out=lib/ protos/test.proto --plugin "pub run protoc_plugin"
 
 ### Options to control the generated Dart code
 


### PR DESCRIPTION
This is much better that a globally activated protoc_plugin that does not keep up to date.

Related to https://github.com/dart-lang/protobuf/issues/303