### PR TITLE
Make protobuf message and field names dependent on a fromEnvironment constants

### DIFF
--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -42,7 +42,7 @@ class _ExtensionFieldSet {
   List<T> _ensureRepeatedField<T>(Extension<T> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
-    assert(fi.extendee == _parent._messageName);
+    assert(fi.extendee == '' || fi.extendee == _parent._messageName);
 
     var list = _values[fi.tagNumber];
     if (list != null) return list as List<T>;

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -8,6 +8,8 @@
 
   If a target is built with `dart_env = {"protobuf.omit_enum_names": "true"}`
   enum names will not be present in the compiled binary.
+* Make message and field names dependenc on a fromEnvironment constants
+  `protobuf.omit_message_names` and `protobuf.omit_field_names` respectively.
 * Omit type on a left hand side of generated static fields for extensions,
   which results in stricter type (`Extension<ExtensionType>` instead of just
   `Extension`).

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -111,13 +111,11 @@ class EnumGenerator extends ProtobufContainer {
       for (var i = 0; i < _canonicalValues.length; i++) {
         var val = _canonicalValues[i];
         final name = dartNames[val.name];
+        final conditionalValName = configurationDependent(
+            'protobuf.omit_enum_names', quoted(val.name));
         out.printlnAnnotated(
             'static const ${classname} $name = '
-            '${classname}._(${val.number}, '
-            'const $_coreImportPrefix.bool.fromEnvironment'
-            '(\'protobuf.omit_enum_names\') ? \'\' : '
-            '${singleQuote(val.name)}'
-            ');',
+            '${classname}._(${val.number}, $conditionalValName);',
             [
               NamedLocation(
                   name: name,

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -95,12 +95,17 @@ class ExtensionGenerator {
     if (_field == null) throw StateError("resolve not called");
 
     var name = _extensionName;
+    final conditionalName = configurationDependent(
+        'protobuf.omit_field_names', quoted(_extensionName));
     var type = _field.baseType;
     var dartType = type.getDartType(fileGen);
+    final conditionalExtendedName = configurationDependent(
+        'protobuf.omit_message_names', quoted(_extendedFullName));
+
     String invocation;
     var positionals = <String>[];
-    positionals.add("'$_extendedFullName'");
-    positionals.add("'${_descriptor.jsonName}'");
+    positionals.add(conditionalExtendedName);
+    positionals.add(conditionalName);
     positionals.add('${_field.number}');
     positionals.add(_field.typeConstant);
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -19,6 +19,15 @@ const String _coreImport = "import 'dart:core' as $_coreImportPrefix;";
 const String _grpcImport =
     "import 'package:grpc/service_api.dart' as $_grpcImportPrefix;";
 
+/// Generates code that will evaluate to the empty string if
+/// `const bool.fromEnvironment(envName)` is `true` and evaluate to [value]
+/// otherwise.
+String configurationDependent(String envName, String value) {
+  return 'const $_coreImportPrefix.bool.fromEnvironment(${quoted(envName)})'
+      ' ? \'\' '
+      ': $value';
+}
+
 /// Generates the Dart output files for one .proto input file.
 ///
 /// Outputs include .pb.dart, pbenum.dart, and .pbjson.dart.

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -292,9 +292,12 @@ class MessageGenerator extends ProtobufContainer {
       mixinClause = ' with ${mixinNames.join(", ")}';
     }
 
-    var packageClause = package == ''
-        ? ''
-        : ', package: const $_protobufImportPrefix.PackageName(\'$package\')';
+    final conditionalPackageName = 'const $_protobufImportPrefix.PackageName(' +
+        configurationDependent('protobuf.omit_message_names', quoted(package)) +
+        ')';
+
+    var packageClause =
+        package == '' ? '' : ', package: $conditionalPackageName';
     var proto3JsonClause = (mixin?.hasProto3JsonHelpers ?? false)
         ? ', toProto3Json: $_mixinImportPrefix.${mixin.name}.toProto3JsonHelper, '
             'fromProto3Json: $_mixinImportPrefix.${mixin.name}.fromProto3JsonHelper'
@@ -318,9 +321,12 @@ class MessageGenerator extends ProtobufContainer {
           out.println('0 : ${oneof.oneofEnumName}.notSet');
         });
       }
+      final conditionalMessageName = configurationDependent(
+          'protobuf.omit_message_names', quoted(messageName));
       out.addBlock(
           'static final $_protobufImportPrefix.BuilderInfo _i = '
-              '$_protobufImportPrefix.BuilderInfo(\'${messageName}\'$packageClause'
+              '$_protobufImportPrefix.BuilderInfo($conditionalMessageName'
+              '$packageClause'
               ', createEmptyInstance: create'
               '$proto3JsonClause)',
           ';', () {

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -149,9 +149,10 @@ class ProtobufField {
   /// [fileGen] represents the .proto file where the code will be evaluated.
   String generateBuilderInfoCall(FileGenerator fileGen, String package) {
     assert(descriptor.hasJsonName());
-    // JSON names should be serialized as-is, but '$' can cause Dart to try to
-    // perform string interpolation on non-existent variables.
-    var quotedName = "'${descriptor.jsonName.replaceAll(r'$', r'\$')}'";
+    var quotedName = configurationDependent(
+      'protobuf.omit_field_names',
+      quoted(descriptor.jsonName),
+    );
 
     var type = baseType.getDartType(fileGen);
 

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -10,12 +10,30 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class DartMixin extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DartMixin',
-      package: const $pb.PackageName('dart_options'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'DartMixin',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_options'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOS(2, 'importFrom')
-    ..aOS(3, 'parent')
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'importFrom')
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'parent')
     ..hasRequiredFields = false;
 
   DartMixin._() : super();
@@ -84,10 +102,21 @@ class DartMixin extends $pb.GeneratedMessage {
 }
 
 class Imports extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Imports',
-      package: const $pb.PackageName('dart_options'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'Imports',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_options'),
       createEmptyInstance: create)
-    ..pc<DartMixin>(1, 'mixins', $pb.PbFieldType.PM,
+    ..pc<DartMixin>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'mixins',
+        $pb.PbFieldType.PM,
         subBuilder: DartMixin.create)
     ..hasRequiredFields = false;
 
@@ -125,37 +154,79 @@ class Imports extends $pb.GeneratedMessage {
 
 class Dart_options {
   static final imports = $pb.Extension<Imports>(
-      'google.protobuf.FileOptions', 'imports', 28125061, $pb.PbFieldType.OM,
-      defaultOrMaker: Imports.getDefault, subBuilder: Imports.create);
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FileOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'imports',
+      28125061,
+      $pb.PbFieldType.OM,
+      defaultOrMaker: Imports.getDefault,
+      subBuilder: Imports.create);
   static final defaultMixin = $pb.Extension<$core.String>(
-      'google.protobuf.FileOptions',
-      'defaultMixin',
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FileOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'defaultMixin',
       96128839,
       $pb.PbFieldType.OS);
   static final mixin = $pb.Extension<$core.String>(
-      'google.protobuf.MessageOptions', 'mixin', 96128839, $pb.PbFieldType.OS);
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.MessageOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'mixin',
+      96128839,
+      $pb.PbFieldType.OS);
   static final overrideGetter = $pb.Extension<$core.bool>(
-      'google.protobuf.FieldOptions',
-      'overrideGetter',
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FieldOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'overrideGetter',
       28205290,
       $pb.PbFieldType.OB);
   static final overrideSetter = $pb.Extension<$core.bool>(
-      'google.protobuf.FieldOptions',
-      'overrideSetter',
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FieldOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'overrideSetter',
       28937366,
       $pb.PbFieldType.OB);
   static final overrideHasMethod = $pb.Extension<$core.bool>(
-      'google.protobuf.FieldOptions',
-      'overrideHasMethod',
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FieldOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'overrideHasMethod',
       28937461,
       $pb.PbFieldType.OB);
   static final overrideClearMethod = $pb.Extension<$core.bool>(
-      'google.protobuf.FieldOptions',
-      'overrideClearMethod',
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FieldOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'overrideClearMethod',
       28907907,
       $pb.PbFieldType.OB);
   static final dartName = $pb.Extension<$core.String>(
-      'google.protobuf.FieldOptions', 'dartName', 28700919, $pb.PbFieldType.OS);
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf.FieldOptions',
+      const $core.bool.fromEnvironment('protobuf.omit_field_names')
+          ? ''
+          : 'dartName',
+      28700919,
+      $pb.PbFieldType.OS);
   static void registerAllExtensions($pb.ExtensionRegistry registry) {
     registry.add(imports);
     registry.add(defaultMixin);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -15,10 +15,21 @@ import 'descriptor.pbenum.dart';
 export 'descriptor.pbenum.dart';
 
 class FileDescriptorSet extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileDescriptorSet',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'FileDescriptorSet',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..pc<FileDescriptorProto>(1, 'file', $pb.PbFieldType.PM,
+    ..pc<FileDescriptorProto>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'file',
+        $pb.PbFieldType.PM,
         subBuilder: FileDescriptorProto.create);
 
   FileDescriptorSet._() : super();
@@ -55,26 +66,39 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
 }
 
 class FileDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FileDescriptorProto',
+      package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOS(2, 'package')
-    ..pPS(3, 'dependency')
-    ..pc<DescriptorProto>(4, 'messageType', $pb.PbFieldType.PM,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'package')
+    ..pPS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'dependency')
+    ..pc<DescriptorProto>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'messageType', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto.create)
-    ..pc<EnumDescriptorProto>(5, 'enumType', $pb.PbFieldType.PM,
+    ..pc<EnumDescriptorProto>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enumType', $pb.PbFieldType.PM,
         subBuilder: EnumDescriptorProto.create)
-    ..pc<ServiceDescriptorProto>(6, 'service', $pb.PbFieldType.PM,
+    ..pc<ServiceDescriptorProto>(
+        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'service', $pb.PbFieldType.PM,
         subBuilder: ServiceDescriptorProto.create)
-    ..pc<FieldDescriptorProto>(7, 'extension', $pb.PbFieldType.PM,
-        subBuilder: FieldDescriptorProto.create)
-    ..aOM<FileOptions>(8, 'options', subBuilder: FileOptions.create)
-    ..aOM<SourceCodeInfo>(9, 'sourceCodeInfo',
-        subBuilder: SourceCodeInfo.create)
-    ..p<$core.int>(10, 'publicDependency', $pb.PbFieldType.P3)
-    ..p<$core.int>(11, 'weakDependency', $pb.PbFieldType.P3)
-    ..aOS(12, 'syntax');
+    ..pc<FieldDescriptorProto>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'extension', $pb.PbFieldType.PM, subBuilder: FieldDescriptorProto.create)
+    ..aOM<FileOptions>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options', subBuilder: FileOptions.create)
+    ..aOM<SourceCodeInfo>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceCodeInfo', subBuilder: SourceCodeInfo.create)
+    ..p<$core.int>(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'publicDependency', $pb.PbFieldType.P3)
+    ..p<$core.int>(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'weakDependency', $pb.PbFieldType.P3)
+    ..aOS(12, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'syntax');
 
   FileDescriptorProto._() : super();
   factory FileDescriptorProto() => create();
@@ -193,11 +217,26 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
 class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'DescriptorProto.ExtensionRange',
-      package: const $pb.PackageName('google.protobuf'),
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'DescriptorProto.ExtensionRange',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, 'start', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'start',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'end',
+        $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   DescriptorProto_ExtensionRange._() : super();
@@ -259,11 +298,26 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
 
 class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'DescriptorProto.ReservedRange',
-      package: const $pb.PackageName('google.protobuf'),
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'DescriptorProto.ReservedRange',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, 'start', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, 'end', $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'start',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'end',
+        $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   DescriptorProto_ReservedRange._() : super();
@@ -324,27 +378,32 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
 }
 
 class DescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DescriptorProto',
+      package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..pc<FieldDescriptorProto>(2, 'field', $pb.PbFieldType.PM,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..pc<FieldDescriptorProto>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'field', $pb.PbFieldType.PM,
         subBuilder: FieldDescriptorProto.create)
-    ..pc<DescriptorProto>(3, 'nestedType', $pb.PbFieldType.PM,
+    ..pc<DescriptorProto>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'nestedType', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto.create)
-    ..pc<EnumDescriptorProto>(4, 'enumType', $pb.PbFieldType.PM,
+    ..pc<EnumDescriptorProto>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'enumType', $pb.PbFieldType.PM,
         subBuilder: EnumDescriptorProto.create)
     ..pc<DescriptorProto_ExtensionRange>(
-        5, 'extensionRange', $pb.PbFieldType.PM,
+        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'extensionRange', $pb.PbFieldType.PM,
         subBuilder: DescriptorProto_ExtensionRange.create)
-    ..pc<FieldDescriptorProto>(6, 'extension', $pb.PbFieldType.PM,
-        subBuilder: FieldDescriptorProto.create)
-    ..aOM<MessageOptions>(7, 'options', subBuilder: MessageOptions.create)
-    ..pc<OneofDescriptorProto>(8, 'oneofDecl', $pb.PbFieldType.PM,
-        subBuilder: OneofDescriptorProto.create)
-    ..pc<DescriptorProto_ReservedRange>(9, 'reservedRange', $pb.PbFieldType.PM,
-        subBuilder: DescriptorProto_ReservedRange.create)
-    ..pPS(10, 'reservedName');
+    ..pc<FieldDescriptorProto>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'extension', $pb.PbFieldType.PM, subBuilder: FieldDescriptorProto.create)
+    ..aOM<MessageOptions>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options', subBuilder: MessageOptions.create)
+    ..pc<OneofDescriptorProto>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'oneofDecl', $pb.PbFieldType.PM, subBuilder: OneofDescriptorProto.create)
+    ..pc<DescriptorProto_ReservedRange>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'reservedRange', $pb.PbFieldType.PM, subBuilder: DescriptorProto_ReservedRange.create)
+    ..pPS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'reservedName');
 
   DescriptorProto._() : super();
   factory DescriptorProto() => create();
