### PR TITLE
Revert "Explain how to use "pub run protoc_plugin" (#316)"

### DIFF
--- a/protoc_plugin/README.md
+++ b/protoc_plugin/README.md
@@ -22,14 +22,32 @@ includes generated files should add "protobuf" to its pubspec.yaml file.
 How to build and use
 --------------------
 
-Add `protoc_plugin: any` to your dependencies (this way the pub version
-resolution will match up with your version of `protobuf`).
+*Note:* currently the workflow is POSIX-oriented.
 
-Run `pub get`.
+To build standalone `protoc` plugin:
+- run `pub install` to install all dependencies
+- Now you can use the plugin either by adding the `bin` directory to your `PATH`,
+  or passing it directly with `protoc`'s `--plugin` option.
 
-Now you can compile your proto files like this:
+Please, remember that the plugin is pure Dart script and requires the presence
+of `dart` executable in your `PATH`.
 
-    $ protoc --dart_out=lib/ protos/test.proto --plugin "pub run protoc_plugin"
+When both the `dart` executable and `bin/protoc-gen-dart` are in the
+`PATH` the protocol buffer compiler can be invoked to generate like this:
+
+    $ protoc --dart_out=. test.proto
+
+### Optionally using `pub global`
+
+    $ pub global activate protoc_plugin
+
+And then add `.pub-cache/bin` in your home dir to your `PATH` if you haven't already.
+
+This will activate the latest published version of the plugin. If you wish to use a
+local working copy, use
+
+    $ pub global activate -s path <path/to/your/dart-protoc-plugin>
+
 
 ### Options to control the generated Dart code
 


### PR DESCRIPTION
This reverts commit 999d4591fb102fb68d68a4faae8ddeafe70a8d2a.

The updated explanation did not work as I thought.