### PR TITLE
feat: support client interceptors

### DIFF
--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -236,7 +236,7 @@ class _GrpcMethod {
             'return \$createStreamingCall(_\$$_dartName, request, options: options).single;');
       } else if (!_clientStreaming && _serverStreaming) {
         out.println(
-            'return \$createStreamingCall(_\$$_dartName, Stream.value(request), options: options);');
+            'return \$createStreamingCall(_\$$_dartName, Stream.fromIterable([request]), options: options);');
       } else {
         out.println(
             'return \$createUnaryCall(_\$$_dartName, request, options: options);');

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -233,14 +233,16 @@ class _GrpcMethod {
     out.addBlock(
         '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
         '}', () {
-      final createCall =
-          _clientStreaming ? '\$createStreamingCall' : '\$createUnaryCall';
-      out.println(
-          'final call = $createCall(_\$$_dartName, request, options: options);');
-      if (_serverStreaming) {
-        out.println('return $_responseStream(call);');
+      final createCall = _clientStreaming || _serverStreaming
+          ? '\$createStreamingCall'
+          : '\$createUnaryCall';
+
+      if (_clientStreaming && !_serverStreaming) {
+        out.println(
+            'return $createCall(_\$$_dartName, request, options: options).toResponseFuture();');
       } else {
-        out.println('return $_responseFuture(call);');
+        out.println(
+            'return $createCall(_\$$_dartName, request, options: options);');
       }
     });
   }

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -228,14 +228,19 @@ class _GrpcMethod {
     out.addBlock(
         '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
         '}', () {
-      final createCall = _clientStreaming || _serverStreaming
-          ? r'$createStreamingCall'
-          : r'$createUnaryCall';
-
-      final cast = _clientStreaming && !_serverStreaming ? '.single' : '';
-
-      out.println(
-          'return $createCall(_\$$_dartName, request, options: options)$cast;');
+      if (_clientStreaming && _serverStreaming) {
+        out.println(
+            'return \$createStreamingCall(_\$$_dartName, request, options: options);');
+      } else if (_clientStreaming && !_serverStreaming) {
+        out.println(
+            'return \$createStreamingCall(_\$$_dartName, request, options: options).single;');
+      } else if (!_clientStreaming && _serverStreaming) {
+        out.println(
+            'return \$createStreamingCall(_\$$_dartName, Stream.value(request), options: options);');
+      } else {
+        out.println(
+            'return \$createUnaryCall(_\$$_dartName, request, options: options);');
+      }
     });
   }
 

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -224,10 +224,10 @@ class _GrpcMethod {
     out.addBlock(
         '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
         '}', () {
-      final requestStream =
-          _clientStreaming ? 'request' : '$_stream.fromIterable([request])';
+      final createCall =
+          _clientStreaming ? '\$createStreamingCall' : '\$createUnaryCall';
       out.println(
-          'final call = \$createCall(_\$$_dartName, $requestStream, options: options);');
+          'final call = $createCall(_\$$_dartName, request, options: options);');
       if (_serverStreaming) {
         out.println('return $_responseStream(call);');
       } else {

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -238,15 +238,11 @@ class _GrpcMethod {
           ? '\$createStreamingCall'
           : '\$createUnaryCall';
 
-      final request = !_clientStreaming || _serverStreaming
-          ? '$_stream.value(request)'
-          : 'request';
-
       final cast =
           _clientStreaming && !_serverStreaming ? '.toResponseFuture()' : '';
 
       out.println(
-          'return $createCall(_\$$_dartName, $request, options: options)$cast;');
+          'return $createCall(_\$$_dartName, request, options: options)$cast;');
     });
   }
 

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -113,9 +113,10 @@ class GrpcServiceGenerator {
       out.println();
       out.println('$_clientClassname($_clientChannel channel,');
       out.println('    {$_callOptions options,');
-      out.println('    Iterable<$_unaryInterceptor> unaryInterceptors,');
       out.println(
-          '    Iterable<$_streamingInterceptor> streamingInterceptors})');
+          '    $_coreImportPrefix.Iterable<$_unaryInterceptor> unaryInterceptors,');
+      out.println(
+          '    $_coreImportPrefix.Iterable<$_streamingInterceptor> streamingInterceptors})');
       out.println('    : super(channel, options: options,');
       out.println('      unaryInterceptors: unaryInterceptors,');
       out.println('      streamingInterceptors: streamingInterceptors);');
@@ -237,13 +238,15 @@ class _GrpcMethod {
           ? '\$createStreamingCall'
           : '\$createUnaryCall';
 
-      if (_clientStreaming && !_serverStreaming) {
-        out.println(
-            'return $createCall(_\$$_dartName, request, options: options).toResponseFuture();');
-      } else {
-        out.println(
-            'return $createCall(_\$$_dartName, request, options: options);');
-      }
+      final request = !_clientStreaming || _serverStreaming
+          ? '$_stream.value(request)'
+          : 'request';
+
+      final cast =
+          _clientStreaming && !_serverStreaming ? '.toResponseFuture()' : '';
+
+      out.println(
+          'return $createCall(_\$$_dartName, $request, options: options)$cast;');
     });
   }
 

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -114,12 +114,9 @@ class GrpcServiceGenerator {
       out.println('$_clientClassname($_clientChannel channel,');
       out.println('    {$_callOptions options,');
       out.println(
-          '    $_coreImportPrefix.Iterable<$_unaryInterceptor> unaryInterceptors,');
-      out.println(
-          '    $_coreImportPrefix.Iterable<$_streamingInterceptor> streamingInterceptors})');
+          '    $_coreImportPrefix.Iterable<$_interceptor> interceptors})');
       out.println('    : super(channel, options: options,');
