### PR TITLE
Set protoc_plugin version to 20.0.0-nullsafety.0

### DIFF
--- a/api_benchmark/pubspec.yaml
+++ b/api_benchmark/pubspec.yaml
@@ -23,3 +23,4 @@ dev_dependencies:
 dependency_overrides:
   protobuf:
     path: "../protobuf"
+  fixnum: ^1.0.0-nullsafety.0

--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.0-nullsafety.0
 
 * Require at least Dart SDK 2.12.0 and support null safety. Use `protoc_plugin`
-  from 19.3.0 to generate null-safe code.
+  from `20.0.0-nullsafety.0` to generate null-safe code.
 
 ## 1.1.0
 

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 19.3.0
+## 20.0.0-nullsafety.0
 
 * Generate null-safe code.
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 19.3.0
+version: 20.0.0-nullsafety.0
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 


### PR DESCRIPTION
Even though protoc_plugin code is not migrated to null safety, we
still need to bump major version to avoid surprises for
packages using protoc_plugin with `^19.0.0` version spec.

Also add dependency override to fix api_benchmark.