@@ -427,25 +486,43 @@ class DescriptorProto extends $pb.GeneratedMessage {
 }
 
 class FieldDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FieldDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FieldDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOS(2, 'extendee')
-    ..a<$core.int>(3, 'number', $pb.PbFieldType.O3)
-    ..e<FieldDescriptorProto_Label>(4, 'label', $pb.PbFieldType.OE,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'extendee')
+    ..a<$core.int>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..e<FieldDescriptorProto_Label>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'label', $pb.PbFieldType.OE,
         defaultOrMaker: FieldDescriptorProto_Label.LABEL_OPTIONAL,
         valueOf: FieldDescriptorProto_Label.valueOf,
         enumValues: FieldDescriptorProto_Label.values)
-    ..e<FieldDescriptorProto_Type>(5, 'type', $pb.PbFieldType.OE,
+    ..e<FieldDescriptorProto_Type>(
+        5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE,
         defaultOrMaker: FieldDescriptorProto_Type.TYPE_DOUBLE,
         valueOf: FieldDescriptorProto_Type.valueOf,
         enumValues: FieldDescriptorProto_Type.values)
-    ..aOS(6, 'typeName')
-    ..aOS(7, 'defaultValue')
-    ..aOM<FieldOptions>(8, 'options', subBuilder: FieldOptions.create)
-    ..a<$core.int>(9, 'oneofIndex', $pb.PbFieldType.O3)
-    ..aOS(10, 'jsonName');
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'typeName')
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'defaultValue')
+    ..aOM<FieldOptions>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options', subBuilder: FieldOptions.create)
+    ..a<$core.int>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'oneofIndex', $pb.PbFieldType.O3)
+    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jsonName');
 
   FieldDescriptorProto._() : super();
   factory FieldDescriptorProto() => create();
