### PR TITLE
Fix Travis build by using older lint settings

### DIFF
--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -15,4 +15,4 @@ dev_dependencies:
   test: '>=1.2.0'
   benchmark_harness: any
   js: any
-  pedantic: ^1.0.0
+  pedantic: '>=1.0.0 <1.9.0'


### PR DESCRIPTION
pedantic 1.9.0 enforced 17 new lints. Constrain pedantic version to `<1.9.0`.