### PR TITLE
Permit unknown enum values when ignoreUnknownFields=true.

### DIFF
--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -227,8 +227,8 @@ abstract class GeneratedMessage {
   /// Well-known types and their special JSON encoding are supported.
   ///
   /// If [ignoreUnknownFields] is `false` (the default) an
-  /// [FormatException] is be thrown if an unknown field name
-  /// is encountered. Otherwise the unknown field is ignored.
+  /// [FormatException] is be thrown if an unknown field or enum name
+  /// is encountered. Otherwise the unknown field or enum is ignored.
   ///
   /// If [supportNamesWithUnderscores] is `true` (the default) field names in
   /// the JSON can be represented as either camel-case JSON-names or names with

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -202,11 +202,14 @@ void _mergeFromProto3Json(
                     orElse: () => null)
                 : fieldInfo.enumValues
                     .firstWhere((e) => e.name == value, orElse: () => null);
-            if (result != null) return result;
+            if ((result != null) || ignoreUnknownFields) return result;
             throw context.parseException('Unknown enum value', value);
           } else if (value is int) {
             return fieldInfo.valueOf(value) ??
-                (throw context.parseException('Unknown enum value', value));
+                (ignoreUnknownFields
+                    ? null
+                    : (throw context.parseException(
+                        'Unknown enum value', value)));
           }
           throw context.parseException(
               'Expected enum as a string or integer', value);

--- a/protobuf/test/map_mixin_test.dart
+++ b/protobuf/test/map_mixin_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     expect(r.isEmpty, false);
     expect(r.isNotEmpty, true);
-    expect(r.keys, ['val', 'str', 'child', 'int32s', 'int64']);
+    expect(r.keys, ['val', 'str', 'child', 'int32s', 'int64', 'enm']);
 
     expect(r['val'], 42);
     expect(r['str'], '');
@@ -42,11 +42,12 @@ void main() {
     expect(r['int32s'], []);
 
     var v = r.values;
-    expect(v.length, 5);
+    expect(v.length, 6);
     expect(v.first, 42);
     expect(v.toList()[1], '');
     expect(v.toList()[3].toString(), '[]');
-    expect(v.last, 0);
+    expect(v.toList()[4], 0);
+    expect(v.toList()[5].name, 'a');
   });
 
   test('operator []= sets record fields', () {

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -6,15 +6,27 @@ library mock_util;
 
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:protobuf/protobuf.dart'
-    show GeneratedMessage, BuilderInfo, CreateBuilderFunc, PbFieldType;
+    show
+        BuilderInfo,
+        CreateBuilderFunc,
+        GeneratedMessage,
+        PbFieldType,
+        ProtobufEnum;
 
+final mockEnumValues = [ProtobufEnum(1, 'a'), ProtobufEnum(2, 'b')];
 BuilderInfo mockInfo(String className, CreateBuilderFunc create) {
   return BuilderInfo(className)
     ..a(1, 'val', PbFieldType.O3, defaultOrMaker: 42)
     ..a(2, 'str', PbFieldType.OS)
     ..a(3, 'child', PbFieldType.OM, defaultOrMaker: create, subBuilder: create)
     ..p<int>(4, 'int32s', PbFieldType.P3)
-    ..a(5, 'int64', PbFieldType.O6);
+    ..a(5, 'int64', PbFieldType.O6)
+    // 6 is reserved for extensions in other tests.
+    ..e(7, 'enm', PbFieldType.OE,
+        defaultOrMaker: mockEnumValues.first,
+        valueOf: (i) =>
+            mockEnumValues.firstWhere((e) => e.value == i, orElse: () => null),
+        enumValues: mockEnumValues);
 }
 
 /// A minimal protobuf implementation for testing.
@@ -36,6 +48,9 @@ abstract class MockMessage extends GeneratedMessage {
 
   Int64 get int64 => $_get(4, Int64(0));
   set int64(x) => setField(5, x);
+
+  ProtobufEnum get enm => $_getN(5);
+  bool get hasEnm => $_has(5);
 
   @override
   GeneratedMessage clone() {


### PR DESCRIPTION
To be consistent with: https://github.com/protocolbuffers/protobuf/blob/master/java/util/src/main/java/com/google/protobuf/util/JsonFormat.java#L1925

This change allows adding additional values to an enum definition without parsing failures occurring on clients with older enum definitions.