@@ -601,11 +678,26 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class OneofDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('OneofDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'OneofDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOM<OneofOptions>(2, 'options', subBuilder: OneofOptions.create);
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOM<OneofOptions>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'options',
+        subBuilder: OneofOptions.create);
 
   OneofDescriptorProto._() : super();
   factory OneofDescriptorProto() => create();
@@ -665,13 +757,26 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class EnumDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'EnumDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..pc<EnumValueDescriptorProto>(2, 'value', $pb.PbFieldType.PM,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..pc<EnumValueDescriptorProto>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.PM,
         subBuilder: EnumValueDescriptorProto.create)
-    ..aOM<EnumOptions>(3, 'options', subBuilder: EnumOptions.create);
+    ..aOM<EnumOptions>(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options',
+        subBuilder: EnumOptions.create);
 
   EnumDescriptorProto._() : super();
   factory EnumDescriptorProto() => create();
@@ -733,12 +838,29 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class EnumValueDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumValueDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'EnumValueDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..a<$core.int>(2, 'number', $pb.PbFieldType.O3)
-    ..aOM<EnumValueOptions>(3, 'options', subBuilder: EnumValueOptions.create);
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..aOM<EnumValueOptions>(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options',
+        subBuilder: EnumValueOptions.create);
 
   EnumValueDescriptorProto._() : super();
   factory EnumValueDescriptorProto() => create();
