### PR TITLE
Enable hashCode memoization for frozen protos.

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Enable hashCode memoization for frozen protos.
+
 ## 1.0.2
 
 * Fix hashcode of bytes fields.

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protobuf
-version: 1.0.2
+version: 1.0.3
 description: >
   Runtime library for protocol buffers support.
   Use https://pub.dartlang.org/packages/protoc_plugin to generate dart code for your '.proto' files.

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -92,6 +92,22 @@ main() {
     }
   });
 
+  test('eagerly computes hashCode if a custom read-only handler is used', () {
+    try {
+      final message = Rec.getDefault();
+      final initialHashCode = message.hashCode;
+
+      frozenMessageModificationHandler =
+          (String messageName, [String methodName]) {};
+      message.setField(1, 456);
+      final modifiedHashCode = message.hashCode;
+      expect(initialHashCode == modifiedHashCode, isFalse);
+    } finally {
+      frozenMessageModificationHandler =
+          defaultFrozenMessageModificationHandler;
+    }
+  });
+
   test("can't clear a read-only message", () {
     expect(
         () => Rec.getDefault().clear(),


### PR DESCRIPTION
If protos are frozen, and the `defaultFrozenMessageModificationHandler` is being used and has never been messed with, there should be no way to illegally mutate proto field sets. In this case, the hashCode should be stable, and we can memoize the value.

This should significantly speed up `hashCode` computations for large protos.