### PR TITLE
Remove unnecessary dart:async import.

### DIFF
--- a/protobuf/lib/protobuf.dart
+++ b/protobuf/lib/protobuf.dart
@@ -4,7 +4,6 @@
 
 library protobuf;
 
-import 'dart:async' show Future;
 import 'dart:collection' show ListBase, MapBase;
 import 'dart:convert'
     show base64Decode, base64Encode, jsonEncode, jsonDecode, Utf8Codec;

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -4,7 +4,7 @@
 
 library protobuf.mixins.event;
 
-import 'dart:async' show Stream, StreamController, scheduleMicrotask;
+import 'dart:async' show StreamController, scheduleMicrotask;
 import 'dart:collection' show UnmodifiableListView;
 
 import 'package:protobuf/protobuf.dart'

--- a/protoc_plugin/lib/protoc.dart
+++ b/protoc_plugin/lib/protoc.dart
@@ -1,6 +1,5 @@
 library protoc;
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';


### PR DESCRIPTION
I'm trying to enforce this inside google3, and so it would be nice to be
able to land this.

This requires Dart 2.1, so this is technically a breaking change. If
that's not OK, then I can abandon this PR and make an exception inside
google3 instead.

Note that Dart 2.1 has been out for quite a long time now.