@@ -811,13 +933,26 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class ServiceDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ServiceDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ServiceDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..pc<MethodDescriptorProto>(2, 'method', $pb.PbFieldType.PM,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..pc<MethodDescriptorProto>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'method', $pb.PbFieldType.PM,
         subBuilder: MethodDescriptorProto.create)
-    ..aOM<ServiceOptions>(3, 'options', subBuilder: ServiceOptions.create);
+    ..aOM<ServiceOptions>(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options',
+        subBuilder: ServiceOptions.create);
 
   ServiceDescriptorProto._() : super();
   factory ServiceDescriptorProto() => create();
@@ -881,15 +1016,35 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class MethodDescriptorProto extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MethodDescriptorProto',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'MethodDescriptorProto',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOS(2, 'inputType')
-    ..aOS(3, 'outputType')
-    ..aOM<MethodOptions>(4, 'options', subBuilder: MethodOptions.create)
-    ..aOB(5, 'clientStreaming')
-    ..aOB(6, 'serverStreaming');
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'inputType')
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'outputType')
+    ..aOM<MethodOptions>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'options',
+        subBuilder: MethodOptions.create)
+    ..aOB(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'clientStreaming')
+    ..aOB(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serverStreaming');
 
   MethodDescriptorProto._() : super();
   factory MethodDescriptorProto() => create();
@@ -998,31 +1153,49 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
 }
 
 class FileOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FileOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'FileOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOS(1, 'javaPackage')
-    ..aOS(8, 'javaOuterClassname')
-    ..e<FileOptions_OptimizeMode>(9, 'optimizeFor', $pb.PbFieldType.OE,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'javaPackage')
+    ..aOS(
+        8,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'javaOuterClassname')
+    ..e<FileOptions_OptimizeMode>(
+        9,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'optimizeFor',
+        $pb.PbFieldType.OE,
         defaultOrMaker: FileOptions_OptimizeMode.SPEED,
         valueOf: FileOptions_OptimizeMode.valueOf,
         enumValues: FileOptions_OptimizeMode.values)