-      out.println('      unaryInterceptors: unaryInterceptors,');
-      out.println('      streamingInterceptors: streamingInterceptors);');
+      out.println('      interceptors: interceptors);');
       for (final method in _methods) {
         method.generateClientStub(out);
       }
@@ -148,10 +145,7 @@ class GrpcServiceGenerator {
   }
 
   static final String _callOptions = '$_grpcImportPrefix.CallOptions';
-  static final String _unaryInterceptor =
-      '$_grpcImportPrefix.ClientUnaryInterceptor';
-  static final String _streamingInterceptor =
-      '$_grpcImportPrefix.ClientStreamingInterceptor';
+  static final String _interceptor = '$_grpcImportPrefix.ClientInterceptor';
   static final String _client = '$_grpcImportPrefix.Client';
   static final String _clientChannel = '$_grpcImportPrefix.ClientChannel';
   static final String _service = '$_grpcImportPrefix.Service';
@@ -235,11 +229,10 @@ class _GrpcMethod {
         '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
         '}', () {
       final createCall = _clientStreaming || _serverStreaming
-          ? '\$createStreamingCall'
-          : '\$createUnaryCall';
+          ? r'$createStreamingCall'
+          : r'$createUnaryCall';
 
-      final cast =
-          _clientStreaming && !_serverStreaming ? '.toResponseFuture()' : '';
+      final cast = _clientStreaming && !_serverStreaming ? '.single' : '';
 
       out.println(
           'return $createCall(_\$$_dartName, request, options: options)$cast;');

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -111,9 +111,14 @@ class GrpcServiceGenerator {
         method.generateClientMethodDescriptor(out);
       }
       out.println();
+      out.println('$_clientClassname($_clientChannel channel,');
+      out.println('    {$_callOptions options,');
+      out.println('    Iterable<$_unaryInterceptor> unaryInterceptors,');
       out.println(
-          '$_clientClassname($_clientChannel channel, {$_callOptions options})');
-      out.println('    : super(channel, options: options);');
+          '    Iterable<$_streamingInterceptor> streamingInterceptors})');
+      out.println('    : super(channel, options: options,');
+      out.println('      unaryInterceptors: unaryInterceptors,');
+      out.println('      streamingInterceptors: streamingInterceptors);');
       for (final method in _methods) {
         method.generateClientStub(out);
       }
@@ -142,6 +147,10 @@ class GrpcServiceGenerator {
   }
 
   static final String _callOptions = '$_grpcImportPrefix.CallOptions';
+  static final String _unaryInterceptor =
+      '$_grpcImportPrefix.ClientUnaryInterceptor';
+  static final String _streamingInterceptor =
+      '$_grpcImportPrefix.ClientStreamingInterceptor';
   static final String _client = '$_grpcImportPrefix.Client';
   static final String _clientChannel = '$_grpcImportPrefix.ClientChannel';
   static final String _service = '$_grpcImportPrefix.Service';

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -50,7 +50,8 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
       {$grpc.CallOptions options}) {
-    return $createStreamingCall(_$serverStreaming, request, options: options);
+    return $createStreamingCall(_$serverStreaming, Stream.value(request),
+        options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -42,8 +42,7 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
       {$grpc.CallOptions options}) {
-    return $createUnaryCall(_$unary, $async.Stream.value(request),
-        options: options);
+    return $createUnaryCall(_$unary, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
@@ -55,14 +54,12 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
       {$grpc.CallOptions options}) {
-    return $createStreamingCall(_$serverStreaming, $async.Stream.value(request),
-        options: options);
+    return $createStreamingCall(_$serverStreaming, request, options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
-    return $createStreamingCall(_$bidirectional, $async.Stream.value(request),
-        options: options);
+    return $createStreamingCall(_$bidirectional, request, options: options);
   }
 }
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -31,35 +31,35 @@ class TestClient extends $grpc.Client {
       ($0.Input value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
 
-  TestClient($grpc.ClientChannel channel, {$grpc.CallOptions options})
-      : super(channel, options: options);
+  TestClient($grpc.ClientChannel channel,
+      {$grpc.CallOptions options,
+      Iterable<$grpc.ClientUnaryInterceptor> unaryInterceptors,
+      Iterable<$grpc.ClientStreamingInterceptor> streamingInterceptors})
+      : super(channel,
+            options: options,
+            unaryInterceptors: unaryInterceptors,
+            streamingInterceptors: streamingInterceptors);
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
       {$grpc.CallOptions options}) {
-    final call = $createCall(_$unary, $async.Stream.fromIterable([request]),
-        options: options);
-    return $grpc.ResponseFuture(call);
+    return $createUnaryCall(_$unary, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
       $async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
-    final call = $createCall(_$clientStreaming, request, options: options);
-    return $grpc.ResponseFuture(call);
+    return $createStreamingCall(_$clientStreaming, request, options: options)
+        .toResponseFuture();
   }
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
       {$grpc.CallOptions options}) {
-    final call = $createCall(
-        _$serverStreaming, $async.Stream.fromIterable([request]),
-        options: options);
-    return $grpc.ResponseStream(call);
+    return $createStreamingCall(_$serverStreaming, request, options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
-    final call = $createCall(_$bidirectional, request, options: options);
-    return $grpc.ResponseStream(call);
+    return $createStreamingCall(_$bidirectional, request, options: options);
   }
 }
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -33,8 +33,8 @@ class TestClient extends $grpc.Client {
 
   TestClient($grpc.ClientChannel channel,
       {$grpc.CallOptions options,
-      Iterable<$grpc.ClientUnaryInterceptor> unaryInterceptors,
-      Iterable<$grpc.ClientStreamingInterceptor> streamingInterceptors})
+      $core.Iterable<$grpc.ClientUnaryInterceptor> unaryInterceptors,
+      $core.Iterable<$grpc.ClientStreamingInterceptor> streamingInterceptors})
       : super(channel,
             options: options,
             unaryInterceptors: unaryInterceptors,
@@ -42,7 +42,8 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
       {$grpc.CallOptions options}) {
-    return $createUnaryCall(_$unary, request, options: options);
+    return $createUnaryCall(_$unary, $async.Stream.value(request),
+        options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
@@ -54,12 +55,14 @@ class TestClient extends $grpc.Client {
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
       {$grpc.CallOptions options}) {
-    return $createStreamingCall(_$serverStreaming, request, options: options);
+    return $createStreamingCall(_$serverStreaming, $async.Stream.value(request),
+        options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
-    return $createStreamingCall(_$bidirectional, request, options: options);
+    return $createStreamingCall(_$bidirectional, $async.Stream.value(request),
+        options: options);
   }
 }
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -33,12 +33,8 @@ class TestClient extends $grpc.Client {
 
   TestClient($grpc.ClientChannel channel,
       {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientUnaryInterceptor> unaryInterceptors,
-      $core.Iterable<$grpc.ClientStreamingInterceptor> streamingInterceptors})
-      : super(channel,
-            options: options,
-            unaryInterceptors: unaryInterceptors,
-            streamingInterceptors: streamingInterceptors);
+      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
       {$grpc.CallOptions options}) {
@@ -49,7 +45,7 @@ class TestClient extends $grpc.Client {
       $async.Stream<$0.Input> request,
       {$grpc.CallOptions options}) {
     return $createStreamingCall(_$clientStreaming, request, options: options)
-        .toResponseFuture();
+        .single;
   }
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,


### PR DESCRIPTION
Support client-side unary and streaming interceptors with similar interface to JS grpc-web interface.
Interceptors are executed by `Client.$createStreamingCall` and `Client.$createUnaryCall`.

Backwards compatibility is retained by keeping `Client.$createCall` for code generated with incompatible `protoc-gen-dart`.