### PR TITLE
add fromJsonObject method so that generated code could parse Proto3 json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Protobuf support for dart
+# A Better ProtoBuf Library For Dart
 
 [![Build Status](https://travis-ci.org/dart-lang/protobuf.svg?branch=master)](https://travis-ci.org/dart-lang/protobuf)
 

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -105,7 +105,7 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     } else {
       jsonValue = valueToProto3Json(value, fieldInfo.type);
     }
-    result[fieldInfo.name] = jsonValue;
+    result[fieldInfo.protoName] = jsonValue;
   }
   // Extensions and unknown fields are not encoded by proto3 JSON.
   return result;

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -365,7 +365,8 @@ class MessageGenerator extends ProtobufContainer {
       out.println('factory ${classname}.fromJson($_coreImportPrefix.String i,'
           ' [$_protobufImportPrefix.ExtensionRegistry r = $_protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' => create()..mergeFromJson(i, r);');
-      out.println('factory ${classname}.fromJsonObject(\$core.Object o) => create()..mergeFromProto3Json(o);');
+      out.println(
+          'factory ${classname}.fromJsonObject(\$core.Object o) => create()..mergeFromProto3Json(o);');
       out.println('''@$_coreImportPrefix.Deprecated(
 'Using this can add significant overhead to your binary. '
 'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -507,6 +507,7 @@ class MessageGenerator extends ProtobufContainer {
         out.printlnAnnotated(
             'set ${names.fieldName}'
             '($fieldTypeString v) { '
+            'if (v == null) return;'
             '$fastSetter(${field.index}, v);'
             ' }',
             [
@@ -519,6 +520,7 @@ class MessageGenerator extends ProtobufContainer {
         out.printlnAnnotated(
             'set ${names.fieldName}'
             '($fieldTypeString v) { '
+            'if (v == null) return;'
             'setField(${field.number}, v);'
             ' }',
             [

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -365,6 +365,7 @@ class MessageGenerator extends ProtobufContainer {
       out.println('factory ${classname}.fromJson($_coreImportPrefix.String i,'
           ' [$_protobufImportPrefix.ExtensionRegistry r = $_protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' => create()..mergeFromJson(i, r);');
+      out.println('factory ${classname}.fromJsonObject(\$core.Object o) => create()..mergeFromProto3Json(o);');
       out.println('''@$_coreImportPrefix.Deprecated(
 'Using this can add significant overhead to your binary. '
 'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   fixnum: ^0.10.9
   path: ^1.0.0
-  protobuf: '>=1.1.0 <2.0.0'
+  protobuf:
+    path: ../protobuf
   dart_style: ^1.0.6
 
 dev_dependencies:

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -10,6 +10,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   factory PhoneNumber() => create();
   factory PhoneNumber.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
   factory PhoneNumber.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  factory PhoneNumber.fromJsonObject($core.Object o) => create()..mergeFromProto3Json(o);
   @$core.Deprecated(
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '


### PR DESCRIPTION
Generated code could only parse json with integer keys.

This commit adds a fromJsonObject to the generated code so that end user could use fromJsonObject to parse json with string keys (i.e. field names in ProtoBuf Message).