-    ..aOB(10, 'javaMultipleFiles')
-    ..aOS(11, 'goPackage')
-    ..aOB(16, 'ccGenericServices')
-    ..aOB(17, 'javaGenericServices')
-    ..aOB(18, 'pyGenericServices')
-    ..aOB(20, 'javaGenerateEqualsAndHash')
-    ..aOB(23, 'deprecated')
-    ..aOB(27, 'javaStringCheckUtf8')
-    ..aOB(31, 'ccEnableArenas')
-    ..aOS(36, 'objcClassPrefix')
-    ..aOS(37, 'csharpNamespace')
-    ..aOS(39, 'swiftPrefix')
-    ..aOS(40, 'phpClassPrefix')
-    ..aOS(41, 'phpNamespace')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
-        subBuilder: UninterpretedOption.create)
+    ..aOB(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'javaMultipleFiles')
+    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'goPackage')
+    ..aOB(16, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ccGenericServices')
+    ..aOB(17, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'javaGenericServices')
+    ..aOB(18, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'pyGenericServices')
+    ..aOB(20, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'javaGenerateEqualsAndHash')
+    ..aOB(23, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deprecated')
+    ..aOB(27, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'javaStringCheckUtf8')
+    ..aOB(31, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'ccEnableArenas')
+    ..aOS(36, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'objcClassPrefix')
+    ..aOS(37, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'csharpNamespace')
+    ..aOS(39, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'swiftPrefix')
+    ..aOS(40, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'phpClassPrefix')
+    ..aOS(41, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'phpNamespace')
+    ..pc<UninterpretedOption>(999, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'uninterpretedOption', $pb.PbFieldType.PM, subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
   FileOptions._() : super();
@@ -1266,15 +1439,33 @@ class FileOptions extends $pb.GeneratedMessage {
 }
 
 class MessageOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MessageOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'MessageOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(1, 'messageSetWireFormat')
-    ..aOB(2, 'noStandardDescriptorAccessor')
-    ..aOB(3, 'deprecated')
-    ..aOB(7, 'mapEntry')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
-        subBuilder: UninterpretedOption.create)
+    ..aOB(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'messageSetWireFormat')
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'noStandardDescriptorAccessor')
+    ..aOB(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'deprecated')
+    ..aOB(
+        7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mapEntry')
+    ..pc<UninterpretedOption>(999, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'uninterpretedOption', $pb.PbFieldType.PM, subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
   MessageOptions._() : super();
@@ -1359,23 +1550,31 @@ class MessageOptions extends $pb.GeneratedMessage {
 }
 
 class FieldOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FieldOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'FieldOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..e<FieldOptions_CType>(1, 'ctype', $pb.PbFieldType.OE,
+    ..e<FieldOptions_CType>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'ctype',
+        $pb.PbFieldType.OE,
         defaultOrMaker: FieldOptions_CType.STRING,
         valueOf: FieldOptions_CType.valueOf,
         enumValues: FieldOptions_CType.values)
-    ..aOB(2, 'packed')
-    ..aOB(3, 'deprecated')
-    ..aOB(5, 'lazy')
-    ..e<FieldOptions_JSType>(6, 'jstype', $pb.PbFieldType.OE,
-        defaultOrMaker: FieldOptions_JSType.JS_NORMAL,
-        valueOf: FieldOptions_JSType.valueOf,
-        enumValues: FieldOptions_JSType.values)
-    ..aOB(10, 'weak')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
-        subBuilder: UninterpretedOption.create)
+    ..aOB(2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'packed')
+    ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deprecated')
+    ..aOB(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lazy')
+    ..e<FieldOptions_JSType>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'jstype', $pb.PbFieldType.OE, defaultOrMaker: FieldOptions_JSType.JS_NORMAL, valueOf: FieldOptions_JSType.valueOf, enumValues: FieldOptions_JSType.values)
+    ..aOB(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'weak')
+    ..pc<UninterpretedOption>(999, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'uninterpretedOption', $pb.PbFieldType.PM, subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
   FieldOptions._() : super();
@@ -1484,10 +1683,21 @@ class FieldOptions extends $pb.GeneratedMessage {
 }
 
 class OneofOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('OneofOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'OneofOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption>(
+        999,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'uninterpretedOption',
+        $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -1525,12 +1735,31 @@ class OneofOptions extends $pb.GeneratedMessage {
 }
 
 class EnumOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'EnumOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(2, 'allowAlias')
-    ..aOB(3, 'deprecated')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'allowAlias')
+    ..aOB(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'deprecated')
+    ..pc<UninterpretedOption>(
+        999,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'uninterpretedOption',
+        $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -1591,11 +1820,26 @@ class EnumOptions extends $pb.GeneratedMessage {
 }
 
 class EnumValueOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('EnumValueOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'EnumValueOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(1, 'deprecated')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..aOB(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'deprecated')
+    ..pc<UninterpretedOption>(
+        999,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'uninterpretedOption',
+        $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -1645,11 +1889,26 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 }
 
 class ServiceOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ServiceOptions',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ServiceOptions',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aOB(33, 'deprecated')
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
+    ..aOB(
+        33,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'deprecated')
+    ..pc<UninterpretedOption>(
+        999,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'uninterpretedOption',
+        $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption.create)
     ..hasExtensions = true;
 
@@ -1699,18 +1958,31 @@ class ServiceOptions extends $pb.GeneratedMessage {
 }
 
 class MethodOptions extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('MethodOptions',
-      package: const $pb.PackageName('google.protobuf'),
-      createEmptyInstance: create)
-    ..aOB(33, 'deprecated')
-    ..e<MethodOptions_IdempotencyLevel>(
-        34, 'idempotencyLevel', $pb.PbFieldType.OE,
-        defaultOrMaker: MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
-        valueOf: MethodOptions_IdempotencyLevel.valueOf,
-        enumValues: MethodOptions_IdempotencyLevel.values)
-    ..pc<UninterpretedOption>(999, 'uninterpretedOption', $pb.PbFieldType.PM,
-        subBuilder: UninterpretedOption.create)
-    ..hasExtensions = true;
+  static final $pb.BuilderInfo _i =
+      $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'MethodOptions',
+          package: const $pb.PackageName(
+              const $core.bool.fromEnvironment('protobuf.omit_message_names')
+                  ? ''
+                  : 'google.protobuf'),
+          createEmptyInstance: create)
+        ..aOB(
+            33,
+            const $core.bool.fromEnvironment('protobuf.omit_field_names')
+                ? ''
+                : 'deprecated')
+        ..e<MethodOptions_IdempotencyLevel>(
+            34, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'idempotencyLevel', $pb.PbFieldType.OE,
+            defaultOrMaker: MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN,
+            valueOf: MethodOptions_IdempotencyLevel.valueOf,
+            enumValues: MethodOptions_IdempotencyLevel.values)
+        ..pc<UninterpretedOption>(
+            999,
+            const $core.bool.fromEnvironment('protobuf.omit_field_names')
+                ? ''
+                : 'uninterpretedOption',
+            $pb.PbFieldType.PM,
+            subBuilder: UninterpretedOption.create)
+        ..hasExtensions = true;
 
   MethodOptions._() : super();
   factory MethodOptions() => create();
@@ -1771,11 +2043,25 @@ class MethodOptions extends $pb.GeneratedMessage {
 
 class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'UninterpretedOption.NamePart',
-      package: const $pb.PackageName('google.protobuf'),
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'UninterpretedOption.NamePart',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..aQS(1, 'namePart')
-    ..a<$core.bool>(2, 'isExtension', $pb.PbFieldType.QB);
+    ..aQS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'namePart')
+    ..a<$core.bool>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'isExtension',
+        $pb.PbFieldType.QB);
 
   UninterpretedOption_NamePart._() : super();
   factory UninterpretedOption_NamePart() => create();
@@ -1835,18 +2121,28 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
 }
 
 class UninterpretedOption extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('UninterpretedOption',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'UninterpretedOption',
+      package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'google.protobuf'),
       createEmptyInstance: create)
-    ..pc<UninterpretedOption_NamePart>(2, 'name', $pb.PbFieldType.PM,
+    ..pc<UninterpretedOption_NamePart>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name', $pb.PbFieldType.PM,
         subBuilder: UninterpretedOption_NamePart.create)
-    ..aOS(3, 'identifierValue')
-    ..a<$fixnum.Int64>(4, 'positiveIntValue', $pb.PbFieldType.OU6,
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'identifierValue')
+    ..a<$fixnum.Int64>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'positiveIntValue', $pb.PbFieldType.OU6,
         defaultOrMaker: $fixnum.Int64.ZERO)
