### PR TITLE
message_generator.dart: generate setters for repeated fields

### DIFF
--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -477,73 +477,73 @@ class MessageGenerator extends ProtobufContainer {
         throw 'Field ${field.fullName} cannot override '
             '${names.clearMethodName}() because it is repeated.';
       }
+    }
+
+    var fastSetter = field.baseType.setter;
+    _emitDeprecatedIf(field.isDeprecated, out);
+    _emitOverrideIf(field.overridesSetter, out);
+    _emitIndexAnnotation(field.number, out);
+    if (fastSetter != null) {
+      out.printlnAnnotated(
+          'set ${names.fieldName}'
+          '($fieldTypeString v) { '
+          '$fastSetter(${field.index}, v);'
+          ' }',
+          [
+            NamedLocation(
+                name: names.fieldName,
+                fieldPathSegment: memberFieldPath,
+                start: 'set '.length)
+          ]);
     } else {
-      var fastSetter = field.baseType.setter;
-      _emitDeprecatedIf(field.isDeprecated, out);
-      _emitOverrideIf(field.overridesSetter, out);
-      _emitIndexAnnotation(field.number, out);
-      if (fastSetter != null) {
-        out.printlnAnnotated(
-            'set ${names.fieldName}'
-            '($fieldTypeString v) { '
-            '$fastSetter(${field.index}, v);'
-            ' }',
-            [
-              NamedLocation(
-                  name: names.fieldName,
-                  fieldPathSegment: memberFieldPath,
-                  start: 'set '.length)
-            ]);
-      } else {
-        out.printlnAnnotated(
-            'set ${names.fieldName}'
-            '($fieldTypeString v) { '
-            'setField(${field.number}, v);'
-            ' }',
-            [
-              NamedLocation(
-                  name: names.fieldName,
-                  fieldPathSegment: memberFieldPath,
-                  start: 'set '.length)
-            ]);
-      }
-      _emitDeprecatedIf(field.isDeprecated, out);
-      _emitOverrideIf(field.overridesHasMethod, out);
-      _emitIndexAnnotation(field.number, out);
       out.printlnAnnotated(
-          '$_coreImportPrefix.bool ${names.hasMethodName}() =>'
-          ' \$_has(${field.index});',
+          'set ${names.fieldName}'
+          '($fieldTypeString v) { '
+          'setField(${field.number}, v);'
+          ' }',
           [
             NamedLocation(
-                name: names.hasMethodName,
+                name: names.fieldName,
                 fieldPathSegment: memberFieldPath,
-                start: '$_coreImportPrefix.bool '.length)
+                start: 'set '.length)
           ]);
+    }
+    _emitDeprecatedIf(field.isDeprecated, out);
+    _emitOverrideIf(field.overridesHasMethod, out);
+    _emitIndexAnnotation(field.number, out);
+    out.printlnAnnotated(
+        '$_coreImportPrefix.bool ${names.hasMethodName}() =>'
+        ' \$_has(${field.index});',
+        [
+          NamedLocation(
+              name: names.hasMethodName,
+              fieldPathSegment: memberFieldPath,
+              start: '$_coreImportPrefix.bool '.length)
+        ]);
+    _emitDeprecatedIf(field.isDeprecated, out);
+    _emitOverrideIf(field.overridesClearMethod, out);
+    _emitIndexAnnotation(field.number, out);
+    out.printlnAnnotated(
+        'void ${names.clearMethodName}() =>'
+        ' clearField(${field.number});',
+        [
+          NamedLocation(
+              name: names.clearMethodName,
+              fieldPathSegment: memberFieldPath,
+              start: 'void '.length)
+        ]);
+    if (field.baseType.isMessage) {
       _emitDeprecatedIf(field.isDeprecated, out);
-      _emitOverrideIf(field.overridesClearMethod, out);
       _emitIndexAnnotation(field.number, out);
       out.printlnAnnotated(
-          'void ${names.clearMethodName}() =>'
-          ' clearField(${field.number});',
-          [
+          '${fieldTypeString} ${names.ensureMethodName}() => '
+          '\$_ensure(${field.index});',
+          <NamedLocation>[
             NamedLocation(
-                name: names.clearMethodName,
+                name: names.ensureMethodName,
                 fieldPathSegment: memberFieldPath,
-                start: 'void '.length)
+                start: '${fieldTypeString} '.length)
           ]);
-      if (field.baseType.isMessage) {
-        _emitDeprecatedIf(field.isDeprecated, out);
-        _emitIndexAnnotation(field.number, out);
-        out.printlnAnnotated(
-            '${fieldTypeString} ${names.ensureMethodName}() => '
-            '\$_ensure(${field.index});',
-            <NamedLocation>[
-              NamedLocation(
-                  name: names.ensureMethodName,
-                  fieldPathSegment: memberFieldPath,
-                  start: '${fieldTypeString} '.length)
-            ]);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
When generating Dart code for protobufs that include repeated fields, `message_generator.dart` only generates the getters. This appears to be an oversight in the branching logic; there are a bunch of sanity checks that apply to repeated fields, but it otherwise skips all setter generation.

## Motivation
I'd like to use generated protobuf code with a proto that contains a repeated field

## Testing
I couldn't find any docs on how to test this locally, so going to rely on Travis CI