### PR TITLE
Throw when reading an extension that is present in the unknown fields.

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -6,6 +6,10 @@
   alternatives can result in smaller binaries, because it is defined once
   instead of once per class. Use `protoc_plugin` from 19.1.0 to generate
   deprecation warnings for `copyWith` and `clone` methods.
+* `GeneratedMessage.getExtension` throws when reading trying to read an
+  extension that is present in the unknown fields.
+  We consider this change a bug-fix because depending on the old behavior is
+  indicative of a bug in your program.
 
 ## 1.0.4
 

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -21,7 +21,10 @@ class _ExtensionFieldSet {
     // I think this was originally here for repeated extensions.
     _addInfoUnchecked(fi);
     var value = _getFieldOrNull(fi);
-    if (value == null) return fi.makeDefault();
+    if (value == null) {
+      _checkNotInUnknown(fi);
+      return fi.makeDefault();
+    }
     return value;
   }
 
@@ -50,6 +53,7 @@ class _ExtensionFieldSet {
   List<T> _getList<T>(Extension<T> fi) {
     var value = _values[fi.tagNumber];
     if (value != null) return value as List<T>;
+    _checkNotInUnknown(fi);
     if (_isReadOnly) return List<T>.unmodifiable(const []);
     return _addInfoAndCreateList(fi);
   }
@@ -182,6 +186,16 @@ class _ExtensionFieldSet {
           (entry as GeneratedMessage).freeze();
         }
       }
+    }
+  }
+
+  void _checkNotInUnknown(Extension extension) {
+    if (_parent._hasUnknownFields &&
+        _parent._unknownFields.hasField(extension.tagNumber)) {
+      throw StateError(
+          'Trying to get $extension that is present as an unknown field. '
+          'Parse the message with this extension in the extension registry or '
+          'use `ExtensionRegistry.reparseMessage`.');
     }
   }
 }

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -277,8 +277,9 @@ void main() {
         TestAllExtensions.fromBuffer(withExtensions.writeToBuffer());
     final reparsed = r.reparseMessage(withUnknownFields);
 
-    expect(withUnknownFields.getExtension(Unittest.defaultStringExtension),
-        'hello');
+    expect(
+        () => withUnknownFields.getExtension(Unittest.defaultStringExtension),
+        throwsA(const TypeMatcher<StateError>()));
 
     expect(reparsed.getExtension(Unittest.defaultStringExtension), 'bar');
 
@@ -304,12 +305,11 @@ void main() {
             .hasExtension(Extend_unittest.extensionInner),
         isFalse);
     expect(
-        onlyOuter
+        () => onlyOuter
             .reparseMessage(withUnknownFields)
             .getExtension(Extend_unittest.outer)
-            .getExtension(Extend_unittest.extensionInner)
-            .value,
-        '');
+            .getExtension(Extend_unittest.extensionInner),
+        throwsA(const TypeMatcher<StateError>()));
 
     expect(
         reparsed


### PR DESCRIPTION
This is a port of an internal change. Let me know if it is better to increase version instead of appending it to a changelog of an existing version