-    ..aInt64(5, 'negativeIntValue')
-    ..a<$core.double>(6, 'doubleValue', $pb.PbFieldType.OD)
-    ..a<$core.List<$core.int>>(7, 'stringValue', $pb.PbFieldType.OY)
-    ..aOS(8, 'aggregateValue');
+    ..aInt64(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'negativeIntValue')
+    ..a<$core.double>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'doubleValue', $pb.PbFieldType.OD)
+    ..a<$core.List<$core.int>>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'stringValue', $pb.PbFieldType.OY)
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'aggregateValue');
 
   UninterpretedOption._() : super();
   factory UninterpretedOption() => create();
@@ -1954,14 +2250,31 @@ class UninterpretedOption extends $pb.GeneratedMessage {
 }
 
 class SourceCodeInfo_Location extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceCodeInfo.Location',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'SourceCodeInfo.Location',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(1, 'path', $pb.PbFieldType.K3)
-    ..p<$core.int>(2, 'span', $pb.PbFieldType.K3)
-    ..aOS(3, 'leadingComments')
-    ..aOS(4, 'trailingComments')
-    ..pPS(6, 'leadingDetachedComments')
+    ..p<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'path',
+        $pb.PbFieldType.K3)
+    ..p<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'span',
+        $pb.PbFieldType.K3)
+    ..aOS(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'leadingComments')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'trailingComments')
+    ..pPS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'leadingDetachedComments')
     ..hasRequiredFields = false;
 
   SourceCodeInfo_Location._() : super();
@@ -2030,10 +2343,21 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
 }
 
 class SourceCodeInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceCodeInfo',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'SourceCodeInfo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..pc<SourceCodeInfo_Location>(1, 'location', $pb.PbFieldType.PM,
+    ..pc<SourceCodeInfo_Location>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'location',
+        $pb.PbFieldType.PM,
         subBuilder: SourceCodeInfo_Location.create)
     ..hasRequiredFields = false;
 
@@ -2072,13 +2396,30 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
 
 class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'GeneratedCodeInfo.Annotation',
-      package: const $pb.PackageName('google.protobuf'),
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GeneratedCodeInfo.Annotation',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..p<$core.int>(1, 'path', $pb.PbFieldType.K3)
-    ..aOS(2, 'sourceFile')
-    ..a<$core.int>(3, 'begin', $pb.PbFieldType.O3)
-    ..a<$core.int>(4, 'end', $pb.PbFieldType.O3)
+    ..p<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'path',
+        $pb.PbFieldType.K3)
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'sourceFile')
+    ..a<$core.int>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'begin',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'end', $pb.PbFieldType.O3)
     ..hasRequiredFields = false;
 
   GeneratedCodeInfo_Annotation._() : super();
