### PR TITLE
Cast repeated field to PbListBase instead of PbList

### DIFF
--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -99,7 +99,7 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
             valueToProto3Json(entryValue, mapEntryInfo.valueFieldType));
       });
     } else if (fieldInfo.isRepeated) {
-      jsonValue = (value as PbList)
+      jsonValue = (value as PbListBase)
           .map((element) => valueToProto3Json(element, fieldInfo.type))
           .toList();
     } else {

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -112,6 +112,10 @@ void main() {
       expect(getAllSet().toProto3Json(), testAllTypesJson);
     });
 
+    test('testFrozenOutput', () {
+      expect(getAllSet().freeze().toProto3Json(), testAllTypesJson);
+    });
+
     test('testUnsignedOutput', () {
       TestAllTypes message = TestAllTypes();
       // These values are selected because they are large enough to set the sign bit.


### PR DESCRIPTION
This change allows for the serialization of repeated fields in frozen
messages. Because FrozenPbList and PbList share the same base class,
PbListBase, both can be safely typecast. Without this change, the
typecast of FrozenPbList to PbList causes serialization to fail.

This is a port of an internal change.