### PR TITLE
Add changes stream to GeneratedMessage

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.3
 
 * Enable hashCode memoization for frozen protos.
+* Add `changes_` stream to `GeneratedMessage`
 
 ## 1.0.2
 

--- a/protobuf/lib/meta.dart
+++ b/protobuf/lib/meta.dart
@@ -12,6 +12,7 @@ const GeneratedMessage_reservedNames = <String>[
   'GeneratedMessage',
   'Object',
   'addExtension',
+  'changes_',
   'check',
   'clear',
   'clearExtension',

--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -4,7 +4,7 @@
 
 library protobuf;
 
-import 'dart:async' show Future;
+import 'dart:async' show Future, Stream;
 import 'dart:collection' show ListBase, MapBase;
 import 'dart:convert'
     show base64Decode, base64Encode, jsonEncode, jsonDecode, Utf8Codec;

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -44,6 +44,11 @@ abstract class GeneratedMessage {
   /// to protobuf fields.
   EventPlugin get eventPlugin => null;
 
+  /// Subclasses can override this getter to provide observable-like API.
+  ///
+  /// The type of [changes_] is left to the implementation, usually via a mixin.
+  Stream get changes_ => null;
+
   /// Creates a deep copy of the fields in this message.
   /// (The generated code uses [mergeFromMessage].)
   GeneratedMessage clone();


### PR DESCRIPTION
An actual implementation should be provided via mixins.

This is a port of an internal change.