@@ -2154,10 +2495,21 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
 }
 
 class GeneratedCodeInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('GeneratedCodeInfo',
-      package: const $pb.PackageName('google.protobuf'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GeneratedCodeInfo',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
       createEmptyInstance: create)
-    ..pc<GeneratedCodeInfo_Annotation>(1, 'annotation', $pb.PbFieldType.PM,
+    ..pc<GeneratedCodeInfo_Annotation>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'annotation',
+        $pb.PbFieldType.PM,
         subBuilder: GeneratedCodeInfo_Annotation.create)
     ..hasRequiredFields = false;
 

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -12,13 +12,32 @@ import 'package:protobuf/protobuf.dart' as $pb;
 import 'descriptor.pb.dart' as $0;
 
 class Version extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Version',
-      package: const $pb.PackageName('google.protobuf.compiler'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'Version',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..a<$core.int>(1, 'major', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, 'minor', $pb.PbFieldType.O3)
-    ..a<$core.int>(3, 'patch', $pb.PbFieldType.O3)
-    ..aOS(4, 'suffix')
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'major',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'minor',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'patch',
+        $pb.PbFieldType.O3)
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'suffix')
     ..hasRequiredFields = false;
 
   Version._() : super();
@@ -99,13 +118,30 @@ class Version extends $pb.GeneratedMessage {
 }
 
 class CodeGeneratorRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CodeGeneratorRequest',
-      package: const $pb.PackageName('google.protobuf.compiler'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CodeGeneratorRequest',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..pPS(1, 'fileToGenerate')
-    ..aOS(2, 'parameter')
-    ..aOM<Version>(3, 'compilerVersion', subBuilder: Version.create)
-    ..pc<$0.FileDescriptorProto>(15, 'protoFile', $pb.PbFieldType.PM,
+    ..pPS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'fileToGenerate')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'parameter')
+    ..aOM<Version>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'compilerVersion',
+        subBuilder: Version.create)
+    ..pc<$0.FileDescriptorProto>(
+        15, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'protoFile', $pb.PbFieldType.PM,
         subBuilder: $0.FileDescriptorProto.create);
 
   CodeGeneratorRequest._() : super();
@@ -173,12 +209,29 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
 
 class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      'CodeGeneratorResponse.File',
-      package: const $pb.PackageName('google.protobuf.compiler'),
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CodeGeneratorResponse.File',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..aOS(1, 'name')
-    ..aOS(2, 'insertionPoint')
-    ..aOS(15, 'content')
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'insertionPoint')
+    ..aOS(
+        15,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'content')
     ..hasRequiredFields = false;
 
   CodeGeneratorResponse_File._() : super();
@@ -250,11 +303,26 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
 }
 
 class CodeGeneratorResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CodeGeneratorResponse',
-      package: const $pb.PackageName('google.protobuf.compiler'),
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CodeGeneratorResponse',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf.compiler'),
       createEmptyInstance: create)
-    ..aOS(1, 'error')
-    ..pc<CodeGeneratorResponse_File>(15, 'file', $pb.PbFieldType.PM,
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'error')
+    ..pc<CodeGeneratorResponse_File>(
+        15,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'file',
+        $pb.PbFieldType.PM,
         subBuilder: CodeGeneratorResponse_File.create)
     ..hasRequiredFields = false;
 

--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -29,6 +29,8 @@ import 'mixin_test.dart' as mixin_test;
 import 'names_test.dart' as names;
 import 'oneof_test.dart' as oneof;
 import 'omit_enum_names_test.dart' as omit_enum_names;
+import 'omit_field_names_test.dart' as omit_field_names;
+import 'omit_message_names_test.dart' as omit_message_names;
 import 'protoc_options_test.dart' as protoc_options;
 import 'repeated_field_test.dart' as repeated_field;
 import 'service_test.dart' as service;
