### PR TITLE
Fix wire format for negative int32 values

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix hashcode of bytes fields.
 * Fix issue with the `permissiveEnums` option to `mergeFromProto3Json`.
   The comparison did not work properly.
+* Fix binary representation of negative int32 values.
 
 ## 1.0.1
 

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -353,7 +353,7 @@ class CodedBufferWriter {
         value.writeToCodedBufferWriter(this);
         break;
       case PbFieldType._INT32_BIT:
-        _writeVarint32(value & 0xffffffff);
+        _writeVarint64(Int64(value));
         break;
       case PbFieldType._INT64_BIT:
         _writeVarint64(value);

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -32,13 +32,6 @@ void main() {
 
   final int32ToBytes = convertToBytes(PbFieldType.O3);
 
-  test('testEquivalentBitwiseRepresentations', () {
-    final uint32ToBytes = convertToBytes(PbFieldType.OU3);
-    // Internal representation appears to be bit-wise identical
-    // an additional internal flag must differentiate.
-    expect(int32ToBytes(-1), uint32ToBytes(4294967295));
-  });
-
   test('testInt32RoundTrips', () {
     final roundtrip = roundtripTester(
         fromBytes: (CodedBufferReader reader) => reader.readInt32(),
@@ -48,9 +41,10 @@ void main() {
     roundtrip(206, [0xce, 0x01]);
     roundtrip(300, [0xac, 0x02]);
     roundtrip(2147483647, [0xff, 0xff, 0xff, 0xff, 0x07]);
-    roundtrip(-2147483648, [0x80, 0x80, 0x80, 0x80, 0x08]);
-    roundtrip(-1, [0xff, 0xff, 0xff, 0xff, 0x0f]);
-    roundtrip(-2, [0xfe, 0xff, 0xff, 0xff, 0x0f]);
+    roundtrip(-2147483648,
+        [0x80, 0x80, 0x80, 0x80, 0xf8, 0xff, 0xff, 0xff, 0xff, 0x01]);
+    roundtrip(-1, [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]);
+    roundtrip(-2, [0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01]);
   });
 
   test('testSint32', () {


### PR DESCRIPTION
According to https://developers.google.com/protocol-buffers/docs/encoding#signed-integers, negative int32 values should be encoded differently:

> If you use int32 or int64 as the type for a negative number, the resulting varint is always ten bytes long – it is, effectively, treated like a very large unsigned integer.

However CodedBufferWriter does not distinguish between negative and positive values, and this may cause problems when protos encoded by Dart are decoded by other proto implementations.

To update expected bytes in codec_test I used encoded bytes produced by C++ protobuf implementation.