### PR TITLE
Make CodedBufferWriter.writeRawBytes public

### DIFF
--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -219,7 +219,7 @@ class CodedBufferWriter {
 
   /// Add TypedData splice - these bytes would be directly copied into the
   /// output buffer by [writeTo].
-  void _writeRawBytes(TypedData value) {
+  void writeRawBytes(TypedData value) {
     _commitSplice();
     _splices.add(value);
     _bytesTotal += value.lengthInBytes;
@@ -392,7 +392,7 @@ class CodedBufferWriter {
 
   void _writeBytesNoTag(dynamic value) {
     writeInt32NoTag(value.length);
-    _writeRawBytes(value);
+    writeRawBytes(value);
   }
 
   void _writeTag(int fieldNumber, int wireFormat) {


### PR DESCRIPTION
writeRawBytes might be occasionally useful to write length-delimited
streams of proto messages. Also it used to be public before
https://github.com/dart-lang/protobuf/commit/6e53bb1404f69d033ecc20afc77a586a6cb6e720