@@ -63,6 +65,8 @@ void main() {
   names.main();
   oneof.main();
   omit_enum_names.main();
+  omit_field_names.main();
+  omit_message_names.main();
   protoc_options.main();
   repeated_field.main();
   service.main();

--- a/protoc_plugin/test/goldens/extension
+++ b/protoc_plugin/test/goldens/extension
@@ -1,1 +1,1 @@
-static final clientInfo = $pb.Extension<$core.String>('Card', 'clientInfo', 261486461, $pb.PbFieldType.OS);
+static final clientInfo = $pb.Extension<$core.String>(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Card', const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'clientInfo', 261486461, $pb.PbFieldType.OS);

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -10,7 +10,7 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Empty', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Empty', createEmptyInstance: create)
     ..hasRequiredFields = false
   ;
 

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -13,10 +13,10 @@ import 'package1.pb.dart' as $1;
 import 'package2.pb.dart' as $2;
 
 class M extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('M', createEmptyInstance: create)
-    ..aOM<M>(1, 'm', subBuilder: M.create)
-    ..aOM<$1.M>(2, 'm1', subBuilder: $1.M.create)
-    ..aOM<$2.M>(3, 'm2', subBuilder: $2.M.create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'M', createEmptyInstance: create)
+    ..aOM<M>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm', subBuilder: M.create)
+    ..aOM<$1.M>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm1', subBuilder: $1.M.create)
+    ..aOM<$2.M>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'm2', subBuilder: $2.M.create)
     ..hasRequiredFields = false
   ;
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -11,8 +11,8 @@ import 'package:fixnum/fixnum.dart' as $fixnum;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Int64 extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Int64', createEmptyInstance: create)
-    ..aInt64(1, 'value')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Int64', createEmptyInstance: create)
+    ..aInt64(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value')
     ..hasRequiredFields = false
   ;
 

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -1,9 +1,9 @@
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PhoneNumber', createEmptyInstance: create)
-    ..aQS(1, 'number')
-    ..e<PhoneNumber_PhoneType>(2, 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
-    ..a<$core.String>(3, 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
-    ..aOS(4, 'deprecatedField')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PhoneNumber', createEmptyInstance: create)
+    ..aQS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'number')
+    ..e<PhoneNumber_PhoneType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: PhoneNumber_PhoneType.MOBILE, valueOf: PhoneNumber_PhoneType.valueOf, enumValues: PhoneNumber_PhoneType.values)
+    ..a<$core.String>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deprecatedField')
   ;
 
   PhoneNumber._() : super();

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: 
-  begin: 472
-  end: 483
+  begin: 819
+  end: 830
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1900
-  end: 1906
+  begin: 2247
+  end: 2253
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 1948
-  end: 1954
+  begin: 2295
+  end: 2301
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2027
-  end: 2036
+  begin: 2374
+  end: 2383
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2079
-  end: 2090
+  begin: 2426
+  end: 2437
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2160
-  end: 2164
+  begin: 2507
+  end: 2511
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2205
-  end: 2209
+  begin: 2552
+  end: 2556
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2288
-  end: 2295
+  begin: 2635
+  end: 2642
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2338
-  end: 2347
+  begin: 2685
+  end: 2694
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2408
-  end: 2412
+  begin: 2755
+  end: 2759
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2459
-  end: 2463
+  begin: 2806
+  end: 2810
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2536
-  end: 2543
+  begin: 2883
+  end: 2890
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2586
-  end: 2595
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 2705
-  end: 2720
+  begin: 2933
+  end: 2942
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2811
-  end: 2826
+  begin: 3052
+  end: 3067
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 2948
-  end: 2966
+  begin: 3158
+  end: 3173
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3058
-  end: 3078
+  begin: 3295
+  end: 3313
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3405
+  end: 3425
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -10,10 +10,10 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class PhoneNumber extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('PhoneNumber', createEmptyInstance: create)
-    ..aQS(1, 'number')
-    ..a<$core.int>(2, 'type', $pb.PbFieldType.O3)
-    ..a<$core.String>(3, 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'PhoneNumber', createEmptyInstance: create)
+    ..aQS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'number')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.O3)
+    ..a<$core.String>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name', $pb.PbFieldType.OS, defaultOrMaker: '\$')
   ;
 
   PhoneNumber._() : super();

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -9,8 +9,8 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 667
-  end: 678
+  begin: 945
+  end: 956
 }
 annotation: {
   path: 4
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2095
-  end: 2101
+  begin: 2373
+  end: 2379
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2143
-  end: 2149
+  begin: 2421
+  end: 2427
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2222
-  end: 2231
+  begin: 2500
+  end: 2509
 }
 annotation: {
   path: 4
@@ -45,17 +45,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2274
-  end: 2285
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 1
-  sourceFile: test
-  begin: 2343
-  end: 2347
+  begin: 2552
+  end: 2563
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2389
-  end: 2393
+  begin: 2621
+  end: 2625
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2468
-  end: 2475
+  begin: 2667
+  end: 2671
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2518
-  end: 2527
+  begin: 2746
+  end: 2753
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2796
+  end: 2805
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2588
-  end: 2592
+  begin: 2866
+  end: 2870
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2639
-  end: 2643
+  begin: 2917
+  end: 2921
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2716
-  end: 2723
+  begin: 2994
+  end: 3001
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2766
-  end: 2775
+  begin: 3044
+  end: 3053
 }

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -11,7 +11,7 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class Empty extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Empty', createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Empty', createEmptyInstance: create)
     ..hasRequiredFields = false
   ;
 

--- a/protoc_plugin/test/omit_field_names_test.dart
+++ b/protoc_plugin/test/omit_field_names_test.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import '../out/protos/google/protobuf/unittest.pb.dart';
+
+@pragma('dart2js:noInline')
+String constant() => 'SHOULD_BE_PRESENT';
+
+Future<void> main() async {
+  test('enum name available depending on environment', () {
+    var proto = TestAllTypes()..optionalForeignMessage = ForeignMessage();
+    expect(
+        proto.toString(),
+        const bool.fromEnvironment('protobuf.omit_field_names')
+            ? ': {\n}\n'
+            : 'optionalForeignMessage: {\n}\n');
+    expect(constant(), 'SHOULD_BE_PRESENT');
+  });
+}

--- a/protoc_plugin/test/omit_message_names_test.dart
+++ b/protoc_plugin/test/omit_message_names_test.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import '../out/protos/google/protobuf/unittest.pb.dart';
+
+@pragma('dart2js:noInline')
+String constant() => 'SHOULD_BE_PRESENT';
+
+Future<void> main() async {
+  test('message name available depending on environment', () {
+    expect(
+        TestAllTypes_NestedMessage().info_.qualifiedMessageName,
+        const bool.fromEnvironment('protobuf.omit_message_names')
+            ? ''
+            : 'protobuf_unittest.TestAllTypes.NestedMessage');
+    expect(constant(), 'SHOULD_BE_PRESENT');
+  });
+}


### PR DESCRIPTION
Port of an internal change.

This PR is created on top of #401 and #402, I'll update it once parents are merged