### PR TITLE
Null safe package:protobuf and null safe code generation

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-nullsafety.0
+
+* Require at least Dart SDK 2.12.0 and support null safety. Use `protoc_plugin`
+  from 19.2.0 to generate null-safe code.
+
 ## 1.1.0
 
 * Require at least Dart SDK 2.7.0 to enable usage of extension methods.

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -16,16 +16,16 @@ class BuilderInfo {
   final Map<int, int> oneofs = <int, int>{};
   bool hasExtensions = false;
   bool hasRequiredFields = true;
-  List<FieldInfo> _sortedByTag;
+  List<FieldInfo>? _sortedByTag;
 
   // For well-known types.
-  final Object Function(GeneratedMessage message, TypeRegistry typeRegistry)
+  final Object? Function(GeneratedMessage message, TypeRegistry typeRegistry)?
       toProto3Json;
   final Function(GeneratedMessage targetMessage, Object json,
-      TypeRegistry typeRegistry, JsonParsingContext context) fromProto3Json;
-  final CreateBuilderFunc createEmptyInstance;
+      TypeRegistry typeRegistry, JsonParsingContext context)? fromProto3Json;
+  final CreateBuilderFunc? createEmptyInstance;
 
-  BuilderInfo(String messageName,
+  BuilderInfo(String? messageName,
       {PackageName package = const PackageName(''),
       this.createEmptyInstance,
       this.toProto3Json,
@@ -35,16 +35,16 @@ class BuilderInfo {
   void add<T>(
       int tagNumber,
       String name,
-      int fieldType,
+      int? fieldType,
       dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      {String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      {String? protoName}) {
     var index = byIndex.length;
     final fieldInfo = (tagNumber == 0)
         ? FieldInfo.dummy(index)
-        : FieldInfo<T>(name, tagNumber, index, fieldType,
+        : FieldInfo<T>(name, tagNumber, index, fieldType!,
             defaultOrMaker: defaultOrMaker,
             subBuilder: subBuilder,
             valueOf: valueOf,
@@ -56,11 +56,11 @@ class BuilderInfo {
   void addMapField<K, V>(
       int tagNumber,
       String name,
-      int keyFieldType,
-      int valueFieldType,
+      int? keyFieldType,
+      int? valueFieldType,
       BuilderInfo mapEntryBuilderInfo,
-      CreateBuilderFunc valueCreator,
-      {String protoName}) {
+      CreateBuilderFunc? valueCreator,
+      {String? protoName}) {
     var index = byIndex.length;
     _addField(MapFieldInfo<K, V>(name, tagNumber, index, PbFieldType.M,
         keyFieldType, valueFieldType, mapEntryBuilderInfo, valueCreator,
@@ -72,10 +72,10 @@ class BuilderInfo {
       String name,
       int fieldType,
       CheckFunc<T> check,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      {String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      {String? protoName}) {
     var index = byIndex.length;
     _addField(FieldInfo<T>.repeated(
         name, tagNumber, index, fieldType, check, subBuilder,
@@ -84,7 +84,7 @@ class BuilderInfo {
 
   void _addField(FieldInfo fi) {
     byIndex.add(fi);
-    assert(byIndex[fi.index] == fi);
+    assert(byIndex[fi.index!] == fi);
     // Fields with tag number 0 are considered dummy fields added to avoid
     // index calculations add up. They should not be reflected in the following
     // maps.
@@ -97,10 +97,10 @@ class BuilderInfo {
 
   void a<T>(int tagNumber, String name, int fieldType,
       {dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName}) {
     add<T>(tagNumber, name, fieldType, defaultOrMaker, subBuilder, valueOf,
         enumValues,
         protoName: protoName);
@@ -108,32 +108,32 @@ class BuilderInfo {
 
   /// Adds PbFieldType.OS String with no default value to reduce generated
   /// code size.
-  void aOS(int tagNumber, String name, {String protoName}) {
+  void aOS(int tagNumber, String name, {String? protoName}) {
     add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null,
         protoName: protoName);
   }
 
   /// Adds PbFieldType.PS String with no default value.
-  void pPS(int tagNumber, String name, {String protoName}) {
+  void pPS(int tagNumber, String name, {String? protoName}) {
     addRepeated<String>(tagNumber, name, PbFieldType.PS,
         getCheckFunction(PbFieldType.PS), null, null, null,
         protoName: protoName);
   }
 
   /// Adds PbFieldType.QS String with no default value.
-  void aQS(int tagNumber, String name, {String protoName}) {
+  void aQS(int tagNumber, String name, {String? protoName}) {
     add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null,
         protoName: protoName);
   }
 
   /// Adds Int64 field with Int64.ZERO default.
-  void aInt64(int tagNumber, String name, {String protoName}) {
+  void aInt64(int tagNumber, String name, {String? protoName}) {
     add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null,
         protoName: protoName);
   }
 
   /// Adds a boolean with no default value.
-  void aOB(int tagNumber, String name, {String protoName}) {
+  void aOB(int tagNumber, String name, {String? protoName}) {
     add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null,
         protoName: protoName);
   }
@@ -141,16 +141,16 @@ class BuilderInfo {
   // Enum.
   void e<T>(int tagNumber, String name, int fieldType,
       {dynamic defaultOrMaker,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName}) {
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName}) {
     add<T>(
         tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues,
         protoName: protoName);
   }
 
   // Repeated, not a message, group, or enum.
-  void p<T>(int tagNumber, String name, int fieldType, {String protoName}) {
+  void p<T>(int tagNumber, String name, int fieldType, {String? protoName}) {
     assert(!_isGroupOrMessage(fieldType) && !_isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, getCheckFunction(fieldType),
         null, null, null,
@@ -159,10 +159,10 @@ class BuilderInfo {
 
   // Repeated message, group, or enum.
   void pc<T>(int tagNumber, String name, int fieldType,
-      {CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName}) {
+      {CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName}) {
     assert(_isGroupOrMessage(fieldType) || _isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, _checkNotNull, subBuilder,
         valueOf, enumValues,
@@ -170,7 +170,7 @@ class BuilderInfo {
   }
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function() subBuilder, String protoName}) {
+      {T Function()? subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,
@@ -183,7 +183,7 @@ class BuilderInfo {
   }
 
   void aQM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function() subBuilder, String protoName}) {
+      {T Function()? subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,
@@ -202,14 +202,14 @@ class BuilderInfo {
 
   // Map field.
   void m<K, V>(int tagNumber, String name,
-      {String entryClassName,
-      int keyFieldType,
-      int valueFieldType,
-      CreateBuilderFunc valueCreator,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
+      {String? entryClassName,
+      int? keyFieldType,
+      int? valueFieldType,
+      CreateBuilderFunc? valueCreator,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
       PackageName packageName = const PackageName(''),
-      String protoName}) {
+      String? protoName}) {
     var mapEntryBuilderInfo = BuilderInfo(entryClassName, package: packageName)
       ..add(PbMap._keyFieldNumber, 'key', keyFieldType, null, null, null, null)
       ..add(PbMap._valueFieldNumber, 'value', valueFieldType, null,
@@ -228,32 +228,32 @@ class BuilderInfo {
   }
 
   // Returns the field name for a given tag number, for debugging purposes.
-  String fieldName(int tagNumber) {
+  String? fieldName(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.name : null;
   }
 
-  int fieldType(int tagNumber) {
+  int? fieldType(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.type : null;
   }
 
-  MakeDefaultFunc makeDefault(int tagNumber) {
+  MakeDefaultFunc? makeDefault(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.makeDefault : null;
   }
 
-  CreateBuilderFunc subBuilder(int tagNumber) {
+  CreateBuilderFunc? subBuilder(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.subBuilder : null;
   }
 
-  int tagNumber(String fieldName) {
+  int? tagNumber(String fieldName) {
     var i = byName[fieldName];
     return i != null ? i.tagNumber : null;
   }
 
-  ValueOfFunc valueOfFunc(int tagNumber) {
+  ValueOfFunc? valueOfFunc(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.valueOf : null;
   }
@@ -277,23 +277,23 @@ class BuilderInfo {
   }
 
   GeneratedMessage _makeEmptyMessage(
-      int tagNumber, ExtensionRegistry extensionRegistry) {
+      int tagNumber, ExtensionRegistry? extensionRegistry) {
     var subBuilderFunc = subBuilder(tagNumber);
     if (subBuilderFunc == null && extensionRegistry != null) {
       subBuilderFunc = extensionRegistry
-          .getExtension(qualifiedMessageName, tagNumber)
+          .getExtension(qualifiedMessageName, tagNumber)!
           .subBuilder;
     }
-    return subBuilderFunc();
+    return subBuilderFunc!();
   }
 
-  ProtobufEnum _decodeEnum(
-      int tagNumber, ExtensionRegistry registry, int rawValue) {
+  ProtobufEnum? _decodeEnum(
+      int tagNumber, ExtensionRegistry? registry, int rawValue) {
     var f = valueOfFunc(tagNumber);
     if (f == null && registry != null) {
-      f = registry.getExtension(qualifiedMessageName, tagNumber).valueOf;
+      f = registry.getExtension(qualifiedMessageName, tagNumber)!.valueOf;
     }
-    return f(rawValue);
+    return f!(rawValue);
   }
 }
 

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -10,25 +10,25 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
   // https://developers.google.com/protocol-buffers/docs/encoding?hl=en#order
 
   for (var fi in fs._infosSortedByTag) {
-    var value = fs._values[fi.index];
+    var value = fs._values[fi.index!];
     if (value == null) continue;
     out.writeField(fi.tagNumber, fi.type, value);
   }
 
   if (fs._hasExtensions) {
-    for (var tagNumber in _sorted(fs._extensions._tagNumbers)) {
-      var fi = fs._extensions._getInfoOrNull(tagNumber);
-      out.writeField(tagNumber, fi.type, fs._extensions._getFieldOrNull(fi));
+    for (var tagNumber in _sorted(fs._extensions!._tagNumbers)) {
+      var fi = fs._extensions!._getInfoOrNull(tagNumber)!;
+      out.writeField(tagNumber, fi.type, fs._extensions!._getFieldOrNull(fi));
     }
   }
   if (fs._hasUnknownFields) {
-    fs._unknownFields.writeToCodedBufferWriter(out);
+    fs._unknownFields!.writeToCodedBufferWriter(out);
   }
 }
 
 void _mergeFromCodedBufferReader(
     _FieldSet fs, CodedBufferReader input, ExtensionRegistry registry) {
-  assert(registry != null);
+  ArgumentError.checkNotNull(registry);
 
   while (true) {
     var tag = input.readTag();
@@ -182,7 +182,7 @@ void _mergeFromCodedBufferReader(
         fs._ensureRepeatedField(fi).add(subMessage);
         break;
       case PbFieldType._MAP:
-        fs._ensureMapField(fi)._mergeEntry(input, registry);
+        fs._ensureMapField(fi as MapFieldInfo)._mergeEntry(input, registry);
         break;
       default:
         throw 'Unknown field type $fieldType';

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -37,14 +37,14 @@ class CodedBufferWriter {
 
   /// Current chunk used to write data into. Once it is full it is
   /// pushed into [_outputChunks] and a new one is allocated.
-  Uint8List _outputChunk;
+  Uint8List? _outputChunk;
 
   /// Number of bytes written into the [_outputChunk].
   int _bytesInChunk = 0;
 
   /// ByteData pointing to [_outputChunk]. Used to write primitive values
   /// more efficiently.
-  ByteData _outputChunkAsByteData;
+  ByteData? _outputChunkAsByteData;
 
   /// Array of pairs <Uint8List chunk, int bytesInChunk> - chunks are
   /// pushed into this array once they are full.
@@ -186,7 +186,7 @@ class CodedBufferWriter {
     if (allocateNew) {
       _outputChunk = Uint8List(_chunkLength);
       _bytesInChunk = 0;
-      _outputChunkAsByteData = ByteData.view(_outputChunk.buffer);
+      _outputChunkAsByteData = ByteData.view(_outputChunk!.buffer);
     } else {
       _outputChunk = _outputChunkAsByteData = null;
       _bytesInChunk = 0;
@@ -242,7 +242,7 @@ class CodedBufferWriter {
   }
 
   void _endLengthDelimited(int index) {
-    final int writtenSizeInBytes = _bytesTotal - _splices[index];
+    final writtenSizeInBytes = _bytesTotal - _splices[index] as int;
     // Note: 0 - writtenSizeInBytes to avoid -0.0 in JavaScript.
     _splices[index] = 0 - writtenSizeInBytes;
     _bytesTotal += _varint32LengthInBytes(writtenSizeInBytes);
@@ -261,10 +261,10 @@ class CodedBufferWriter {
     _ensureBytes(5);
     var i = _bytesInChunk;
     while (value >= 0x80) {
-      _outputChunk[i++] = 0x80 | (value & 0x7f);
+      _outputChunk![i++] = 0x80 | (value & 0x7f);
       value >>= 7;
     }
-    _outputChunk[i++] = value;
+    _outputChunk![i++] = value;
     _bytesTotal += (i - _bytesInChunk);
     _bytesInChunk = i;
   }
@@ -275,11 +275,11 @@ class CodedBufferWriter {
     var lo = value.toUnsigned(32).toInt();
     var hi = (value >> 32).toUnsigned(32).toInt();
     while (hi > 0 || lo >= 0x80) {
-      _outputChunk[i++] = 0x80 | (lo & 0x7f);
+      _outputChunk![i++] = 0x80 | (lo & 0x7f);
       lo = (lo >> 7) | ((hi & 0x7f) << 25);
       hi >>= 7;
     }
-    _outputChunk[i++] = lo;
+    _outputChunk![i++] = lo;
     _bytesTotal += (i - _bytesInChunk);
     _bytesInChunk = i;
   }
@@ -291,7 +291,7 @@ class CodedBufferWriter {
       return;
     }
     _ensureBytes(8);
-    _outputChunkAsByteData.setFloat64(_bytesInChunk, value, Endian.little);
+    _outputChunkAsByteData!.setFloat64(_bytesInChunk, value, Endian.little);
     _bytesInChunk += 8;
     _bytesTotal += 8;
   }
@@ -308,7 +308,7 @@ class CodedBufferWriter {
     } else {
       const sz = 4;
       _ensureBytes(sz);
-      _outputChunkAsByteData.setFloat32(_bytesInChunk, value, Endian.little);
+      _outputChunkAsByteData!.setFloat32(_bytesInChunk, value, Endian.little);
       _bytesInChunk += sz;
       _bytesTotal += sz;
     }
@@ -317,8 +317,8 @@ class CodedBufferWriter {
   void _writeInt32(int value) {
     const sizeInBytes = 4;
     _ensureBytes(sizeInBytes);
-    _outputChunkAsByteData.setInt32(
-        _bytesInChunk, value & 0xFFFFFFFF, Endian.little);
+    _outputChunkAsByteData!
+        .setInt32(_bytesInChunk, value & 0xFFFFFFFF, Endian.little);
     _bytesInChunk += sizeInBytes;
     _bytesTotal += sizeInBytes;
   }

--- a/protobuf/lib/src/protobuf/extension.dart
+++ b/protobuf/lib/src/protobuf/extension.dart
@@ -10,10 +10,10 @@ class Extension<T> extends FieldInfo<T> {
 
   Extension(this.extendee, String name, int tagNumber, int fieldType,
       {dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName})
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName})
       : super(name, tagNumber, null, fieldType,
             defaultOrMaker: defaultOrMaker,
             subBuilder: subBuilder,
@@ -22,11 +22,11 @@ class Extension<T> extends FieldInfo<T> {
             protoName: protoName);
 
   Extension.repeated(this.extendee, String name, int tagNumber, int fieldType,
-      {CheckFunc<T> check,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName})
+      {CheckFunc<T>? check,
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName})
       : super.repeated(name, tagNumber, null, fieldType, check, subBuilder,
             valueOf: valueOf, enumValues: enumValues, protoName: protoName);
 
@@ -37,7 +37,7 @@ class Extension<T> extends FieldInfo<T> {
   bool operator ==(other) {
     if (other is! Extension) return false;
 
-    Extension o = other;
+    var o = other;
     return extendee == o.extendee && tagNumber == o.tagNumber;
   }
 }

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -12,7 +12,7 @@ class _ExtensionFieldSet {
 
   _ExtensionFieldSet(this._parent);
 
-  Extension _getInfoOrNull(int tagNumber) => _info[tagNumber];
+  Extension? _getInfoOrNull(int? tagNumber) => _info[tagNumber];
 
   dynamic _getFieldOrDefault(Extension fi) {
     if (fi.isRepeated) return _getList(fi);
@@ -23,7 +23,7 @@ class _ExtensionFieldSet {
     var value = _getFieldOrNull(fi);
     if (value == null) {
       _checkNotInUnknown(fi);
-      return fi.makeDefault();
+      return fi.makeDefault!();
     }
     return value;
   }
@@ -39,7 +39,7 @@ class _ExtensionFieldSet {
   ///
   /// If it doesn't exist, creates the list and saves the extension.
   /// Suitable for public API and decoders.
-  List<T> _ensureRepeatedField<T>(Extension<T> fi) {
+  List<T?> _ensureRepeatedField<T>(Extension<T?> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     assert(fi.extendee == '' || fi.extendee == _parent._messageName);
@@ -47,20 +47,20 @@ class _ExtensionFieldSet {
     var list = _values[fi.tagNumber];
     if (list != null) return list as List<T>;
 
-    return _addInfoAndCreateList(fi);
+    return _addInfoAndCreateList(fi) as List<T?>;
   }
 
-  List<T> _getList<T>(Extension<T> fi) {
+  List<T?> _getList<T>(Extension<T?> fi) {
     var value = _values[fi.tagNumber];
     if (value != null) return value as List<T>;
     _checkNotInUnknown(fi);
     if (_isReadOnly) return List<T>.unmodifiable(const []);
-    return _addInfoAndCreateList(fi);
+    return _addInfoAndCreateList(fi) as List<T?>;
   }
 
   List _addInfoAndCreateList(Extension fi) {
     _validateInfo(fi);
-    var newList = fi._createRepeatedField(_parent._message);
+    var newList = fi._createRepeatedField(_parent._message!);
     _addInfoUnchecked(fi);
     _setFieldUnchecked(fi, newList);
     return newList;
@@ -76,7 +76,7 @@ class _ExtensionFieldSet {
   void _clearField(Extension fi) {
     _ensureWritable();
     _validateInfo(fi);
-    if (_parent._hasObservers) _parent._eventPlugin.beforeClearField(fi);
+    if (_parent._hasObservers) _parent._eventPlugin!.beforeClearField(fi);
     _values.remove(fi.tagNumber);
   }
 
@@ -130,7 +130,7 @@ class _ExtensionFieldSet {
 
   void _setFieldUnchecked(Extension fi, value) {
     if (_parent._hasObservers) {
-      _parent._eventPlugin.beforeSetField(fi, value);
+      _parent._eventPlugin!.beforeSetField(fi, value);
     }
     _values[fi.tagNumber] = value;
   }
@@ -142,7 +142,7 @@ class _ExtensionFieldSet {
 
   bool get _hasValues => _values.isNotEmpty;
 
-  bool _equalValues(_ExtensionFieldSet other) =>
+  bool _equalValues(_ExtensionFieldSet? other) =>
       other != null && _areMapsEqual(_values, other._values);
 
   void _clearValues() => _values.clear();
@@ -153,7 +153,7 @@ class _ExtensionFieldSet {
   /// Extensions cannot contain map fields.
   void _shallowCopyValues(_ExtensionFieldSet original) {
     for (var tagNumber in original._tagNumbers) {
-      var extension = original._getInfoOrNull(tagNumber);
+      var extension = original._getInfoOrNull(tagNumber)!;
       _addInfoUnchecked(extension);
 
       final value = original._getFieldOrNull(extension);
@@ -191,7 +191,7 @@ class _ExtensionFieldSet {
 
   void _checkNotInUnknown(Extension extension) {
     if (_parent._hasUnknownFields &&
-        _parent._unknownFields.hasField(extension.tagNumber)) {
+        _parent._unknownFields!.hasField(extension.tagNumber)) {
       throw StateError(
           'Trying to get $extension that is present as an unknown field. '
           'Parse the message with this extension in the extension registry or '

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -26,7 +26,7 @@ class ExtensionRegistry {
 
   /// Retrieves an extension from the registry that adds tag number [tagNumber]
   /// to the [messageName] message type.
-  Extension getExtension(String messageName, int tagNumber) {
+  Extension? getExtension(String messageName, int tagNumber) {
     var map = _extensions[messageName];
     if (map != null) {
       return map[tagNumber];
@@ -92,18 +92,18 @@ class ExtensionRegistry {
 
 T _reparseMessage<T extends GeneratedMessage>(
     T message, ExtensionRegistry extensionRegistry) {
-  T result;
+  T? result;
   T ensureResult() {
     if (result == null) {
-      result ??= message.createEmptyInstance();
-      result._fieldSet._shallowCopyValues(message._fieldSet);
+      result ??= message.info_.createEmptyInstance!() as T;
+      result!._fieldSet._shallowCopyValues(message._fieldSet);
     }
-    return result;
+    return result!;
   }
 
-  UnknownFieldSet resultUnknownFields;
+  UnknownFieldSet? resultUnknownFields;
   UnknownFieldSet ensureUnknownFields() =>
-      resultUnknownFields ??= ensureResult()._fieldSet._unknownFields;
+      resultUnknownFields ??= ensureResult()._fieldSet._unknownFields!;
 
   var messageUnknownFields = message._fieldSet._unknownFields;
   if (messageUnknownFields != null) {
@@ -124,16 +124,16 @@ T _reparseMessage<T extends GeneratedMessage>(
   }
 
   message._fieldSet._meta.byIndex.forEach((FieldInfo field) {
-    PbList resultEntries;
+    PbList? resultEntries;
     PbList ensureEntries() =>
-        resultEntries ??= ensureResult()._fieldSet._values[field.index];
+        resultEntries ??= ensureResult()._fieldSet._values[field.index!];
 
-    PbMap resultMap;
+    PbMap? resultMap;
     PbMap ensureMap() =>
-        resultMap ??= ensureResult()._fieldSet._values[field.index];
+        resultMap ??= ensureResult()._fieldSet._values[field.index!];
 
     if (field.isRepeated) {
-      final messageEntries = message._fieldSet._values[field.index];
+      final messageEntries = message._fieldSet._values[field.index!];
       if (messageEntries == null) return;
       if (field.isGroupOrMessage) {
         for (var i = 0; i < messageEntries.length; i++) {
@@ -145,9 +145,9 @@ T _reparseMessage<T extends GeneratedMessage>(
         }
       }
     } else if (field is MapFieldInfo) {
-      final messageMap = message._fieldSet._values[field.index];
+      final messageMap = message._fieldSet._values[field.index!];
       if (messageMap == null) return;
-      if (_isGroupOrMessage(field.valueFieldType)) {
+      if (_isGroupOrMessage(field.valueFieldType!)) {
         for (var key in messageMap.keys) {
           final GeneratedMessage value = messageMap[key];
           final reparsedValue = _reparseMessage(value, extensionRegistry);
@@ -157,18 +157,18 @@ T _reparseMessage<T extends GeneratedMessage>(
         }
       }
     } else if (field.isGroupOrMessage) {
-      final messageSubField = message._fieldSet._values[field.index];
+      final messageSubField = message._fieldSet._values[field.index!];
       if (messageSubField == null) return;
       final reparsedSubField =
           _reparseMessage<GeneratedMessage>(messageSubField, extensionRegistry);
       if (!identical(messageSubField, reparsedSubField)) {
-        ensureResult()._fieldSet._values[field.index] = reparsedSubField;
+        ensureResult()._fieldSet._values[field.index!] = reparsedSubField;
       }
     }
   });
 
   if (result != null && message.isFrozen) {
-    result.freeze();
+    result!.freeze();
   }
 
   return result ?? message;
@@ -192,7 +192,7 @@ class _EmptyExtensionRegistry implements ExtensionRegistry {
   }
 
   @override
-  Extension getExtension(String messageName, int tagNumber) => null;
+  Extension? getExtension(String messageName, int tagNumber) => null;
 
   @override
   T reparseMessage<T extends GeneratedMessage>(T message) =>

--- a/protobuf/lib/src/protobuf/field_error.dart
+++ b/protobuf/lib/src/protobuf/field_error.dart
@@ -9,7 +9,7 @@ part of protobuf;
 ///
 /// For enums, group, and message fields, this check is only approximate,
 /// because the exact type isn't included in [fieldType].
-String _getFieldError(int fieldType, var value) {
+String? _getFieldError(int fieldType, var value) {
   switch (PbFieldType._baseType(fieldType)) {
     case PbFieldType._BOOL_BIT:
       if (value is! bool) return 'not type bool';
@@ -112,22 +112,24 @@ CheckFunc getCheckFunction(int fieldType) {
 
 // check functions for repeated fields
 
-void _checkNotNull(Object val) {
+void _checkNotNull(Object? val) {
   if (val == null) {
     throw ArgumentError("Can't add a null to a repeated field");
   }
 }
 
-void _checkFloat(Object val) {
-  if (!_isFloat32(val)) throw _createFieldRangeError(val, 'a float');
+void _checkFloat(Object? val) {
+  if (!_isFloat32(val as double)) throw _createFieldRangeError(val, 'a float');
 }
 
-void _checkSigned32(Object val) {
-  if (!_isSigned32(val)) throw _createFieldRangeError(val, 'a signed int32');
+void _checkSigned32(Object? val) {
+  if (!_isSigned32(val as int)) {
+    throw _createFieldRangeError(val, 'a signed int32');
+  }
 }
 
-void _checkUnsigned32(Object val) {
-  if (!_isUnsigned32(val)) {
+void _checkUnsigned32(Object? val) {
+  if (!_isUnsigned32(val as int)) {
     throw _createFieldRangeError(val, 'an unsigned int32');
   }
 }

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 /// An object representing a protobuf message field.
 class FieldInfo<T> {
-  FrozenPbList<T> _emptyList;
+  FrozenPbList<T>? _emptyList;
 
   /// Name of this field as the `json_name` reported by protoc.
   ///
@@ -19,37 +19,37 @@ class FieldInfo<T> {
   final String protoName;
 
   final int tagNumber;
-  final int index; // index of the field's value. Null for extensions.
+  final int? index; // index of the field's value. Null for extensions.
   final int type;
 
   // Constructs the default value of a field.
   // (Only used for repeated fields where check is null.)
-  final MakeDefaultFunc makeDefault;
+  final MakeDefaultFunc? makeDefault;
 
   // Creates an empty message or group when decoding a message.
   // Not used for other types.
   // see GeneratedMessage._getEmptyMessage
-  final CreateBuilderFunc subBuilder;
+  final CreateBuilderFunc? subBuilder;
 
   // List of all enum enumValues.
   // (Not used for other types.)
-  final List<ProtobufEnum> enumValues;
+  final List<ProtobufEnum>? enumValues;
 
   // Looks up the enum value given its integer code.
   // (Not used for other types.)
   // see GeneratedMessage._getValueOfFunc
-  final ValueOfFunc valueOf;
+  final ValueOfFunc? valueOf;
 
   // Verifies an item being added to a repeated field
   // (Not used for non-repeated fields.)
-  final CheckFunc<T> check;
+  final CheckFunc<T>? check;
 
   FieldInfo(this.name, this.tagNumber, this.index, this.type,
       {dynamic defaultOrMaker,
       this.subBuilder,
       this.valueOf,
       this.enumValues,
-      String protoName})
+      String? protoName})
       : makeDefault = findMakeDefault(type, defaultOrMaker),
         check = null,
         protoName = protoName ?? _unCamelCase(name),
@@ -73,17 +73,17 @@ class FieldInfo<T> {
 
   FieldInfo.repeated(this.name, this.tagNumber, this.index, this.type,
       this.check, this.subBuilder,
-      {this.valueOf, this.enumValues, String protoName})
-      : makeDefault = (() => PbList<T>(check: check)),
+      {this.valueOf, this.enumValues, String? protoName})
+      : makeDefault = (() => PbList<T>(check: check!)),
         protoName = protoName ?? _unCamelCase(name) {
-    assert(name != null);
-    assert(tagNumber != null);
+    ArgumentError.checkNotNull(name, 'name');
+    ArgumentError.checkNotNull(tagNumber, 'tagNumber');
     assert(_isRepeated(type));
     assert(check != null);
     assert(!_isEnum(type) || valueOf != null);
   }
 
-  static MakeDefaultFunc findMakeDefault(int type, dynamic defaultOrMaker) {
+  static MakeDefaultFunc? findMakeDefault(int type, dynamic defaultOrMaker) {
     if (defaultOrMaker == null) return PbFieldType._defaultForType(type);
     if (defaultOrMaker is MakeDefaultFunc) return defaultOrMaker;
     return () => defaultOrMaker;
@@ -105,7 +105,7 @@ class FieldInfo<T> {
     if (isRepeated) {
       return _emptyList ??= FrozenPbList._([]);
     }
-    return makeDefault();
+    return makeDefault!();
   }
 
   /// Returns true if the field's value is okay to transmit.
@@ -163,7 +163,7 @@ class FieldInfo<T> {
   ///
   /// Delegates actual list creation to the message, so that it can
   /// be overridden by a mixin.
-  List<T> _createRepeatedField(GeneratedMessage m) {
+  List<T?> _createRepeatedField(GeneratedMessage m) {
     assert(isRepeated);
     return m.createRepeatedField<T>(tagNumber, this);
   }
@@ -171,12 +171,12 @@ class FieldInfo<T> {
   /// Same as above, but allow a tighter typed List to be created.
   List<S> _createRepeatedFieldWithType<S extends T>(GeneratedMessage m) {
     assert(isRepeated);
-    return m.createRepeatedField<S>(tagNumber, this);
+    return m.createRepeatedField<S>(tagNumber, this as FieldInfo<S>);
   }
 
   /// Convenience method to thread this FieldInfo's reified type parameter to
   /// _FieldSet._ensureRepeatedField.
-  List<T> _ensureRepeatedField(_FieldSet fs) {
+  List<T?> _ensureRepeatedField(_FieldSet fs) {
     return fs._ensureRepeatedField<T>(this);
   }
 
@@ -188,17 +188,17 @@ final RegExp _upperCase = RegExp('[A-Z]');
 
 String _unCamelCase(String name) {
   return name.replaceAllMapped(
-      _upperCase, (match) => '_${match.group(0).toLowerCase()}');
+      _upperCase, (match) => '_${match.group(0)!.toLowerCase()}');
 }
 
-class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
-  final int keyFieldType;
-  final int valueFieldType;
+class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>?> {
+  final int? keyFieldType;
+  final int? valueFieldType;
 
   /// Creates a new empty instance of the value type.
   ///
   /// `null` if the value type is not a Message type.
-  final CreateBuilderFunc valueCreator;
+  final CreateBuilderFunc? valueCreator;
 
   final BuilderInfo mapEntryBuilderInfo;
 
@@ -211,19 +211,19 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
       this.valueFieldType,
       this.mapEntryBuilderInfo,
       this.valueCreator,
-      {String protoName})
+      {String? protoName})
       : super(name, tagNumber, index, type,
             defaultOrMaker: () =>
                 PbMap<K, V>(keyFieldType, valueFieldType, mapEntryBuilderInfo),
             protoName: protoName) {
-    assert(name != null);
-    assert(tagNumber != null);
+    ArgumentError.checkNotNull(name, 'name');
+    ArgumentError.checkNotNull(tagNumber, 'tagNumber');
     assert(_isMapField(type));
     assert(!_isEnum(type) || valueOf != null);
   }
 
   FieldInfo get valueFieldInfo =>
-      mapEntryBuilderInfo.fieldInfo[PbMap._valueFieldNumber];
+      mapEntryBuilderInfo.fieldInfo[PbMap._valueFieldNumber]!;
 
   Map<K, V> _ensureMapField(_FieldSet fs) {
     return fs._ensureMapField<K, V>(this);

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -5,10 +5,10 @@
 part of protobuf;
 
 typedef FrozenMessageErrorHandler = void Function(String messageName,
-    [String methodName]);
+    [String? methodName]);
 
 void defaultFrozenMessageModificationHandler(String messageName,
-    [String methodName]) {
+    [String? methodName]) {
   if (methodName != null) {
     throw UnsupportedError(
         'Attempted to call $methodName on a read-only message ($messageName)');
@@ -48,9 +48,9 @@ bool _hashCodesCanBeMemoized = true;
 /// polymorphic access due to inheritance. This turns out to
 /// be faster when compiled to JavaScript.
 class _FieldSet {
-  final GeneratedMessage _message;
+  final GeneratedMessage? _message;
   final BuilderInfo _meta;
-  final EventPlugin _eventPlugin;
+  final EventPlugin? _eventPlugin;
 
   /// The value of each non-extension field in a fixed-length array.
   /// The index of a field can be found in [FieldInfo.index].
@@ -58,10 +58,10 @@ class _FieldSet {
   final List _values;
 
   /// Contains all the extension fields, or null if there aren't any.
-  _ExtensionFieldSet _extensions;
+  _ExtensionFieldSet? _extensions;
 
   /// Contains all the unknown fields, or null if there aren't any.
-  UnknownFieldSet _unknownFields;
+  UnknownFieldSet? _unknownFields;
 
   /// Encodes whether `this` has been frozen, and if so, also memoizes the
   /// hash code.
@@ -79,7 +79,7 @@ class _FieldSet {
   ///
   /// If the value is not a `bool`, then it must contain the memoized hash code
   /// value, in which case the proto must be read-only.
-  bool get _isReadOnly => _frozenState is bool ? _frozenState : true;
+  bool get _isReadOnly => _frozenState is bool ? _frozenState as bool : true;
 
   /// Returns the value of [_frozenState] if it contains the pre-computed value
   /// of the hashCode for the frozen field sets.
@@ -90,11 +90,12 @@ class _FieldSet {
   ///
   /// If [_frozenState] contains a boolean, the hashCode hasn't been memoized,
   /// so it will return null.
-  int get _memoizedHashCode => _frozenState is int ? _frozenState : null;
+  int? get _memoizedHashCode =>
+      _frozenState is int ? _frozenState as int : null;
 
   // Maps a oneof decl index to the tag number which is currently set. If the
   // index is not present, the oneof field is unset.
-  final Map<int, int> _oneofCases;
+  final Map<int, int>? _oneofCases;
 
   _FieldSet(this._message, BuilderInfo meta, this._eventPlugin)
       : _meta = meta,
@@ -103,12 +104,12 @@ class _FieldSet {
 
   static List _makeValueList(int length) {
     if (length == 0) return _zeroList;
-    return List(length);
+    return List.filled(length, null);
   }
 
   // Use a fixed length list and not a constant list to ensure that _values
   // always has the same implementation type.
-  static final List _zeroList = List(0);
+  static final List _zeroList = List.filled(0, null);
 
   // Metadata about multiple fields
 
@@ -122,14 +123,14 @@ class _FieldSet {
   Iterable<FieldInfo> get _infosSortedByTag => _meta.sortedByTag;
 
   /// Returns true if we should send events to the plugin.
-  bool get _hasObservers => _eventPlugin != null && _eventPlugin.hasObservers;
+  bool get _hasObservers => _eventPlugin != null && _eventPlugin!.hasObservers;
 
   bool get _hasExtensions => _extensions != null;
   bool get _hasUnknownFields => _unknownFields != null;
 
   _ExtensionFieldSet _ensureExtensions() {
     if (!_hasExtensions) _extensions = _ExtensionFieldSet(this);
-    return _extensions;
+    return _extensions!;
   }
 
   UnknownFieldSet _ensureUnknownFields() {
@@ -137,13 +138,13 @@ class _FieldSet {
       if (_isReadOnly) return UnknownFieldSet.emptyUnknownFieldSet;
       _unknownFields = UnknownFieldSet();
     }
-    return _unknownFields;
+    return _unknownFields!;
   }
 
   // Metadata about single fields
 
   /// Returns FieldInfo for a non-extension field, or null if not found.
-  FieldInfo _nonExtensionInfo(int tagNumber) => _meta.fieldInfo[tagNumber];
+  FieldInfo? _nonExtensionInfo(int? tagNumber) => _meta.fieldInfo[tagNumber];
 
   /// Returns FieldInfo for a non-extension field.
   FieldInfo _nonExtensionInfoByIndex(int index) => _meta.byIndex[index];
@@ -157,11 +158,11 @@ class _FieldSet {
   }
 
   /// Returns the FieldInfo for a regular or extension field.
-  FieldInfo _getFieldInfoOrNull(int tagNumber) {
+  FieldInfo? _getFieldInfoOrNull(int tagNumber) {
     var fi = _nonExtensionInfo(tagNumber);
     if (fi != null) return fi;
     if (!_hasExtensions) return null;
-    return _extensions._getInfoOrNull(tagNumber);
+    return _extensions!._getInfoOrNull(tagNumber);
   }
 
   void _markReadOnly() {
@@ -169,20 +170,20 @@ class _FieldSet {
     _frozenState = true;
     for (var field in _meta.sortedByTag) {
       if (field.isRepeated) {
-        final entries = _values[field.index];
+        final entries = _values[field.index!];
         if (entries == null) continue;
         if (field.isGroupOrMessage) {
           for (var subMessage in entries as List<GeneratedMessage>) {
             subMessage.freeze();
           }
         }
-        _values[field.index] = entries.toFrozenPbList();
+        _values[field.index!] = entries.toFrozenPbList();
       } else if (field.isMapField) {
-        PbMap map = _values[field.index];
+        PbMap? map = _values[field.index!];
         if (map == null) continue;
-        _values[field.index] = map.freeze();
+        _values[field.index!] = map.freeze();
       } else if (field.isGroupOrMessage) {
-        final entry = _values[field.index];
+        final entry = _values[field.index!];
         if (entry != null) {
           (entry as GeneratedMessage).freeze();
         }
@@ -211,27 +212,27 @@ class _FieldSet {
   dynamic _getField(int tagNumber) {
     var fi = _nonExtensionInfo(tagNumber);
     if (fi != null) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       if (value != null) return value;
       return _getDefault(fi);
     }
     if (_hasExtensions) {
-      var fi = _extensions._getInfoOrNull(tagNumber);
+      var fi = _extensions!._getInfoOrNull(tagNumber);
       if (fi != null) {
-        return _extensions._getFieldOrDefault(fi);
+        return _extensions!._getFieldOrDefault(fi);
       }
     }
     throw ArgumentError('tag $tagNumber not defined in $_messageName');
   }
 
   dynamic _getDefault(FieldInfo fi) {
-    if (!fi.isRepeated) return fi.makeDefault();
+    if (!fi.isRepeated) return fi.makeDefault!();
     if (_isReadOnly) return fi.readonlyDefault;
 
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:
     //   msg.mutableFoo().add(123);
-    var value = fi._createRepeatedField(_message);
+    var value = fi._createRepeatedField(_message!);
     _setNonExtensionFieldUnchecked(fi, value);
     return value;
   }
@@ -243,7 +244,7 @@ class _FieldSet {
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:
     //   msg.mutableFoo().add(123);
-    var value = fi._createRepeatedFieldWithType<T>(_message);
+    var value = fi._createRepeatedFieldWithType<T>(_message!);
     _setNonExtensionFieldUnchecked(fi, value);
     return value;
   }
@@ -256,7 +257,7 @@ class _FieldSet {
           fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo));
     }
 
-    var value = fi._createMapField(_message);
+    var value = fi._createMapField(_message!);
     _setNonExtensionFieldUnchecked(fi, value);
     return value;
   }
@@ -272,39 +273,39 @@ class _FieldSet {
   /// Works for both extended and non-extend fields.
   /// Works for both repeated and non-repeated fields.
   dynamic _getFieldOrNull(FieldInfo fi) {
-    if (fi.index != null) return _values[fi.index];
+    if (fi.index != null) return _values[fi.index!];
     if (!_hasExtensions) return null;
-    return _extensions._getFieldOrNull(fi);
+    return _extensions!._getFieldOrNull(fi as Extension<dynamic>);
   }
 
   bool _hasField(int tagNumber) {
     var fi = _nonExtensionInfo(tagNumber);
-    if (fi != null) return _$has(fi.index);
+    if (fi != null) return _$has(fi.index!);
     if (!_hasExtensions) return false;
-    return _extensions._hasField(tagNumber);
+    return _extensions!._hasField(tagNumber);
   }
 
-  void _clearField(int tagNumber) {
+  void _clearField(int? tagNumber) {
     _ensureWritable();
     var fi = _nonExtensionInfo(tagNumber);
     if (fi != null) {
       // clear a non-extension field
-      if (_hasObservers) _eventPlugin.beforeClearField(fi);
-      _values[fi.index] = null;
+      if (_hasObservers) _eventPlugin!.beforeClearField(fi);
+      _values[fi.index!] = null;
 
       if (_meta.oneofs.containsKey(fi.tagNumber)) {
-        _oneofCases.remove(_meta.oneofs[fi.tagNumber]);
+        _oneofCases!.remove(_meta.oneofs[fi.tagNumber]);
       }
 
       var oneofIndex = _meta.oneofs[fi.tagNumber];
-      if (oneofIndex != null) _oneofCases[oneofIndex] = 0;
+      if (oneofIndex != null) _oneofCases![oneofIndex] = 0;
       return;
     }
 
     if (_hasExtensions) {
-      var fi = _extensions._getInfoOrNull(tagNumber);
+      var fi = _extensions!._getInfoOrNull(tagNumber);
       if (fi != null) {
-        _extensions._clearField(fi);
+        _extensions!._clearField(fi);
         return;
       }
     }
@@ -317,15 +318,15 @@ class _FieldSet {
   ///
   /// Works for both extended and non-extended fields.
   /// Suitable for public API.
-  void _setField(int tagNumber, value) {
-    if (value == null) throw ArgumentError('value is null');
+  void _setField(int tagNumber, Object value) {
+    ArgumentError.checkNotNull(value, 'value');
 
     var fi = _nonExtensionInfo(tagNumber);
     if (fi == null) {
       if (!_hasExtensions) {
         throw ArgumentError('tag $tagNumber not defined in $_messageName');
       }
-      _extensions._setField(tagNumber, value);
+      _extensions!._setField(tagNumber, value);
       return;
     }
 
@@ -342,11 +343,11 @@ class _FieldSet {
   /// Works for both extended and non-extended fields.
   /// Suitable for decoders that do their own validation.
   void _setFieldUnchecked(FieldInfo fi, value) {
-    assert(fi != null);
+    ArgumentError.checkNotNull(fi, 'fi');
     assert(!fi.isRepeated);
     if (fi.index == null) {
       _ensureExtensions()
-        .._addInfoUnchecked(fi)
+        .._addInfoUnchecked(fi as Extension<dynamic>)
         .._setFieldUnchecked(fi, value);
     } else {
       _setNonExtensionFieldUnchecked(fi, value);
@@ -359,16 +360,16 @@ class _FieldSet {
   /// Creates and stores the repeated field if it doesn't exist.
   /// If it's an extension and the list doesn't exist, validates and stores it.
   /// Suitable for decoders.
-  List<T> _ensureRepeatedField<T>(FieldInfo<T> fi) {
+  List<T?> _ensureRepeatedField<T>(FieldInfo<T> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     if (fi.index == null) {
-      return _ensureExtensions()._ensureRepeatedField(fi);
+      return _ensureExtensions()._ensureRepeatedField(fi as Extension<T>);
     }
     var value = _getFieldOrNull(fi);
     if (value != null) return value as List<T>;
 
-    var newValue = fi._createRepeatedField(_message);
+    var newValue = fi._createRepeatedField(_message!);
     _setNonExtensionFieldUnchecked(fi, newValue);
     return newValue;
   }
@@ -379,11 +380,11 @@ class _FieldSet {
     assert(fi.index != null); // Map fields are not allowed to be extensions.
 
     var value = _getFieldOrNull(fi);
-    if (value != null) return value as Map<K, V>;
+    if (value != null) return (value as Map<K, V>) as PbMap<K, V>;
 
-    var newValue = fi._createMapField(_message);
+    var newValue = fi._createMapField(_message!);
     _setNonExtensionFieldUnchecked(fi, newValue);
-    return newValue;
+    return newValue as PbMap<K, V>;
   }
 
   /// Sets a non-extended field and fires events.
@@ -391,8 +392,8 @@ class _FieldSet {
     var tag = fi.tagNumber;
     var oneofIndex = _meta.oneofs[tag];
     if (oneofIndex != null) {
-      _clearField(_oneofCases[oneofIndex]);
-      _oneofCases[oneofIndex] = tag;
+      _clearField(_oneofCases![oneofIndex]);
+      _oneofCases![oneofIndex] = tag;
     }
 
     // It is important that the callback to the observers is not moved to the
@@ -400,15 +401,15 @@ class _FieldSet {
     // Otherwise the observers will be notified about 'clearField' and
     // 'setField' events in an incorrect order.
     if (_hasObservers) {
-      _eventPlugin.beforeSetField(fi, value);
+      _eventPlugin!.beforeSetField(fi, value);
     }
-    _values[fi.index] = value;
+    _values[fi.index!] = value;
   }
 
   // Generated method implementations
 
   /// The implementation of a generated getter.
-  T _$get<T>(int index, T defaultValue) {
+  T _$get<T>(int index, T? defaultValue) {
     var value = _values[index];
     if (value != null) return value as T;
     if (defaultValue != null) return defaultValue;
@@ -426,7 +427,7 @@ class _FieldSet {
 
   T _$ensure<T>(int index) {
     if (!_$has(index)) {
-      dynamic value = _nonExtensionInfoByIndex(index).subBuilder();
+      dynamic value = _nonExtensionInfoByIndex(index).subBuilder!();
       _$set(index, value);
       return value;
     }
@@ -439,18 +440,19 @@ class _FieldSet {
   List<T> _$getList<T>(int index) {
     var value = _values[index];
     if (value != null) return value as List<T>;
-    return _getDefaultList<T>(_nonExtensionInfoByIndex(index));
+    return _getDefaultList<T>(_nonExtensionInfoByIndex(index) as FieldInfo<T>);
   }
 
   /// The implementation of a generated getter for map fields.
   Map<K, V> _$getMap<K, V>(int index) {
     var value = _values[index];
     if (value != null) return value as Map<K, V>;
-    return _getDefaultMap<K, V>(_nonExtensionInfoByIndex(index));
+    return _getDefaultMap<K, V>(
+        _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>);
   }
 
   /// The implementation of a generated getter for `bool` fields.
-  bool _$getB(int index, bool defaultValue) {
+  bool _$getB(int index, bool? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -470,7 +472,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for int fields.
-  int _$getI(int index, int defaultValue) {
+  int _$getI(int index, int? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -490,7 +492,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for String fields.
-  String _$getS(int index, String defaultValue) {
+  String _$getS(int index, String? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -530,7 +532,7 @@ class _FieldSet {
   /// In production, does no validation other than a null check.
   /// Only handles non-repeated, non-extension fields.
   /// Also, doesn't handle enums or messages which need per-type validation.
-  void _$set(int index, value) {
+  void _$set(int index, Object? value) {
     assert(!_nonExtensionInfoByIndex(index).isRepeated);
     assert(_$check(index, value));
     _ensureWritable();
@@ -538,14 +540,14 @@ class _FieldSet {
       _$check(index, value); // throw exception for null value
     }
     if (_hasObservers) {
-      _eventPlugin.beforeSetField(_nonExtensionInfoByIndex(index), value);
+      _eventPlugin!.beforeSetField(_nonExtensionInfoByIndex(index), value);
     }
     var tag = _meta.byIndex[index].tagNumber;
     var oneofIndex = _meta.oneofs[tag];
 
     if (oneofIndex != null) {
-      _clearField(_oneofCases[oneofIndex]);
-      _oneofCases[oneofIndex] = tag;
+      _clearField(_oneofCases![oneofIndex]);
+      _oneofCases![oneofIndex] = tag;
     }
     _values[index] = value;
   }
@@ -560,24 +562,24 @@ class _FieldSet {
   void _clear() {
     _ensureWritable();
     if (_unknownFields != null) {
-      _unknownFields.clear();
+      _unknownFields!.clear();
     }
 
     if (_hasObservers) {
       for (var fi in _infos) {
-        if (_values[fi.index] != null) {
-          _eventPlugin.beforeClearField(fi);
+        if (_values[fi.index!] != null) {
+          _eventPlugin!.beforeClearField(fi);
         }
       }
       if (_hasExtensions) {
-        for (var key in _extensions._tagNumbers) {
-          var fi = _extensions._getInfoOrNull(key);
-          _eventPlugin.beforeClearField(fi);
+        for (var key in _extensions!._tagNumbers) {
+          var fi = _extensions!._getInfoOrNull(key)!;
+          _eventPlugin!.beforeClearField(fi);
         }
       }
     }
     if (_values.isNotEmpty) _values.fillRange(0, _values.length, null);
-    if (_hasExtensions) _extensions._clearValues();
+    if (_hasExtensions) _extensions!._clearValues();
   }
 
   bool _equals(_FieldSet o) {
@@ -586,20 +588,22 @@ class _FieldSet {
       if (!_equalFieldValues(_values[i], o._values[i])) return false;
     }
 
-    if (!_hasExtensions || !_extensions._hasValues) {
+    if (!_hasExtensions || !_extensions!._hasValues) {
       // Check if other extensions are logically empty.
       // (Don't create them unnecessarily.)
-      if (o._hasExtensions && o._extensions._hasValues) {
+      if (o._hasExtensions && o._extensions!._hasValues) {
         return false;
       }
     } else {
-      if (!_extensions._equalValues(o._extensions)) return false;
+      if (!_extensions!._equalValues(o._extensions)) return false;
     }
 
-    if (_unknownFields == null || _unknownFields.isEmpty) {
+    if (_unknownFields == null || _unknownFields!.isEmpty) {
       // Check if other unknown fields is logically empty.
       // (Don't create them unnecessarily.)
-      if (o._unknownFields != null && o._unknownFields.isNotEmpty) return false;
+      if (o._unknownFields != null && o._unknownFields!.isNotEmpty) {
+        return false;
+      }
     } else {
       // Check if the other unknown fields has the same fields.
       if (_unknownFields != o._unknownFields) return false;
@@ -640,7 +644,7 @@ class _FieldSet {
   /// behavior, the hashCode can be memoized to speed up performance.
   int get _hashCode {
     if (_hashCodesCanBeMemoized && _memoizedHashCode != null) {
-      return _memoizedHashCode;
+      return _memoizedHashCode!;
     }
     // Hashes the value of one field (recursively).
     int hashField(int hash, FieldInfo fi, value) {
@@ -667,15 +671,15 @@ class _FieldSet {
 
     int hashEachField(int hash) {
       //non-extension fields
-      hash = _infosSortedByTag.where((fi) => _values[fi.index] != null).fold(
-          hash, (int h, FieldInfo fi) => hashField(h, fi, _values[fi.index]));
+      hash = _infosSortedByTag.where((fi) => _values[fi.index!] != null).fold(
+          hash, (int h, FieldInfo fi) => hashField(h, fi, _values[fi.index!]));
 
       if (!_hasExtensions) return hash;
 
       hash =
-          _sorted(_extensions._tagNumbers).fold(hash, (int h, int tagNumber) {
-        var fi = _extensions._getInfoOrNull(tagNumber);
-        return hashField(h, fi, _extensions._getFieldOrNull(fi));
+          _sorted(_extensions!._tagNumbers).fold(hash, (int h, int tagNumber) {
+        var fi = _extensions!._getInfoOrNull(tagNumber)!;
+        return hashField(h, fi, _extensions!._getFieldOrNull(fi));
       });
 
       return hash;
@@ -728,15 +732,15 @@ class _FieldSet {
       }
     }
 
-    _infosSortedByTag
-        .forEach((FieldInfo fi) => writeFieldValue(_values[fi.index], fi.name));
+    _infosSortedByTag.forEach(
+        (FieldInfo fi) => writeFieldValue(_values[fi.index!], fi.name));
 
     if (_hasExtensions) {
-      _extensions._info.keys.toList()
+      _extensions!._info.keys.toList()
         ..sort()
         ..forEach((int tagNumber) => writeFieldValue(
-            _extensions._values[tagNumber],
-            '[${_extensions._info[tagNumber].name}]'));
+            _extensions!._values[tagNumber],
+            '[${_extensions!._info[tagNumber]!.name}]'));
     }
     if (_hasUnknownFields) {
       out.write(_unknownFields.toString());
@@ -757,40 +761,40 @@ class _FieldSet {
     // validation checks.
 
     for (var fi in other._infosSortedByTag) {
-      var value = other._values[fi.index];
+      var value = other._values[fi.index!];
       if (value != null) _mergeField(fi, value, isExtension: false);
     }
     if (other._hasExtensions) {
-      var others = other._extensions;
+      var others = other._extensions!;
       for (var tagNumber in others._tagNumbers) {
-        var extension = others._getInfoOrNull(tagNumber);
+        var extension = others._getInfoOrNull(tagNumber)!;
         var value = others._getFieldOrNull(extension);
         _mergeField(extension, value, isExtension: true);
       }
     }
 
     if (other._hasUnknownFields) {
-      _ensureUnknownFields().mergeFromUnknownFieldSet(other._unknownFields);
+      _ensureUnknownFields().mergeFromUnknownFieldSet(other._unknownFields!);
     }
   }
 
-  void _mergeField(FieldInfo otherFi, fieldValue, {bool isExtension}) {
+  void _mergeField(FieldInfo otherFi, fieldValue, {bool? isExtension}) {
     var tagNumber = otherFi.tagNumber;
 
     // Determine the FieldInfo to use.
     // Don't allow regular fields to be overwritten by extensions.
     var fi = _nonExtensionInfo(tagNumber);
-    if (fi == null && isExtension) {
+    if (fi == null && isExtension!) {
       // This will overwrite any existing extension field info.
       fi = otherFi;
     }
 
     var mustClone = _isGroupOrMessage(otherFi.type);
 
-    if (fi.isMapField) {
-      MapFieldInfo f = fi;
-      mustClone = _isGroupOrMessage(f.valueFieldType);
-      PbMap map = f._ensureMapField(this);
+    if (fi!.isMapField) {
+      var f = fi as MapFieldInfo<dynamic, dynamic>;
+      mustClone = _isGroupOrMessage(f.valueFieldType!);
+      var map = f._ensureMapField(this) as PbMap<dynamic, dynamic>;
       if (mustClone) {
         for (MapEntry entry in fieldValue.entries) {
           map[entry.key] = (entry.value as GeneratedMessage).deepCopy();
@@ -818,9 +822,9 @@ class _FieldSet {
     }
 
     if (otherFi.isGroupOrMessage) {
-      final currentFi = isExtension
-          ? _ensureExtensions()._getFieldOrNull(fi)
-          : _values[fi.index];
+      final currentFi = isExtension!
+          ? _ensureExtensions()._getFieldOrNull(fi as Extension<dynamic>)
+          : _values[fi.index!];
 
       if (currentFi == null) {
         fieldValue = (fieldValue as GeneratedMessage).deepCopy();
@@ -829,8 +833,9 @@ class _FieldSet {
       }
     }
 
-    if (isExtension) {
-      _ensureExtensions()._setFieldAndInfo(fi, fieldValue);
+    if (isExtension!) {
+      _ensureExtensions()
+          ._setFieldAndInfo(fi as Extension<dynamic>, fieldValue);
     } else {
       _validateField(fi, fieldValue);
       _setNonExtensionFieldUnchecked(fi, fieldValue);
@@ -856,7 +861,7 @@ class _FieldSet {
   bool _hasRequiredValues() {
     if (!_hasRequiredFields) return true;
     for (var fi in _infos) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       if (!fi._hasRequiredValues(value)) return false;
     }
     return _hasRequiredExtensionValues();
@@ -864,8 +869,8 @@ class _FieldSet {
 
   bool _hasRequiredExtensionValues() {
     if (!_hasExtensions) return true;
-    for (var fi in _extensions._infos) {
-      var value = _extensions._getFieldOrNull(fi);
+    for (var fi in _extensions!._infos) {
+      var value = _extensions!._getFieldOrNull(fi);
       if (!fi._hasRequiredValues(value)) return false;
     }
     return true; // No problems found.
@@ -875,7 +880,7 @@ class _FieldSet {
   void _appendInvalidFields(List<String> problems, String prefix) {
     if (!_hasRequiredFields) return;
     for (var fi in _infos) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       fi._appendInvalidFields(problems, value, prefix);
     }
     // TODO(skybrian): search extensions as well
@@ -890,28 +895,29 @@ class _FieldSet {
     for (var index = 0; index < _meta.byIndex.length; index++) {
       var fieldInfo = _meta.byIndex[index];
       if (fieldInfo.isMapField) {
-        PbMap map = _values[index];
+        PbMap? map = _values[index];
         if (map != null) {
-          _values[index] = (fieldInfo as MapFieldInfo)._createMapField(_message)
-            ..addAll(map);
+          _values[index] = (fieldInfo as MapFieldInfo)
+              ._createMapField(_message!)
+                ..addAll(map);
         }
       } else if (fieldInfo.isRepeated) {
-        PbListBase list = _values[index];
+        PbListBase? list = _values[index];
         if (list != null) {
-          _values[index] = fieldInfo._createRepeatedField(_message)
+          _values[index] = fieldInfo._createRepeatedField(_message!)
             ..addAll(list);
         }
       }
     }
 
     if (original._hasExtensions) {
-      _ensureExtensions()._shallowCopyValues(original._extensions);
+      _ensureExtensions()._shallowCopyValues(original._extensions!);
     }
 
     if (original._hasUnknownFields) {
-      _ensureUnknownFields()._fields?.addAll(original._unknownFields._fields);
+      _ensureUnknownFields()._fields.addAll(original._unknownFields!._fields);
     }
 
-    _oneofCases?.addAll(original._oneofCases);
+    _oneofCases?.addAll(original._oneofCases!);
   }
 }

--- a/protobuf/lib/src/protobuf/field_type.dart
+++ b/protobuf/lib/src/protobuf/field_type.dart
@@ -26,7 +26,7 @@ class PbFieldType {
   static int _baseType(int fieldType) =>
       fieldType & ~(_REQUIRED_BIT | _REPEATED_BIT | _PACKED_BIT | _MAP_BIT);
 
-  static MakeDefaultFunc _defaultForType(int type) {
+  static MakeDefaultFunc? _defaultForType(int type) {
     switch (type) {
       case _OPTIONAL_BOOL:
       case _REQUIRED_BOOL:

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 typedef CreateBuilderFunc = GeneratedMessage Function();
 typedef MakeDefaultFunc = Function();
-typedef ValueOfFunc = ProtobufEnum Function(int value);
+typedef ValueOfFunc = ProtobufEnum? Function(int value);
 
 /// The base class for all protobuf message types.
 ///
@@ -17,23 +17,26 @@ typedef ValueOfFunc = ProtobufEnum Function(int value);
 /// GeneratedMessage_reservedNames and should be unlikely to be used in
 /// a proto file.
 abstract class GeneratedMessage {
-  _FieldSet _fieldSet;
+  _FieldSet? __fieldSet;
+
+  @pragma('dart2js:tryInline')
+  _FieldSet get _fieldSet => __fieldSet!;
 
   GeneratedMessage() {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
   }
 
   GeneratedMessage.fromBuffer(
       List<int> input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
     mergeFromBuffer(input, extensionRegistry);
   }
 
   GeneratedMessage.fromJson(String input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
     mergeFromJson(input, extensionRegistry);
   }
 
@@ -42,7 +45,7 @@ abstract class GeneratedMessage {
 
   /// Subclasses can override this getter to be notified of changes
   /// to protobuf fields.
-  EventPlugin get eventPlugin => null;
+  EventPlugin? get eventPlugin => null;
 
   /// Creates a deep copy of the fields in this message.
   /// (The generated code uses [mergeFromMessage].)
@@ -114,7 +117,7 @@ abstract class GeneratedMessage {
   void clear() => _fieldSet._clear();
 
   // TODO(antonm): move to getters.
-  int getTagNumber(String fieldName) => info_.tagNumber(fieldName);
+  int? getTagNumber(String fieldName) => info_.tagNumber(fieldName);
 
   @override
   bool operator ==(other) {
@@ -224,7 +227,7 @@ abstract class GeneratedMessage {
   /// The [typeRegistry] is be used for encoding `Any` messages. If an `Any`
   /// message encoding a type not in [typeRegistry] is encountered, an
   /// error is thrown.
-  Object toProto3Json(
+  Object? toProto3Json(
           {TypeRegistry typeRegistry = const TypeRegistry.empty()}) =>
       _writeToProto3Json(_fieldSet, typeRegistry);
 
@@ -254,7 +257,7 @@ abstract class GeneratedMessage {
   ///
   /// If the JSON is otherwise not formatted correctly (a String where a
   /// number was expected etc.) a [FormatException] is thrown.
-  void mergeFromProto3Json(Object json,
+  void mergeFromProto3Json(Object? json,
           {TypeRegistry typeRegistry = const TypeRegistry.empty(),
           bool ignoreUnknownFields = false,
           bool supportNamesWithUnderscores = true,
@@ -302,7 +305,7 @@ abstract class GeneratedMessage {
   /// Clears an extension field and also removes the extension.
   void clearExtension(Extension extension) {
     if (_fieldSet._hasExtensions) {
-      _fieldSet._extensions._clearFieldAndInfo(extension);
+      _fieldSet._extensions!._clearFieldAndInfo(extension);
     }
   }
 
@@ -312,7 +315,7 @@ abstract class GeneratedMessage {
   /// The tagNumber should be a valid tag or extension.
   void clearField(int tagNumber) => _fieldSet._clearField(tagNumber);
 
-  int $_whichOneof(int oneofIndex) => _fieldSet._oneofCases[oneofIndex] ?? 0;
+  int $_whichOneof(int oneofIndex) => _fieldSet._oneofCases![oneofIndex] ?? 0;
 
   bool extensionsAreInitialized() => _fieldSet._hasRequiredExtensionValues();
 
@@ -334,7 +337,7 @@ abstract class GeneratedMessage {
   /// validate all items added to it. This can most easily be done
   /// using the FieldInfo.check function.
   List<T> createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
-    return PbList<T>(check: fi.check);
+    return PbList<T>(check: fi.check!);
   }
 
   /// Creates a Map representing a map field.
@@ -361,7 +364,7 @@ abstract class GeneratedMessage {
   /// Returns [:true:] if a value of [extension] is present.
   bool hasExtension(Extension extension) =>
       _fieldSet._hasExtensions &&
-      _fieldSet._extensions._getFieldOrNull(extension) != null;
+      _fieldSet._extensions!._getFieldOrNull(extension) != null;
 
   /// Returns [:true:] if this message has a field associated with [tagNumber].
   bool hasField(int tagNumber) => _fieldSet._hasField(tagNumber);
@@ -371,6 +374,7 @@ abstract class GeneratedMessage {
   /// Singular fields that are set in [other] overwrite the corresponding fields
   /// in this message. Repeated fields are appended. Singular sub-messages are
   /// recursively merged.
+  @pragma('dart2js:noInline')
   void mergeFromMessage(GeneratedMessage other) =>
       _fieldSet._mergeFromMessage(other._fieldSet);
 
@@ -379,8 +383,8 @@ abstract class GeneratedMessage {
       .mergeFromUnknownFieldSet(unknownFieldSet);
 
   /// Sets the value of a non-repeated extension field to [value].
-  void setExtension(Extension extension, value) {
-    if (value == null) throw ArgumentError('value is null');
+  void setExtension(Extension extension, Object value) {
+    ArgumentError.checkNotNull(value, 'value');
     if (_isRepeated(extension.type)) {
       throw ArgumentError(_fieldSet._setFieldFailedMessage(
           extension, value, 'repeating field (use get + .add())'));
@@ -395,7 +399,7 @@ abstract class GeneratedMessage {
   ///
   /// Throws an [:ArgumentError:] if [value] is [:null:]. To clear a field of
   /// it's current value, use [clearField] instead.
-  void setField(int tagNumber, value) {
+  void setField(int tagNumber, Object value) {
     _fieldSet._setField(tagNumber, value);
     return; // ignore: dead_code
     return; // ignore: dead_code
@@ -466,7 +470,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setFloat(int index, double value) {
-    if (value == null || !_isFloat32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isFloat32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -477,7 +482,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setSignedInt32(int index, int value) {
-    if (value == null || !_isSigned32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isSigned32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -485,7 +491,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setUnsignedInt32(int index, int value) {
-    if (value == null || !_isUnsigned32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isUnsigned32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -496,16 +503,17 @@ abstract class GeneratedMessage {
 
   // Support for generating a read-only default singleton instance.
 
-  static final Map<Function, Function> _defaultMakers = {};
+  static final Map<Function?, Function> _defaultMakers = {};
 
   static T Function() _defaultMakerFor<T extends GeneratedMessage>(
-      T Function() createFn) {
-    return _defaultMakers[createFn] ??= _createDefaultMakerFor<T>(createFn);
+      T Function()? createFn) {
+    return (_defaultMakers[createFn] ??= _createDefaultMakerFor<T>(createFn!))
+        as T Function();
   }
 
   static T Function() _createDefaultMakerFor<T extends GeneratedMessage>(
       T Function() createFn) {
-    T defaultValue;
+    T? defaultValue;
     T defaultMaker() {
       return defaultValue ??= createFn()..freeze();
     }
@@ -537,10 +545,10 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
       throw ArgumentError('Rebuilding only works on frozen messages.');
     }
     final t = toBuilder();
-    updates(t);
+    updates(t as T);
     return t..freeze();
   }
 
   /// Returns a writable deep copy of this message.
-  T deepCopy() => info_.createEmptyInstance()..mergeFromMessage(this);
+  T deepCopy() => info_.createEmptyInstance!() as T..mergeFromMessage(this);
 }

--- a/protobuf/lib/src/protobuf/json_parsing_context.dart
+++ b/protobuf/lib/src/protobuf/json_parsing_context.dart
@@ -25,7 +25,7 @@ class JsonParsingContext {
   }
 
   /// Returns a FormatException indicating the indices to the current [path].
-  Exception parseException(String message, Object source) {
+  Exception parseException(String message, Object? source) {
     var formattedPath = _path.map((s) => '[\"$s\"]').join();
     return FormatException(
         'Protobuf JSON decoding failed at: root$formattedPath. $message',

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -31,7 +31,7 @@ abstract class PbEventMixin {
 
 /// A change to a field in a GeneratedMessage.
 class PbFieldChange {
-  final GeneratedMessage message;
+  final GeneratedMessage? message;
   final FieldInfo info;
   final oldValue;
   final newValue;
@@ -47,33 +47,33 @@ class EventBuffer extends EventPlugin {
   // An EventBuffer is created for each GeneratedMessage, so
   // initialization should be fast; create fields lazily.
 
-  GeneratedMessage _parent;
-  StreamController<List<PbFieldChange>> _controller;
+  GeneratedMessage? _parent;
+  StreamController<List<PbFieldChange>>? _controller;
 
   // If _buffer is non-null, at least one event is in the buffer
   // and a microtask has been scheduled to empty it.
-  List<PbFieldChange> _buffer;
+  List<PbFieldChange>? _buffer;
 
   @override
   void attach(GeneratedMessage newParent) {
     assert(_parent == null);
-    assert(newParent != null);
+    ArgumentError.checkNotNull(newParent, 'newParent');
     _parent = newParent;
   }
 
   Stream<List<PbFieldChange>> get changes {
-    _controller ??= StreamController.broadcast(sync: true);
-    return _controller.stream;
+    var controller = _controller ??= StreamController.broadcast(sync: true);
+    return controller.stream;
   }
 
   @override
-  bool get hasObservers => _controller != null && _controller.hasListener;
+  bool get hasObservers => _controller != null && _controller!.hasListener;
 
   void deliverChanges() {
     var records = _buffer;
     _buffer = null;
     if (records != null && hasObservers) {
-      _controller.add(UnmodifiableListView<PbFieldChange>(records));
+      _controller!.add(UnmodifiableListView<PbFieldChange>(records));
     }
   }
 
@@ -83,12 +83,12 @@ class EventBuffer extends EventPlugin {
       _buffer = <PbFieldChange>[];
       scheduleMicrotask(deliverChanges);
     }
-    _buffer.add(change);
+    _buffer!.add(change);
   }
 
   @override
   void beforeSetField(FieldInfo fi, newValue) {
-    var oldValue = _parent.getFieldOrNull(fi.tagNumber);
+    var oldValue = _parent!.getFieldOrNull(fi.tagNumber);
     oldValue ??= fi.readonlyDefault;
     if (identical(oldValue, newValue)) return;
     addEvent(PbFieldChange(_parent, fi, oldValue, newValue));
@@ -96,7 +96,7 @@ class EventBuffer extends EventPlugin {
 
   @override
   void beforeClearField(FieldInfo fi) {
-    var oldValue = _parent.getFieldOrNull(fi.tagNumber);
+    var oldValue = _parent!.getFieldOrNull(fi.tagNumber);
     if (oldValue == null) return;
     var newValue = fi.readonlyDefault;
     addEvent(PbFieldChange(_parent, fi, oldValue, newValue));

--- a/protobuf/lib/src/protobuf/mixins/map_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/map_mixin.dart
@@ -17,9 +17,9 @@ abstract class PbMapMixin {
 
   BuilderInfo get info_;
   void clear();
-  int getTagNumber(String fieldName);
+  int? getTagNumber(String fieldName);
   dynamic getField(int tagNumber);
-  void setField(int tagNumber, var value);
+  void setField(int tagNumber, Object value);
 
   dynamic operator [](key) {
     if (key is! String) return null;
@@ -39,7 +39,7 @@ abstract class PbMapMixin {
 
   Iterable<String> get keys => info_.byName.keys;
 
-  bool containsKey(Object key) => info_.byName.containsKey(key);
+  bool containsKey(Object? key) => info_.byName.containsKey(key);
 
   int get length => info_.byName.length;
 

--- a/protobuf/lib/src/protobuf/mixins/well_known.dart
+++ b/protobuf/lib/src/protobuf/mixins/well_known.dart
@@ -85,7 +85,7 @@ abstract class AnyMixin implements GeneratedMessage {
       throw ArgumentError(
           'The type of the Any message (${any.typeUrl}) is not in the given typeRegistry.');
     }
-    var unpacked = info.createEmptyInstance()..mergeFromBuffer(any.value);
+    var unpacked = info.createEmptyInstance!()..mergeFromBuffer(any.value);
     var proto3Json = unpacked.toProto3Json();
     if (info.toProto3Json == null) {
       var map = proto3Json as Map<String, dynamic>;
@@ -102,7 +102,7 @@ abstract class AnyMixin implements GeneratedMessage {
       throw context.parseException(
           'Expected Any message encoded as {@type,...},', json);
     }
-    final object = json as Map<String, dynamic>;
+    final object = json;
     final typeUrl = object['@type'];
 
     if (typeUrl is String) {
@@ -114,12 +114,12 @@ abstract class AnyMixin implements GeneratedMessage {
             json);
       }
 
-      Object subJson = info.fromProto3Json == null
+      Object? subJson = info.fromProto3Json == null
           // TODO(sigurdm): avoid cloning [object] here.
           ? (Map<String, dynamic>.from(object)..remove('@type'))
           : object['value'];
       // TODO(sigurdm): We lose [context.path].
-      var packedMessage = info.createEmptyInstance()
+      var packedMessage = info.createEmptyInstance!()
         ..mergeFromProto3Json(subJson,
             typeRegistry: typeRegistry,
             supportNamesWithUnderscores: context.supportNamesWithUnderscores,
@@ -231,9 +231,9 @@ abstract class TimestampMixin {
     if (json is String) {
       var jsonWithoutFracSec = json;
       var nanos = 0;
-      Match fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
+      Match? fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
       if (fracSecsMatch != null) {
-        var fracSecs = fracSecsMatch[1];
+        var fracSecs = fracSecsMatch[1]!;
         if (fracSecs.length > 9) {
           throw context.parseException(
               'Timestamp can have at most than 9 decimal digits', json);
@@ -290,7 +290,7 @@ abstract class DurationMixin {
         throw context.parseException(
             'Expected a String of the form `<seconds>.<nanos>s`', json);
       } else {
-        var secondsString = match[1];
+        var secondsString = match[1]!;
         var seconds =
             secondsString == '' ? Int64.ZERO : Int64.parseInt(secondsString);
         duration.seconds = seconds;
@@ -326,13 +326,13 @@ abstract class StructMixin implements GeneratedMessage {
         var fields = (message as StructMixin).fields;
         var valueCreator =
             (message.info_.fieldInfo[_fieldsFieldTagNumber] as MapFieldInfo)
-                .valueCreator;
+                .valueCreator!;
 
         json.forEach((key, value) {
           if (key is! String) {
             throw context.parseException('Expected String key', json);
           }
-          ValueMixin v = valueCreator();
+          var v = valueCreator() as ValueMixin;
           context.addMapIndex(key);
           ValueMixin.fromProto3JsonHelper(v, value, typeRegistry, context);
           context.popIndex();
@@ -368,7 +368,7 @@ abstract class ValueMixin implements GeneratedMessage {
 
   // From google/protobuf/struct.proto:
   // The JSON representation for `Value` is JSON value
-  static Object toProto3JsonHelper(
+  static Object? toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
     var value = message as ValueMixin;
     // This would ideally be a switch, but we cannot import the enum we are
@@ -390,7 +390,7 @@ abstract class ValueMixin implements GeneratedMessage {
     }
   }
 
-  static void fromProto3JsonHelper(GeneratedMessage message, Object json,
+  static void fromProto3JsonHelper(GeneratedMessage message, Object? json,
       TypeRegistry typeRegistry, JsonParsingContext context) {
     var value = message as ValueMixin;
     if (json == null) {
@@ -441,10 +441,10 @@ abstract class ListValueMixin implements GeneratedMessage {
       TypeRegistry typeRegistry, JsonParsingContext context) {
     var list = message as ListValueMixin;
     if (json is List) {
-      var subBuilder = message.info_.subBuilder(_valueFieldTagNumber);
+      var subBuilder = message.info_.subBuilder(_valueFieldTagNumber)!;
       for (var i = 0; i < json.length; i++) {
         Object element = json[i];
-        ValueMixin v = subBuilder();
+        var v = subBuilder() as ValueMixin;
         context.addListIndex(i);
         ValueMixin.fromProto3JsonHelper(v, element, typeRegistry, context);
         context.popIndex();
@@ -498,12 +498,12 @@ abstract class FieldMaskMixin {
 
   static String _toCamelCase(String name) {
     return name.replaceAllMapped(
-        RegExp('_([a-z])'), (Match m) => '${m.group(1).toUpperCase()}');
+        RegExp('_([a-z])'), (Match m) => '${m.group(1)!.toUpperCase()}');
   }
 
   static String _fromCamelCase(String name) {
     return name.replaceAllMapped(
-        RegExp('[A-Z]'), (Match m) => '_${m.group(0).toLowerCase()}');
+        RegExp('[A-Z]'), (Match m) => '_${m.group(0)!.toLowerCase()}');
   }
 }
 

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -4,7 +4,7 @@
 
 part of protobuf;
 
-typedef CheckFunc<E> = void Function(E x);
+typedef CheckFunc<E> = void Function(E? x);
 
 class FrozenPbList<E> extends PbListBase<E> {
   FrozenPbList._(List<E> wrappedList) : super._(wrappedList);
@@ -22,7 +22,7 @@ class FrozenPbList<E> extends PbListBase<E> {
   @override
   void setAll(int at, Iterable<E> iterable) => throw _unsupported('setAll');
   @override
-  void add(E value) => throw _unsupported('add');
+  void add(E? value) => throw _unsupported('add');
   @override
   void addAll(Iterable<E> iterable) => throw _unsupported('addAll');
   @override
@@ -31,7 +31,7 @@ class FrozenPbList<E> extends PbListBase<E> {
   void insertAll(int at, Iterable<E> iterable) =>
       throw _unsupported('insertAll');
   @override
-  bool remove(Object element) => throw _unsupported('remove');
+  bool remove(Object? element) => throw _unsupported('remove');
   @override
   void removeWhere(bool Function(E element) test) =>
       throw _unsupported('removeWhere');
@@ -39,9 +39,9 @@ class FrozenPbList<E> extends PbListBase<E> {
   void retainWhere(bool Function(E element) test) =>
       throw _unsupported('retainWhere');
   @override
-  void sort([Comparator<E> compare]) => throw _unsupported('sort');
+  void sort([Comparator<E>? compare]) => throw _unsupported('sort');
   @override
-  void shuffle([math.Random random]) => throw _unsupported('shuffle');
+  void shuffle([math.Random? random]) => throw _unsupported('shuffle');
   @override
   void clear() => throw _unsupported('clear');
   @override
@@ -58,12 +58,12 @@ class FrozenPbList<E> extends PbListBase<E> {
   void replaceRange(int start, int end, Iterable<E> iterable) =>
       throw _unsupported('replaceRange');
   @override
-  void fillRange(int start, int end, [E fillValue]) =>
+  void fillRange(int start, int end, [E? fillValue]) =>
       throw _unsupported('fillRange');
 }
 
 class PbList<E> extends PbListBase<E> {
-  PbList({check = _checkNotNull}) : super._noList(check: check);
+  PbList({CheckFunc<E> check = _checkNotNull}) : super._noList(check: check);
 
   PbList.from(List from) : super._from(from);
 
@@ -99,11 +99,11 @@ class PbList<E> extends PbListBase<E> {
   /// Sorts this list according to the order specified by the [compare]
   /// function.
   @override
-  void sort([int Function(E a, E b) compare]) => _wrappedList.sort(compare);
+  void sort([int Function(E a, E b)? compare]) => _wrappedList.sort(compare);
 
   /// Shuffles the elements of this list randomly.
   @override
-  void shuffle([math.Random random]) => _wrappedList.shuffle(random);
+  void shuffle([math.Random? random]) => _wrappedList.shuffle(random);
 
   /// Removes all objects from this list; the length of the list becomes zero.
   @override
@@ -138,7 +138,7 @@ class PbList<E> extends PbListBase<E> {
 
   /// Removes the first occurrence of [value] from this list.
   @override
-  bool remove(Object value) => _wrappedList.remove(value);
+  bool remove(Object? value) => _wrappedList.remove(value);
 
   /// Removes the object at position [index] from this list.
   @override
@@ -176,7 +176,7 @@ class PbList<E> extends PbListBase<E> {
   /// Sets the objects in the range [start] inclusive to [end] exclusive to the
   /// given [fillValue].
   @override
-  void fillRange(int start, int end, [E fillValue]) {
+  void fillRange(int start, int end, [E? fillValue]) {
     check(fillValue);
     _wrappedList.fillRange(start, end, fillValue);
   }
@@ -198,7 +198,7 @@ abstract class PbListBase<E> extends ListBase<E> {
   PbListBase._(this._wrappedList, {this.check = _checkNotNull});
 
   PbListBase._noList({this.check = _checkNotNull}) : _wrappedList = <E>[] {
-    assert(check != null);
+    ArgumentError.checkNotNull(check, 'check');
   }
 
   PbListBase._from(List from)
@@ -234,7 +234,7 @@ abstract class PbListBase<E> extends ListBase<E> {
 
   /// Returns true if the collection contains an element equal to [element].
   @override
-  bool contains(Object element) => _wrappedList.contains(element);
+  bool contains(Object? element) => _wrappedList.contains(element);
 
   /// Applies the function [f] to each element of this list in iteration order.
   @override
@@ -316,12 +316,12 @@ abstract class PbListBase<E> extends ListBase<E> {
 
   /// Returns the first element that satisfies the given predicate [test].
   @override
-  E firstWhere(bool Function(E element) test, {E Function() orElse}) =>
+  E firstWhere(bool Function(E element) test, {E Function()? orElse}) =>
       _wrappedList.firstWhere(test, orElse: orElse);
 
   /// Returns the last element that satisfies the given predicate [test].
   @override
-  E lastWhere(bool Function(E element) test, {E Function() orElse}) =>
+  E lastWhere(bool Function(E element) test, {E Function()? orElse}) =>
       _wrappedList.lastWhere(test, orElse: orElse);
 
   /// Returns the single element that satisfies [test].
@@ -349,19 +349,19 @@ abstract class PbListBase<E> extends ListBase<E> {
   // TODO(jakobr): E instead of Object once dart-lang/sdk#31311 is fixed.
   /// Returns the first index of [element] in this list.
   @override
-  int indexOf(Object element, [int start = 0]) =>
-      _wrappedList.indexOf(element, start);
+  int indexOf(Object? element, [int start = 0]) =>
+      _wrappedList.indexOf(element as E, start);
 
   // TODO(jakobr): E instead of Object once dart-lang/sdk#31311 is fixed.
   /// Returns the last index of [element] in this list.
   @override
-  int lastIndexOf(Object element, [int start]) =>
-      _wrappedList.lastIndexOf(element, start);
+  int lastIndexOf(Object? element, [int? start]) =>
+      _wrappedList.lastIndexOf(element as E, start);
 
   /// Returns a new list containing the objects from [start] inclusive to [end]
   /// exclusive.
   @override
-  List<E> sublist(int start, [int end]) => _wrappedList.sublist(start, end);
+  List<E> sublist(int start, [int? end]) => _wrappedList.sublist(start, end);
 
   /// Returns an [Iterable] that iterates over the objects in the range [start]
   /// inclusive to [end] exclusive.

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -5,8 +5,8 @@
 part of protobuf;
 
 class PbMap<K, V> extends MapBase<K, V> {
-  final int keyFieldType;
-  final int valueFieldType;
+  final int? keyFieldType;
+  final int? valueFieldType;
 
   static const int _keyFieldNumber = 1;
   static const int _valueFieldNumber = 2;
@@ -28,7 +28,7 @@ class PbMap<K, V> extends MapBase<K, V> {
         _isReadonly = other._isReadonly;
 
   @override
-  V operator [](Object key) => _wrappedMap[key];
+  V? operator [](Object? key) => _wrappedMap[key];
 
   @override
   void operator []=(K key, V value) {
@@ -86,7 +86,7 @@ class PbMap<K, V> extends MapBase<K, V> {
   Iterable<K> get keys => _wrappedMap.keys;
 
   @override
-  V remove(Object key) {
+  V? remove(Object? key) {
     if (_isReadonly) {
       throw UnsupportedError('Attempted to change a read-only map field');
     }
@@ -95,16 +95,16 @@ class PbMap<K, V> extends MapBase<K, V> {
 
   @Deprecated('This function was not intended to be public. '
       'It will be removed from the public api in next major version. ')
-  void add(CodedBufferReader input, [ExtensionRegistry registry]) {
+  void add(CodedBufferReader input, [ExtensionRegistry? registry]) {
     _mergeEntry(input, registry);
   }
 
-  void _mergeEntry(CodedBufferReader input, [ExtensionRegistry registry]) {
+  void _mergeEntry(CodedBufferReader input, [ExtensionRegistry? registry]) {
     var length = input.readInt32();
     var oldLimit = input._currentLimit;
     input._currentLimit = input._bufferPos + length;
     var entryFieldSet = _entryFieldSet();
-    _mergeFromCodedBufferReader(entryFieldSet, input, registry);
+    _mergeFromCodedBufferReader(entryFieldSet, input, registry!);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;
     var key = entryFieldSet._$get<K>(0, null);
@@ -112,7 +112,7 @@ class PbMap<K, V> extends MapBase<K, V> {
     _wrappedMap[key] = value;
   }
 
-  void _checkNotNull(Object val) {
+  void _checkNotNull(Object? val) {
     if (val == null) {
       throw ArgumentError("Can't add a null to a map field");
     }
@@ -120,7 +120,7 @@ class PbMap<K, V> extends MapBase<K, V> {
 
   PbMap freeze() {
     _isReadonly = true;
-    if (_isGroupOrMessage(valueFieldType)) {
+    if (_isGroupOrMessage(valueFieldType!)) {
       for (var subMessage in values as Iterable<GeneratedMessage>) {
         subMessage.freeze();
       }

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -4,8 +4,8 @@
 
 part of protobuf;
 
-Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
-  String convertToMapKey(dynamic key, int keyType) {
+Object? _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
+  String? convertToMapKey(dynamic key, int keyType) {
     var baseType = PbFieldType._baseType(keyType);
 
     assert(!_isRepeated(keyType));
@@ -32,10 +32,10 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     }
   }
 
-  Object valueToProto3Json(dynamic fieldValue, int fieldType) {
+  Object? valueToProto3Json(dynamic fieldValue, int? fieldType) {
     if (fieldValue == null) return null;
 
-    if (_isGroupOrMessage(fieldType)) {
+    if (_isGroupOrMessage(fieldType!)) {
       return _writeToProto3Json(
           (fieldValue as GeneratedMessage)._fieldSet, typeRegistry);
     } else if (_isEnum(fieldType)) {
@@ -82,12 +82,12 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
   }
 
   if (fs._meta.toProto3Json != null) {
-    return fs._meta.toProto3Json(fs._message, typeRegistry);
+    return fs._meta.toProto3Json!(fs._message!, typeRegistry);
   }
 
   var result = <String, dynamic>{};
   for (var fieldInfo in fs._infosSortedByTag) {
-    var value = fs._values[fieldInfo.index];
+    var value = fs._values[fieldInfo.index!];
     if (value == null || (value is List && value.isEmpty)) {
       continue; // It's missing, repeated, or an empty byte array.
     }
@@ -95,7 +95,7 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     if (fieldInfo.isMapField) {
       jsonValue = (value as PbMap).map((key, entryValue) {
         var mapEntryInfo = fieldInfo as MapFieldInfo;
-        return MapEntry(convertToMapKey(key, mapEntryInfo.keyFieldType),
+        return MapEntry(convertToMapKey(key, mapEntryInfo.keyFieldType!),
             valueToProto3Json(entryValue, mapEntryInfo.valueFieldType));
       });
     } else if (fieldInfo.isRepeated) {
@@ -111,8 +111,18 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
   return result;
 }
 
+/// TODO(paulberry): find a better home for this?
+extension _FindFirst<E> on Iterable<E> {
+  E? findFirst(bool Function(E) test) {
+    for (var element in this) {
+      if (test(element)) return element;
+    }
+    return null;
+  }
+}
+
 void _mergeFromProto3Json(
-    Object json,
+    Object? json,
     _FieldSet fieldSet,
     TypeRegistry typeRegistry,
     bool ignoreUnknownFields,
@@ -121,7 +131,7 @@ void _mergeFromProto3Json(
   var context = JsonParsingContext(
       ignoreUnknownFields, supportNamesWithUnderscores, permissiveEnums);
 
-  void recursionHelper(Object json, _FieldSet fieldSet) {
+  void recursionHelper(Object? json, _FieldSet fieldSet) {
     int tryParse32Bit(String s) {
       return int.tryParse(s) ??
           (throw context.parseException('expected integer', s));
@@ -151,9 +161,9 @@ void _mergeFromProto3Json(
       return result;
     }
 
-    Object convertProto3JsonValue(Object value, FieldInfo fieldInfo) {
+    Object? convertProto3JsonValue(Object? value, FieldInfo fieldInfo) {
       if (value == null) {
-        return fieldInfo.makeDefault();
+        return fieldInfo.makeDefault!();
       }
       var fieldType = fieldInfo.type;
       switch (PbFieldType._baseType(fieldType)) {
@@ -197,15 +207,13 @@ void _mergeFromProto3Json(
           if (value is String) {
             // TODO(sigurdm): Do we want to avoid linear search here? Measure...
             final result = permissiveEnums
-                ? fieldInfo.enumValues.firstWhere(
-                    (e) => permissiveCompare(e.name, value),
-                    orElse: () => null)
-                : fieldInfo.enumValues
-                    .firstWhere((e) => e.name == value, orElse: () => null);
+                ? fieldInfo.enumValues!
+                    .findFirst((e) => permissiveCompare(e.name, value))
+                : fieldInfo.enumValues!.findFirst((e) => e.name == value);
             if ((result != null) || ignoreUnknownFields) return result;
             throw context.parseException('Unknown enum value', value);
           } else if (value is int) {
-            return fieldInfo.valueOf(value) ??
+            return fieldInfo.valueOf!(value) ??
                 (ignoreUnknownFields
                     ? null
                     : (throw context.parseException(
@@ -269,7 +277,7 @@ void _mergeFromProto3Json(
               'Expected int or stringified int', value);
         case PbFieldType._GROUP_BIT:
         case PbFieldType._MESSAGE_BIT:
-          var subMessage = fieldInfo.subBuilder();
+          var subMessage = fieldInfo.subBuilder!();
           recursionHelper(value, subMessage._fieldSet);
           return subMessage;
         default:
@@ -323,12 +331,12 @@ void _mergeFromProto3Json(
 
     final wellKnownConverter = info.fromProto3Json;
     if (wellKnownConverter != null) {
-      wellKnownConverter(fieldSet._message, json, typeRegistry, context);
+      wellKnownConverter(fieldSet._message!, json, typeRegistry, context);
     } else {
       if (json is Map) {
         var byName = info.byName;
 
-        json.forEach((key, value) {
+        json.forEach((key, Object? value) {
           if (key is! String) {
             throw context.parseException('Key was not a String', key);
           }
@@ -338,9 +346,8 @@ void _mergeFromProto3Json(
           if (fieldInfo == null && supportNamesWithUnderscores) {
             // We don't optimize for field names with underscores, instead do a
             // linear search for the index.
-            fieldInfo = byName.values.firstWhere(
-                (FieldInfo info) => info.protoName == key,
-                orElse: () => null);
+            fieldInfo = byName.values
+                .findFirst((FieldInfo info) => info.protoName == key);
           }
           if (fieldInfo == null) {
             if (ignoreUnknownFields) {
@@ -352,19 +359,17 @@ void _mergeFromProto3Json(
 
           if (_isMapField(fieldInfo.type)) {
             if (value is Map) {
-              MapFieldInfo mapFieldInfo = fieldInfo;
+              var mapFieldInfo = fieldInfo as MapFieldInfo<dynamic, dynamic>;
               Map fieldValues = fieldSet._ensureMapField(fieldInfo);
               value.forEach((subKey, subValue) {
                 if (subKey is! String) {
                   throw context.parseException('Expected a String key', subKey);
                 }
                 context.addMapIndex(subKey);
-                final result = fieldValues[
-                        decodeMapKey(subKey, mapFieldInfo.keyFieldType)] =
+                fieldValues[decodeMapKey(subKey, mapFieldInfo.keyFieldType!)] =
                     convertProto3JsonValue(
                         subValue, mapFieldInfo.valueFieldInfo);
                 context.popIndex();
-                return result;
               });
             } else {
               throw context.parseException('Expected a map', value);
@@ -385,12 +390,13 @@ void _mergeFromProto3Json(
               throw context.parseException('Expected a list', value);
             }
           } else if (_isGroupOrMessage(fieldInfo.type)) {
-            // TODO(sigurdm) consider a cleaner separation between parsing and merging.
-            GeneratedMessage parsedSubMessage =
-                convertProto3JsonValue(value, fieldInfo);
-            GeneratedMessage original = fieldSet._values[fieldInfo.index];
+            // TODO(sigurdm) consider a cleaner separation between parsing and
+            // merging.
+            var parsedSubMessage =
+                convertProto3JsonValue(value, fieldInfo) as GeneratedMessage;
+            GeneratedMessage? original = fieldSet._values[fieldInfo.index!];
             if (original == null) {
-              fieldSet._values[fieldInfo.index] = parsedSubMessage;
+              fieldSet._values[fieldInfo.index!] = parsedSubMessage;
             } else {
               original.mergeFromMessage(parsedSubMessage);
             }

--- a/protobuf/lib/src/protobuf/readonly_message.dart
+++ b/protobuf/lib/src/protobuf/readonly_message.dart
@@ -17,7 +17,7 @@ abstract class ReadonlyMessageMixin {
 
   void clearField(int tagNumber) => _readonly('clearField');
 
-  List<T> createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
+  List<T>? createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
     _readonly('createRepeatedField');
     return null; // not reached
   }
@@ -47,7 +47,7 @@ abstract class ReadonlyMessageMixin {
   void setExtension(Extension extension, var value) =>
       _readonly('setExtension');
 
-  void setField(int tagNumber, var value, [int fieldType]) =>
+  void setField(int tagNumber, var value, [int? fieldType]) =>
       _readonly('setField');
 
   void _readonly(String methodName) {

--- a/protobuf/lib/src/protobuf/rpc_client.dart
+++ b/protobuf/lib/src/protobuf/rpc_client.dart
@@ -7,7 +7,7 @@ part of protobuf;
 /// Client side context.
 class ClientContext {
   /// The desired timeout of the RPC call.
-  final Duration timeout;
+  final Duration? timeout;
 
   ClientContext({this.timeout});
 }
@@ -28,7 +28,7 @@ abstract class RpcClient {
   /// appropriate. It should merge the reply into [emptyResponse] and
   /// return it.
   Future<T> invoke<T extends GeneratedMessage>(
-      ClientContext ctx,
+      ClientContext? ctx,
       String serviceName,
       String methodName,
       GeneratedMessage request,

--- a/protobuf/lib/src/protobuf/type_registry.dart
+++ b/protobuf/lib/src/protobuf/type_registry.dart
@@ -26,7 +26,7 @@ class TypeRegistry {
 
   const TypeRegistry.empty() : _mapping = const {};
 
-  BuilderInfo lookup(String qualifiedName) {
+  BuilderInfo? lookup(String qualifiedName) {
     return _mapping[qualifiedName];
   }
 }

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -28,7 +28,7 @@ class UnknownFieldSet {
     _fields.clear();
   }
 
-  UnknownFieldSetField getField(int tagNumber) => _fields[tagNumber];
+  UnknownFieldSetField? getField(int tagNumber) => _fields[tagNumber];
 
   bool hasField(int tagNumber) => _fields.containsKey(tagNumber);
 
@@ -88,7 +88,7 @@ class UnknownFieldSet {
   void mergeFromUnknownFieldSet(UnknownFieldSet other) {
     _ensureWritable('mergeFromUnknownFieldSet');
     for (var key in other._fields.keys) {
-      mergeField(key, other._fields[key]);
+      mergeField(key, other._fields[key]!);
     }
   }
 
@@ -133,7 +133,7 @@ class UnknownFieldSet {
   bool operator ==(other) {
     if (other is! UnknownFieldSet) return false;
 
-    UnknownFieldSet o = other;
+    var o = other;
     return _areMapsEqual(o._fields, _fields);
   }
 
@@ -154,7 +154,7 @@ class UnknownFieldSet {
     var stringBuffer = StringBuffer();
 
     for (var tag in _sorted(_fields.keys)) {
-      var field = _fields[tag];
+      var field = _fields[tag]!;
       for (var value in field.values) {
         if (value is UnknownFieldSet) {
           stringBuffer
@@ -176,7 +176,7 @@ class UnknownFieldSet {
 
   void writeToCodedBufferWriter(CodedBufferWriter output) {
     for (var key in _fields.keys) {
-      _fields[key].writeTo(key, output);
+      _fields[key]!.writeTo(key, output);
     }
   }
 
@@ -222,7 +222,7 @@ class UnknownFieldSetField {
   bool operator ==(other) {
     if (other is! UnknownFieldSetField) return false;
 
-    UnknownFieldSetField o = other;
+    var o = other;
     if (lengthDelimited.length != o.lengthDelimited.length) return false;
     for (var i = 0; i < lengthDelimited.length; i++) {
       if (!_areListsEqual(o.lengthDelimited[i], lengthDelimited[i])) {

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,18 +1,19 @@
 name: protobuf
-version: 1.1.0
+version: 2.0.0-nullsafety.0
 description: >-
   Runtime library for protocol buffers support.
   Use https://pub.dev/packages/protoc_plugin to generate dart code for your '.proto' files.
 homepage: https://github.com/dart-lang/protobuf
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
+  fixnum: ^1.0.0-nullsafety.0
 
 dev_dependencies:
-  test: '>=1.2.0'
-  benchmark_harness: any
-  js: any
-  pedantic: ^1.9.2
+  test: ^1.16.0-nullsafety.9
+  benchmark_harness: ^2.0.0-nullsafety.0
+  js: ^0.6.3-nullsafety.3
+  pedantic: ^1.10.0-nullsafety.3
+  collection: ^1.15.0-nullsafety.5

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -23,11 +23,11 @@ void main() {
       };
 
   RoundtripTester<T> roundtripTester<T>(
-      {T Function(CodedBufferReader bytes) fromBytes,
-      List<int> Function(T value) toBytes}) {
+      {T Function(CodedBufferReader bytes)? fromBytes,
+      List<int> Function(T value)? toBytes}) {
     return (T value, List<int> bytes) {
-      expect(fromBytes(CodedBufferReader(bytes)), equals(value));
-      expect(toBytes(value), bytes);
+      expect(fromBytes!(CodedBufferReader(bytes)), equals(value));
+      expect(toBytes!(value), bytes);
     };
   }
 
@@ -130,8 +130,8 @@ void main() {
 
   // Compare two doubles, where NaNs and same-sign inifinities compare equal.
   // For normal values, use equals.
-  Matcher doubleEquals(expected) => expected.isNaN
-      ? predicate((x) => x.isNaN, 'NaN expected')
+  Matcher doubleEquals(double expected) => expected.isNaN
+      ? predicate<double>((x) => x.isNaN, 'NaN expected')
       : equals(expected);
 
   List<int> dataToBytes(ByteData byteData) => Uint8List.view(byteData.buffer);

--- a/protobuf/test/dummy_field_test.dart
+++ b/protobuf/test/dummy_field_test.dart
@@ -9,7 +9,7 @@ class Message extends GeneratedMessage {
   @override
   BuilderInfo get info_ => _i;
   static final _i = BuilderInfo('Message')
-    ..add(0, null, null, null, null, null, null);
+    ..add(0, 'dummy', null, null, null, null, null);
   @override
   Message createEmptyInstance() => Message();
 

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -29,8 +29,10 @@ void main() {
     // "c" is not a legal enum value.
     expect(
         () => example..mergeFromProto3Json({'enm': 'c'}),
-        throwsA(allOf(isFormatException,
-            predicate((e) => e.message.contains('Unknown enum value')))));
+        throwsA(allOf(
+            isFormatException,
+            predicate(
+                (dynamic e) => e.message.contains('Unknown enum value')))));
     // `example` hasn't changed.
     expect(example.hasEnm, isTrue);
     expect(example.enm.name, equals('b'));
@@ -48,8 +50,10 @@ void main() {
     expect((example..mergeFromProto3Json({'enm': 2})).enm.name, 'b');
     expect(
         () => example..mergeFromProto3Json({'enm': 3}),
-        throwsA(allOf(isFormatException,
-            predicate((e) => e.message.contains('Unknown enum value')))));
+        throwsA(allOf(
+            isFormatException,
+            predicate(
+                (dynamic e) => e.message.contains('Unknown enum value')))));
     // `example` hasn't changed.
     expect(example.hasEnm, isTrue);
     expect(example.enm.name, equals('b'));

--- a/protobuf/test/message_test.dart
+++ b/protobuf/test/message_test.dart
@@ -20,9 +20,9 @@ class Rec extends MockMessage {
 }
 
 Matcher throwsError(Type expectedType, String expectedMessage) =>
-    throwsA(predicate((x) {
+    throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
-      expect(x.message, expectedMessage);
+      expect(x!.message, expectedMessage);
       return true;
     }));
 

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -4,6 +4,7 @@
 
 library mock_util;
 
+import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:protobuf/protobuf.dart'
     show
@@ -24,8 +25,7 @@ BuilderInfo mockInfo(String className, CreateBuilderFunc create) {
     // 6 is reserved for extensions in other tests.
     ..e(7, 'enm', PbFieldType.OE,
         defaultOrMaker: mockEnumValues.first,
-        valueOf: (i) =>
-            mockEnumValues.firstWhere((e) => e.value == i, orElse: () => null),
+        valueOf: (i) => mockEnumValues.firstWhereOrNull((e) => e.value == i),
         enumValues: mockEnumValues);
 }
 
@@ -54,7 +54,7 @@ abstract class MockMessage extends GeneratedMessage {
 
   @override
   GeneratedMessage clone() {
-    var create = info_.byName['child'].subBuilder;
+    var create = info_.byName['child']!.subBuilder!;
     return create()..mergeFromMessage(this);
   }
 }

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -17,9 +17,9 @@ import 'package:protobuf/protobuf.dart'
         defaultFrozenMessageModificationHandler;
 
 Matcher throwsError(Type expectedType, Matcher expectedMessage) =>
-    throwsA(predicate((x) {
+    throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
-      expect(x.message, expectedMessage);
+      expect(x!.message, expectedMessage);
       return true;
     }));
 
@@ -52,8 +52,8 @@ class Rec extends GeneratedMessage {
   @override
   Rec copyWith(void Function(Rec) updates) {
     final builder = toBuilder();
-    updates(builder);
-    return builder.freeze();
+    updates(builder as Rec);
+    return builder.freeze() as Rec;
   }
 }
 
@@ -83,7 +83,7 @@ void main() {
       var called = 0;
 
       frozenMessageModificationHandler =
-          (String messageName, [String methodName]) {
+          (String messageName, [String? methodName]) {
         expect(messageName, 'rec');
         expect(methodName, isNull);
         called++;
@@ -103,7 +103,7 @@ void main() {
       final initialHashCode = message.hashCode;
 
       frozenMessageModificationHandler =
-          (String messageName, [String methodName]) {};
+          (String messageName, [String? methodName]) {};
       message.setField(1, 456);
       final modifiedHashCode = message.hashCode;
       expect(initialHashCode == modifiedHashCode, isFalse);

--- a/protobuf/test/test_util.dart
+++ b/protobuf/test/test_util.dart
@@ -7,12 +7,12 @@ library test_util;
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
-Int64 make64(int lo, [int hi]) {
+Int64 make64(int lo, [int? hi]) {
   hi ??= lo < 0 ? -1 : 0;
   return Int64.fromInts(hi, lo);
 }
 
-Matcher expect64(int lo, [int hi]) {
+Matcher expect64(int lo, [int? hi]) {
   final expected = make64(lo, hi);
   return predicate((Int64 actual) => actual == expected);
 }

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 19.2.0
+
+* Generate null-safe code.
+
 ## 19.1.0
 
 * Emit depreciation of generated `copyWith` and `clone` methods.

--- a/protoc_plugin/lib/client_generator.dart
+++ b/protoc_plugin/lib/client_generator.dart
@@ -42,7 +42,7 @@ class ClientApiGenerator {
     var outputType = service._getDartClassName(m.outputType, forMainFile: true);
     out.addBlock(
         '$_asyncImportPrefix.Future<$outputType> $methodName('
-            '$_protobufImportPrefix.ClientContext ctx, $inputType request) {',
+            '$_protobufImportPrefix.ClientContext? ctx, $inputType request) {',
         '}', () {
       out.println('var emptyResponse = $outputType();');
       out.println('return _client.invoke<$outputType>(ctx, \'${className}\', '

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -155,7 +155,8 @@ class EnumGenerator extends ProtobufContainer {
       out.println(
           'static final $_coreImportPrefix.Map<$_coreImportPrefix.int, $classname> _byValue ='
           ' $_protobufImportPrefix.ProtobufEnum.initByValue(values);');
-      out.println('static ${classname} valueOf($_coreImportPrefix.int value) =>'
+      out.println(
+          'static ${classname}? valueOf($_coreImportPrefix.int value) =>'
           ' _byValue[value];');
       out.println();
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -479,7 +479,7 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError("not linked");
     var out = makeWriter();
-    _writeHeading(out);
+    _writeHeading(out, nullSafe: false);
 
     out.println(_asyncImport);
     out.println();
@@ -515,6 +515,7 @@ class FileGenerator extends ProtobufContainer {
     var out = makeWriter();
     _writeHeading(out);
 
+    out.println(_coreImport);
     // Import the .pbjson.dart files we depend on.
     var imports = _findJsonProtosToImport();
     for (var target in imports) {
@@ -553,13 +554,14 @@ class FileGenerator extends ProtobufContainer {
   }
 
   /// Writes the header at the top of the dart file.
-  void _writeHeading(IndentingWriter out) {
+  void _writeHeading(IndentingWriter out, {bool nullSafe = true}) {
+    var version = nullSafe ? '2.12' : '2.3';
     out.println('''
 ///
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 //
-// @dart = 2.3
+// @dart = $version
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 ''');
   }

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -376,7 +376,8 @@ class MessageGenerator extends ProtobufContainer {
 'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
 'Will be removed in next major version\')''');
       out.println('$classname copyWith(void Function($classname) updates) =>'
-          ' super.copyWith((message) => updates(message as $classname));'
+          ' super.copyWith((message) => updates(message as $classname))'
+          ' as $classname;'
           ' // ignore: deprecated_member_use');
 
       out.println('$_protobufImportPrefix.BuilderInfo get info_ => _i;');
@@ -394,7 +395,7 @@ class MessageGenerator extends ProtobufContainer {
           ' _defaultInstance ??='
           ' $_protobufImportPrefix.GeneratedMessage.\$_defaultFor<${classname}>'
           '(create);');
-      out.println('static ${classname} _defaultInstance;');
+      out.println('static ${classname}? _defaultInstance;');
 
       generateFieldsAccessorsMutators(out);
       mixin?.injectHelpers(out);
@@ -459,7 +460,7 @@ class MessageGenerator extends ProtobufContainer {
   void generateOneofAccessors(IndentingWriter out, OneofNames oneof) {
     out.println();
     out.println("${oneof.oneofEnumName} ${oneof.whichOneofMethodName}() "
-        "=> ${oneof.byTagMapName}[\$_whichOneof(${oneof.index})];");
+        "=> ${oneof.byTagMapName}[\$_whichOneof(${oneof.index})]!;");
     out.println('void ${oneof.clearMethodName}() '
         '=> clearField(\$_whichOneof(${oneof.index}));');
   }

--- a/protoc_plugin/lib/service_generator.dart
+++ b/protoc_plugin/lib/service_generator.dart
@@ -176,8 +176,9 @@ class ServiceGenerator {
       out.addBlock("switch (method) {", "}", () {
         for (var m in _methodDescriptors) {
           var methodName = _methodName(m.name);
-          out.println(
-              "case '${m.name}': return this.$methodName(ctx, request);");
+          var inputClass = _getDartClassName(m.inputType);
+          out.println("case '${m.name}': return this.$methodName"
+              "(ctx, request as $inputClass);");
         }
         out.println("default: "
             "throw $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
@@ -215,7 +216,8 @@ class ServiceGenerator {
   /// The map includes an entry for every message type that might need
   /// to be read or written (assuming the type name resolved).
   void generateConstants(IndentingWriter out) {
-    out.print("const $jsonConstant = ");
+    out.print("const $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+        " $_coreImportPrefix.dynamic> $jsonConstant = ");
     writeJsonConst(out, _descriptor.writeToJsonMap());
     out.println(";");
     out.println();
@@ -224,7 +226,11 @@ class ServiceGenerator {
     for (var key in _transitiveDeps.keys) {
       typeConstants[key] = _transitiveDeps[key].getJsonConstant(fileGen);
     }
-    out.addBlock("const $messageJsonConstant = const {", "};", () {
+    out.addBlock(
+        "const $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+            " $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+            " $_coreImportPrefix.dynamic>> $messageJsonConstant = const {",
+        "};", () {
       for (var key in typeConstants.keys) {
         var typeConst = typeConstants[key];
         out.println("'$key': $typeConst,");

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: dart_options.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -52,8 +52,8 @@ class DartMixin extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DartMixin copyWith(void Function(DartMixin) updates) =>
-      super.copyWith((message) =>
-          updates(message as DartMixin)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DartMixin))
+          as DartMixin; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DartMixin create() => DartMixin._();
@@ -62,7 +62,7 @@ class DartMixin extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DartMixin getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DartMixin>(create);
-  static DartMixin _defaultInstance;
+  static DartMixin? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -136,8 +136,8 @@ class Imports extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Imports copyWith(void Function(Imports) updates) =>
-      super.copyWith((message) =>
-          updates(message as Imports)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Imports))
+          as Imports; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Imports create() => Imports._();
@@ -146,7 +146,7 @@ class Imports extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Imports getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Imports>(create);
-  static Imports _defaultInstance;
+  static Imports? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<DartMixin> get mixins => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -48,8 +48,8 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
-      super.copyWith((message) => updates(
-          message as FileDescriptorSet)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileDescriptorSet))
+          as FileDescriptorSet; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet create() => FileDescriptorSet._();
@@ -59,7 +59,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorSet>(create);
-  static FileDescriptorSet _defaultInstance;
+  static FileDescriptorSet? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<FileDescriptorProto> get file => $_getList(0);
@@ -116,8 +116,8 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as FileDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileDescriptorProto))
+          as FileDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto create() => FileDescriptorProto._();
@@ -127,7 +127,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorProto>(create);
-  static FileDescriptorProto _defaultInstance;
+  static FileDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -257,8 +257,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   DescriptorProto_ExtensionRange copyWith(
           void Function(DescriptorProto_ExtensionRange) updates) =>
-      super.copyWith((message) => updates(message
-          as DescriptorProto_ExtensionRange)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as DescriptorProto_ExtensionRange))
+          as DescriptorProto_ExtensionRange; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange create() =>
@@ -269,7 +270,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ExtensionRange>(create);
-  static DescriptorProto_ExtensionRange _defaultInstance;
+  static DescriptorProto_ExtensionRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -338,8 +339,9 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   DescriptorProto_ReservedRange copyWith(
           void Function(DescriptorProto_ReservedRange) updates) =>
-      super.copyWith((message) => updates(message
-          as DescriptorProto_ReservedRange)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as DescriptorProto_ReservedRange))
+          as DescriptorProto_ReservedRange; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange create() =>
@@ -350,7 +352,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ReservedRange>(create);
-  static DescriptorProto_ReservedRange _defaultInstance;
+  static DescriptorProto_ReservedRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -421,8 +423,8 @@ class DescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
-      super.copyWith((message) =>
-          updates(message as DescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DescriptorProto))
+          as DescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto create() => DescriptorProto._();
@@ -432,7 +434,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto>(create);
-  static DescriptorProto _defaultInstance;
+  static DescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -541,8 +543,8 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as FieldDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FieldDescriptorProto))
+          as FieldDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto create() => FieldDescriptorProto._();
@@ -552,7 +554,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldDescriptorProto>(create);
-  static FieldDescriptorProto _defaultInstance;
+  static FieldDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -716,8 +718,8 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as OneofDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as OneofDescriptorProto))
+          as OneofDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto create() => OneofDescriptorProto._();
@@ -727,7 +729,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofDescriptorProto>(create);
-  static OneofDescriptorProto _defaultInstance;
+  static OneofDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -794,8 +796,8 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as EnumDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumDescriptorProto))
+          as EnumDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto create() => EnumDescriptorProto._();
@@ -805,7 +807,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumDescriptorProto>(create);
-  static EnumDescriptorProto _defaultInstance;
+  static EnumDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -880,8 +882,8 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumValueDescriptorProto copyWith(
           void Function(EnumValueDescriptorProto) updates) =>
-      super.copyWith((message) => updates(message
-          as EnumValueDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumValueDescriptorProto))
+          as EnumValueDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto create() => EnumValueDescriptorProto._();
@@ -891,7 +893,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueDescriptorProto>(create);
-  static EnumValueDescriptorProto _defaultInstance;
+  static EnumValueDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -972,8 +974,8 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ServiceDescriptorProto copyWith(
           void Function(ServiceDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as ServiceDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ServiceDescriptorProto))
+          as ServiceDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto create() => ServiceDescriptorProto._();
@@ -983,7 +985,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceDescriptorProto>(create);
-  static ServiceDescriptorProto _defaultInstance;
+  static ServiceDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1064,8 +1066,8 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   MethodDescriptorProto copyWith(
           void Function(MethodDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as MethodDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MethodDescriptorProto))
+          as MethodDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto create() => MethodDescriptorProto._();
@@ -1075,7 +1077,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodDescriptorProto>(create);
-  static MethodDescriptorProto _defaultInstance;
+  static MethodDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1214,8 +1216,8 @@ class FileOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileOptions copyWith(void Function(FileOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as FileOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileOptions))
+          as FileOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileOptions create() => FileOptions._();
@@ -1224,7 +1226,7 @@ class FileOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileOptions>(create);
-  static FileOptions _defaultInstance;
+  static FileOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get javaPackage => $_getSZ(0);
@@ -1484,8 +1486,8 @@ class MessageOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as MessageOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MessageOptions))
+          as MessageOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MessageOptions create() => MessageOptions._();
@@ -1495,7 +1497,7 @@ class MessageOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MessageOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MessageOptions>(create);
-  static MessageOptions _defaultInstance;
+  static MessageOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get messageSetWireFormat => $_getBF(0);
@@ -1593,8 +1595,8 @@ class FieldOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as FieldOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FieldOptions))
+          as FieldOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FieldOptions create() => FieldOptions._();
@@ -1604,7 +1606,7 @@ class FieldOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldOptions>(create);
-  static FieldOptions _defaultInstance;
+  static FieldOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   FieldOptions_CType get ctype => $_getN(0);
@@ -1717,8 +1719,8 @@ class OneofOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as OneofOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as OneofOptions))
+          as OneofOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OneofOptions create() => OneofOptions._();
@@ -1728,7 +1730,7 @@ class OneofOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofOptions>(create);
-  static OneofOptions _defaultInstance;
+  static OneofOptions? _defaultInstance;
 
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
@@ -1779,8 +1781,8 @@ class EnumOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumOptions copyWith(void Function(EnumOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as EnumOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumOptions))
+          as EnumOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumOptions create() => EnumOptions._();
@@ -1789,7 +1791,7 @@ class EnumOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumOptions>(create);
-  static EnumOptions _defaultInstance;
+  static EnumOptions? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.bool get allowAlias => $_getBF(0);
@@ -1859,8 +1861,8 @@ class EnumValueOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
-      super.copyWith((message) => updates(
-          message as EnumValueOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumValueOptions))
+          as EnumValueOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions create() => EnumValueOptions._();
@@ -1870,7 +1872,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueOptions>(create);
-  static EnumValueOptions _defaultInstance;
+  static EnumValueOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deprecated => $_getBF(0);
@@ -1928,8 +1930,8 @@ class ServiceOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as ServiceOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ServiceOptions))
+          as ServiceOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceOptions create() => ServiceOptions._();
@@ -1939,7 +1941,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceOptions>(create);
-  static ServiceOptions _defaultInstance;
+  static ServiceOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -2000,8 +2002,8 @@ class MethodOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as MethodOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MethodOptions))
+          as MethodOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MethodOptions create() => MethodOptions._();
@@ -2011,7 +2013,7 @@ class MethodOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodOptions>(create);
-  static MethodOptions _defaultInstance;
+  static MethodOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -2081,8 +2083,9 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   UninterpretedOption_NamePart copyWith(
           void Function(UninterpretedOption_NamePart) updates) =>
-      super.copyWith((message) => updates(message
-          as UninterpretedOption_NamePart)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as UninterpretedOption_NamePart))
+          as UninterpretedOption_NamePart; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart create() =>
@@ -2093,7 +2096,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption_NamePart>(create);
-  static UninterpretedOption_NamePart _defaultInstance;
+  static UninterpretedOption_NamePart? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get namePart => $_getSZ(0);
@@ -2160,8 +2163,8 @@ class UninterpretedOption extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
-      super.copyWith((message) => updates(
-          message as UninterpretedOption)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as UninterpretedOption))
+          as UninterpretedOption; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption create() => UninterpretedOption._();
@@ -2171,7 +2174,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption>(create);
-  static UninterpretedOption _defaultInstance;
+  static UninterpretedOption? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.List<UninterpretedOption_NamePart> get name => $_getList(0);
@@ -2295,8 +2298,8 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   SourceCodeInfo_Location copyWith(
           void Function(SourceCodeInfo_Location) updates) =>
-      super.copyWith((message) => updates(
-          message as SourceCodeInfo_Location)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SourceCodeInfo_Location))
+          as SourceCodeInfo_Location; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location create() => SourceCodeInfo_Location._();
@@ -2306,7 +2309,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo_Location>(create);
-  static SourceCodeInfo_Location _defaultInstance;
+  static SourceCodeInfo_Location? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -2377,8 +2380,8 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as SourceCodeInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SourceCodeInfo))
+          as SourceCodeInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo create() => SourceCodeInfo._();
@@ -2388,7 +2391,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo>(create);
-  static SourceCodeInfo _defaultInstance;
+  static SourceCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<SourceCodeInfo_Location> get location => $_getList(0);
@@ -2440,8 +2443,9 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   GeneratedCodeInfo_Annotation copyWith(
           void Function(GeneratedCodeInfo_Annotation) updates) =>
-      super.copyWith((message) => updates(message
-          as GeneratedCodeInfo_Annotation)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as GeneratedCodeInfo_Annotation))
+          as GeneratedCodeInfo_Annotation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation create() =>
@@ -2452,7 +2456,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo_Annotation>(create);
-  static GeneratedCodeInfo_Annotation _defaultInstance;
+  static GeneratedCodeInfo_Annotation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -2529,8 +2533,8 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
-      super.copyWith((message) => updates(
-          message as GeneratedCodeInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as GeneratedCodeInfo))
+          as GeneratedCodeInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo create() => GeneratedCodeInfo._();
@@ -2540,7 +2544,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo>(create);
-  static GeneratedCodeInfo _defaultInstance;
+  static GeneratedCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/descriptor.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -143,7 +143,7 @@ class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Type> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Type valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Type? valueOf($core.int value) => _byValue[value];
 
   const FieldDescriptorProto_Type._($core.int v, $core.String n) : super(v, n);
 }
@@ -177,7 +177,8 @@ class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Label> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Label valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Label? valueOf($core.int value) =>
+      _byValue[value];
 
   const FieldDescriptorProto_Label._($core.int v, $core.String n) : super(v, n);
 }
@@ -209,7 +210,7 @@ class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FileOptions_OptimizeMode> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FileOptions_OptimizeMode valueOf($core.int value) => _byValue[value];
+  static FileOptions_OptimizeMode? valueOf($core.int value) => _byValue[value];
 
   const FileOptions_OptimizeMode._($core.int v, $core.String n) : super(v, n);
 }
@@ -239,7 +240,7 @@ class FieldOptions_CType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_CType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_CType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_CType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_CType._($core.int v, $core.String n) : super(v, n);
 }
@@ -269,7 +270,7 @@ class FieldOptions_JSType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_JSType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_JSType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_JSType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_JSType._($core.int v, $core.String n) : super(v, n);
 }
@@ -303,7 +304,7 @@ class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, MethodOptions_IdempotencyLevel> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static MethodOptions_IdempotencyLevel valueOf($core.int value) =>
+  static MethodOptions_IdempotencyLevel? valueOf($core.int value) =>
       _byValue[value];
 
   const MethodOptions_IdempotencyLevel._($core.int v, $core.String n)

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -56,8 +56,8 @@ class Version extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Version copyWith(void Function(Version) updates) =>
-      super.copyWith((message) =>
-          updates(message as Version)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Version))
+          as Version; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Version create() => Version._();
@@ -66,7 +66,7 @@ class Version extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Version getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Version>(create);
-  static Version _defaultInstance;
+  static Version? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get major => $_getIZ(0);
@@ -161,8 +161,8 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
-      super.copyWith((message) => updates(
-          message as CodeGeneratorRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as CodeGeneratorRequest))
+          as CodeGeneratorRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest create() => CodeGeneratorRequest._();
@@ -172,7 +172,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorRequest>(create);
-  static CodeGeneratorRequest _defaultInstance;
+  static CodeGeneratorRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.String> get fileToGenerate => $_getList(0);
@@ -252,8 +252,9 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   CodeGeneratorResponse_File copyWith(
           void Function(CodeGeneratorResponse_File) updates) =>
-      super.copyWith((message) => updates(message
-          as CodeGeneratorResponse_File)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as CodeGeneratorResponse_File))
+          as CodeGeneratorResponse_File; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File create() => CodeGeneratorResponse_File._();
@@ -263,7 +264,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse_File>(create);
-  static CodeGeneratorResponse_File _defaultInstance;
+  static CodeGeneratorResponse_File? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -344,8 +345,8 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   CodeGeneratorResponse copyWith(
           void Function(CodeGeneratorResponse) updates) =>
-      super.copyWith((message) => updates(
-          message as CodeGeneratorResponse)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as CodeGeneratorResponse))
+          as CodeGeneratorResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse create() => CodeGeneratorResponse._();
@@ -355,7 +356,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse>(create);
-  static CodeGeneratorResponse _defaultInstance;
+  static CodeGeneratorResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get error => $_getSZ(0);

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 19.1.0
+version: 19.2.0
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
+  fixnum: '>=0.10.9 <2.0.0'
   path: ^1.0.0
   protobuf: '>=1.1.0 <2.0.0'
   dart_style: ^1.0.6

--- a/protoc_plugin/test/goldens/client
+++ b/protoc_plugin/test/goldens/client
@@ -2,11 +2,11 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<SomeReply> aMethod($pb.ClientContext ctx, SomeRequest request) {
+  $async.Future<SomeReply> aMethod($pb.ClientContext? ctx, SomeRequest request) {
     var emptyResponse = SomeReply();
     return _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, emptyResponse);
   }
-  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext ctx, $0.EmptyMessage request) {
+  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext? ctx, $0.EmptyMessage request) {
     var emptyResponse = $0.AnotherReply();
     return _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
   }

--- a/protoc_plugin/test/goldens/enum
+++ b/protoc_plugin/test/goldens/enum
@@ -12,7 +12,7 @@ class PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -27,7 +27,7 @@ class Empty extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)); // ignore: deprecated_member_use
+  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
@@ -35,6 +35,6 @@ class Empty extends $pb.GeneratedMessage {
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
-  static Empty _defaultInstance;
+  static Empty? _defaultInstance;
 }
 

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -33,7 +33,7 @@ class M extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M)); // ignore: deprecated_member_use
+  M copyWith(void Function(M) updates) => super.copyWith((message) => updates(message as M)) as M; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static M create() => M._();
@@ -41,7 +41,7 @@ class M extends $pb.GeneratedMessage {
   static $pb.PbList<M> createRepeated() => $pb.PbList<M>();
   @$core.pragma('dart2js:noInline')
   static M getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<M>(create);
-  static M _defaultInstance;
+  static M? _defaultInstance;
 
   @$pb.TagNumber(1)
   M get m => $_getN(0);

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -2,6 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -29,7 +29,7 @@ class Int64 extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Int64 copyWith(void Function(Int64) updates) => super.copyWith((message) => updates(message as Int64)); // ignore: deprecated_member_use
+  Int64 copyWith(void Function(Int64) updates) => super.copyWith((message) => updates(message as Int64)) as Int64; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Int64 create() => Int64._();
@@ -37,7 +37,7 @@ class Int64 extends $pb.GeneratedMessage {
   static $pb.PbList<Int64> createRepeated() => $pb.PbList<Int64>();
   @$core.pragma('dart2js:noInline')
   static Int64 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int64>(create);
-  static Int64 _defaultInstance;
+  static Int64? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -19,7 +19,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)); // ignore: deprecated_member_use
+  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
@@ -27,7 +27,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
-  static PhoneNumber _defaultInstance;
+  static PhoneNumber? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2247
-  end: 2253
+  begin: 2263
+  end: 2269
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2295
-  end: 2301
+  begin: 2311
+  end: 2317
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2374
-  end: 2383
+  begin: 2390
+  end: 2399
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2426
-  end: 2437
+  begin: 2442
+  end: 2453
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2507
-  end: 2511
+  begin: 2523
+  end: 2527
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2552
-  end: 2556
+  begin: 2568
+  end: 2572
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2635
-  end: 2642
+  begin: 2651
+  end: 2658
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 2685
-  end: 2694
+  begin: 2701
+  end: 2710
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2755
-  end: 2759
+  begin: 2771
+  end: 2775
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2806
-  end: 2810
+  begin: 2822
+  end: 2826
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2883
-  end: 2890
+  begin: 2899
+  end: 2906
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 2933
-  end: 2942
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 3052
-  end: 3067
+  begin: 2949
+  end: 2958
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3158
-  end: 3173
+  begin: 3068
+  end: 3083
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3295
-  end: 3313
+  begin: 3174
+  end: 3189
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3405
-  end: 3425
+  begin: 3311
+  end: 3329
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3421
+  end: 3441
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums
@@ -12,7 +12,7 @@ class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneNumber_PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneNumber_PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneNumber_PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneNumber_PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -29,7 +29,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)); // ignore: deprecated_member_use
+  PhoneNumber copyWith(void Function(PhoneNumber) updates) => super.copyWith((message) => updates(message as PhoneNumber)) as PhoneNumber; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static PhoneNumber create() => PhoneNumber._();
@@ -37,7 +37,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
-  static PhoneNumber _defaultInstance;
+  static PhoneNumber? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 373
-  end: 384
+  begin: 374
+  end: 385
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 945
-  end: 956
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2373
-  end: 2379
+  begin: 946
+  end: 957
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2421
-  end: 2427
+  begin: 2390
+  end: 2396
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2500
-  end: 2509
+  begin: 2438
+  end: 2444
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2552
-  end: 2563
+  begin: 2517
+  end: 2526
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2621
-  end: 2625
+  begin: 2569
+  end: 2580
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2667
-  end: 2671
+  begin: 2638
+  end: 2642
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2746
-  end: 2753
+  begin: 2684
+  end: 2688
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2796
-  end: 2805
+  begin: 2763
+  end: 2770
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 2813
+  end: 2822
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2866
-  end: 2870
+  begin: 2883
+  end: 2887
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2917
-  end: 2921
+  begin: 2934
+  end: 2938
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 2994
-  end: 3001
+  begin: 3011
+  end: 3018
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3044
-  end: 3053
+  begin: 3061
+  end: 3070
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -2,9 +2,10 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
+import 'dart:core' as $core;
 const PhoneNumber$json = const {
   '1': 'PhoneNumber',
   '2': const [

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -28,7 +28,7 @@ class Empty extends $pb.GeneratedMessage {
   'Using this can add significant overhead to your binary. '
   'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
   'Will be removed in next major version')
-  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)); // ignore: deprecated_member_use
+  Empty copyWith(void Function(Empty) updates) => super.copyWith((message) => updates(message as Empty)) as Empty; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Empty create() => Empty._();
@@ -36,14 +36,14 @@ class Empty extends $pb.GeneratedMessage {
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
-  static Empty _defaultInstance;
+  static Empty? _defaultInstance;
 }
 
 class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<Empty> ping($pb.ClientContext ctx, Empty request) {
+  $async.Future<Empty> ping($pb.ClientContext? ctx, Empty request) {
     var emptyResponse = Empty();
     return _client.invoke<Empty>(ctx, 'Test', 'Ping', request, emptyResponse);
   }

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -27,7 +27,7 @@ abstract class TestServiceBase extends $pb.GeneratedService {
 
   $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
     switch (method) {
-      case 'Ping': return this.ping(ctx, request);
+      case 'Ping': return this.ping(ctx, request as $0.Empty);
       default: throw $core.ArgumentError('Unknown method: $method');
     }
   }

--- a/protoc_plugin/test/goldens/serviceGenerator
+++ b/protoc_plugin/test/goldens/serviceGenerator
@@ -12,8 +12,8 @@ abstract class TestServiceBase extends $pb.GeneratedService {
 
   $async.Future<$pb.GeneratedMessage> handleCall($pb.ServerContext ctx, $core.String method, $pb.GeneratedMessage request) {
     switch (method) {
-      case 'AMethod': return this.aMethod(ctx, request);
-      case 'AnotherMethod': return this.anotherMethod(ctx, request);
+      case 'AMethod': return this.aMethod(ctx, request as $0.SomeRequest);
+      case 'AnotherMethod': return this.anotherMethod(ctx, request as $1.EmptyMessage);
       default: throw $core.ArgumentError('Unknown method: $method');
     }
   }

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -2,9 +2,10 @@
 //  Generated code. Do not modify.
 //  source: testpkg.proto
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
+import 'dart:core' as $core;
 import 'foobar.pbjson.dart' as $1;
 
 const SomeRequest$json = const {
@@ -15,7 +16,7 @@ const SomeReply$json = const {
   '1': 'SomeReply',
 };
 
-const TestServiceBase$json = const {
+const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = const {
   '1': 'Test',
   '2': const [
     const {'1': 'AMethod', '2': '.testpkg.SomeRequest', '3': '.testpkg.SomeReply'},
@@ -23,7 +24,7 @@ const TestServiceBase$json = const {
   ],
 };
 
-const TestServiceBase$messageJson = const {
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServiceBase$messageJson = const {
   '.testpkg.SomeRequest': SomeRequest$json,
   '.testpkg.SomeReply': SomeReply$json,
   '.foo.bar.EmptyMessage': $1.EmptyMessage$json,

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -23,7 +23,7 @@ class PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 413
-  end: 422
+  begin: 414
+  end: 423
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 475
-  end: 481
+  begin: 476
+  end: 482
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 603
-  end: 607
+  begin: 604
+  end: 608
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 727
-  end: 731
+  begin: 728
+  end: 732
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 852
-  end: 860
+  begin: 853
+  end: 861
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -2,9 +2,10 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.3
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
+import 'dart:core' as $core;
 const PhoneType$json = const {
   '1': 'PhoneType',
   '2': const [


### PR DESCRIPTION
Makes `protobuf` null safe and makes `protoc_plugin` to generate null safe code. `protoc_plugin` itself is not yet migrated to null safety because it depends on `dart_style`. 

Also cannot make `api_benchmark` and `query_benchmark` working yet, as they transitively depend on `fixnum ^0.10.9`, which is incompatible with protobuf dependency on `fixnum ^1.0.0`.