### PR TITLE
Allow dart protos to be sent through sendports (and therefore to other isolates)

### DIFF
--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+* Remove `PbMap.add` method which was deprecated in 0.13.3
+
 ## 1.1.0
 
 * Require at least Dart SDK 2.7.0 to enable usage of extension methods.

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -26,18 +26,17 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
   }
 }
 
-void _mergeFromCodedBufferReader(
-    _FieldSet fs, CodedBufferReader input, ExtensionRegistry registry) {
+void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
+    CodedBufferReader input, ExtensionRegistry registry) {
   assert(registry != null);
-
   while (true) {
     var tag = input.readTag();
     if (tag == 0) return;
     var wireType = tag & 0x7;
     var tagNumber = tag >> 3;
 
-    var fi = fs._nonExtensionInfo(tagNumber);
-    fi ??= registry.getExtension(fs._messageName, tagNumber);
+    var fi = fs._nonExtensionInfo(meta, tagNumber);
+    fi ??= registry.getExtension(meta.qualifiedMessageName, tagNumber);
 
     if (fi == null || !_wireTypeMatches(fi.type, wireType)) {
       if (!fs._ensureUnknownFields().mergeFieldFromBuffer(tag, input)) {
@@ -51,138 +50,141 @@ void _mergeFromCodedBufferReader(
     fieldType &= ~(PbFieldType._PACKED_BIT | PbFieldType._REQUIRED_BIT);
     switch (fieldType) {
       case PbFieldType._OPTIONAL_BOOL:
-        fs._setFieldUnchecked(fi, input.readBool());
+        fs._setFieldUnchecked(meta, fi, input.readBool());
         break;
       case PbFieldType._OPTIONAL_BYTES:
-        fs._setFieldUnchecked(fi, input.readBytes());
+        fs._setFieldUnchecked(meta, fi, input.readBytes());
         break;
       case PbFieldType._OPTIONAL_STRING:
-        fs._setFieldUnchecked(fi, input.readString());
+        fs._setFieldUnchecked(meta, fi, input.readString());
         break;
       case PbFieldType._OPTIONAL_FLOAT:
-        fs._setFieldUnchecked(fi, input.readFloat());
+        fs._setFieldUnchecked(meta, fi, input.readFloat());
         break;
       case PbFieldType._OPTIONAL_DOUBLE:
-        fs._setFieldUnchecked(fi, input.readDouble());
+        fs._setFieldUnchecked(meta, fi, input.readDouble());
         break;
       case PbFieldType._OPTIONAL_ENUM:
         var rawValue = input.readEnum();
-        var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
+        var value = meta._decodeEnum(tagNumber, registry, rawValue);
         if (value == null) {
           var unknown = fs._ensureUnknownFields();
           unknown.mergeVarintField(tagNumber, Int64(rawValue));
         } else {
-          fs._setFieldUnchecked(fi, value);
+          fs._setFieldUnchecked(meta, fi, value);
         }
         break;
       case PbFieldType._OPTIONAL_GROUP:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         var oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           subMessage.mergeFromMessage(oldValue);
         }
         input.readGroup(tagNumber, subMessage, registry);
-        fs._setFieldUnchecked(fi, subMessage);
+        fs._setFieldUnchecked(meta, fi, subMessage);
         break;
       case PbFieldType._OPTIONAL_INT32:
-        fs._setFieldUnchecked(fi, input.readInt32());
+        fs._setFieldUnchecked(meta, fi, input.readInt32());
         break;
       case PbFieldType._OPTIONAL_INT64:
-        fs._setFieldUnchecked(fi, input.readInt64());
+        fs._setFieldUnchecked(meta, fi, input.readInt64());
         break;
       case PbFieldType._OPTIONAL_SINT32:
-        fs._setFieldUnchecked(fi, input.readSint32());
+        fs._setFieldUnchecked(meta, fi, input.readSint32());
         break;
       case PbFieldType._OPTIONAL_SINT64:
-        fs._setFieldUnchecked(fi, input.readSint64());
+        fs._setFieldUnchecked(meta, fi, input.readSint64());
         break;
       case PbFieldType._OPTIONAL_UINT32:
-        fs._setFieldUnchecked(fi, input.readUint32());
+        fs._setFieldUnchecked(meta, fi, input.readUint32());
         break;
       case PbFieldType._OPTIONAL_UINT64:
-        fs._setFieldUnchecked(fi, input.readUint64());
+        fs._setFieldUnchecked(meta, fi, input.readUint64());
         break;
       case PbFieldType._OPTIONAL_FIXED32:
-        fs._setFieldUnchecked(fi, input.readFixed32());
+        fs._setFieldUnchecked(meta, fi, input.readFixed32());
         break;
       case PbFieldType._OPTIONAL_FIXED64:
-        fs._setFieldUnchecked(fi, input.readFixed64());
+        fs._setFieldUnchecked(meta, fi, input.readFixed64());
         break;
       case PbFieldType._OPTIONAL_SFIXED32:
-        fs._setFieldUnchecked(fi, input.readSfixed32());
+        fs._setFieldUnchecked(meta, fi, input.readSfixed32());
         break;
       case PbFieldType._OPTIONAL_SFIXED64:
-        fs._setFieldUnchecked(fi, input.readSfixed64());
+        fs._setFieldUnchecked(meta, fi, input.readSfixed64());
         break;
       case PbFieldType._OPTIONAL_MESSAGE:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         var oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           subMessage.mergeFromMessage(oldValue);
         }
         input.readMessage(subMessage, registry);
-        fs._setFieldUnchecked(fi, subMessage);
+        fs._setFieldUnchecked(meta, fi, subMessage);
         break;
       case PbFieldType._REPEATED_BOOL:
-        _readPackable(fs, input, wireType, fi, input.readBool);
+        _readPackable(meta, fs, input, wireType, fi, input.readBool);
         break;
       case PbFieldType._REPEATED_BYTES:
-        fs._ensureRepeatedField(fi).add(input.readBytes());
+        fs._ensureRepeatedField(meta, fi).add(input.readBytes());
         break;
       case PbFieldType._REPEATED_STRING:
-        fs._ensureRepeatedField(fi).add(input.readString());
+        fs._ensureRepeatedField(meta, fi).add(input.readString());
         break;
       case PbFieldType._REPEATED_FLOAT:
-        _readPackable(fs, input, wireType, fi, input.readFloat);
+        _readPackable(meta, fs, input, wireType, fi, input.readFloat);
         break;
       case PbFieldType._REPEATED_DOUBLE:
-        _readPackable(fs, input, wireType, fi, input.readDouble);
+        _readPackable(meta, fs, input, wireType, fi, input.readDouble);
         break;
       case PbFieldType._REPEATED_ENUM:
-        _readPackableToListEnum(fs, input, wireType, fi, tagNumber, registry);
+        _readPackableToListEnum(
+            meta, fs, input, wireType, fi, tagNumber, registry);
         break;
       case PbFieldType._REPEATED_GROUP:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
-        fs._ensureRepeatedField(fi).add(subMessage);
+        fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
       case PbFieldType._REPEATED_INT32:
-        _readPackable(fs, input, wireType, fi, input.readInt32);
+        _readPackable(meta, fs, input, wireType, fi, input.readInt32);
         break;
       case PbFieldType._REPEATED_INT64:
-        _readPackable(fs, input, wireType, fi, input.readInt64);
+        _readPackable(meta, fs, input, wireType, fi, input.readInt64);
         break;
       case PbFieldType._REPEATED_SINT32:
-        _readPackable(fs, input, wireType, fi, input.readSint32);
+        _readPackable(meta, fs, input, wireType, fi, input.readSint32);
         break;
       case PbFieldType._REPEATED_SINT64:
-        _readPackable(fs, input, wireType, fi, input.readSint64);
+        _readPackable(meta, fs, input, wireType, fi, input.readSint64);
         break;
       case PbFieldType._REPEATED_UINT32:
-        _readPackable(fs, input, wireType, fi, input.readUint32);
+        _readPackable(meta, fs, input, wireType, fi, input.readUint32);
         break;
       case PbFieldType._REPEATED_UINT64:
-        _readPackable(fs, input, wireType, fi, input.readUint64);
+        _readPackable(meta, fs, input, wireType, fi, input.readUint64);
         break;
       case PbFieldType._REPEATED_FIXED32:
-        _readPackable(fs, input, wireType, fi, input.readFixed32);
+        _readPackable(meta, fs, input, wireType, fi, input.readFixed32);
         break;
       case PbFieldType._REPEATED_FIXED64:
-        _readPackable(fs, input, wireType, fi, input.readFixed64);
+        _readPackable(meta, fs, input, wireType, fi, input.readFixed64);
         break;
       case PbFieldType._REPEATED_SFIXED32:
-        _readPackable(fs, input, wireType, fi, input.readSfixed32);
+        _readPackable(meta, fs, input, wireType, fi, input.readSfixed32);
         break;
       case PbFieldType._REPEATED_SFIXED64:
-        _readPackable(fs, input, wireType, fi, input.readSfixed64);
+        _readPackable(meta, fs, input, wireType, fi, input.readSfixed64);
         break;
       case PbFieldType._REPEATED_MESSAGE:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
-        fs._ensureRepeatedField(fi).add(subMessage);
+        fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
       case PbFieldType._MAP:
-        fs._ensureMapField(fi)._mergeEntry(input, registry);
+        final mapEntryMeta =
+            (meta.byIndex[fi.index] as MapFieldInfo).mapEntryBuilderInfo;
+        fs._ensureMapField(meta, fi)._mergeEntry(mapEntryMeta, input, registry);
         break;
       default:
         throw 'Unknown field type $fieldType';
@@ -190,17 +192,23 @@ void _mergeFromCodedBufferReader(
   }
 }
 
-void _readPackable(_FieldSet fs, CodedBufferReader input, int wireType,
-    FieldInfo fi, Function readFunc) {
+void _readPackable(BuilderInfo meta, _FieldSet fs, CodedBufferReader input,
+    int wireType, FieldInfo fi, Function readFunc) {
   void readToList(List list) => list.add(readFunc());
-  _readPackableToList(fs, input, wireType, fi, readToList);
+  _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
 
-void _readPackableToListEnum(_FieldSet fs, CodedBufferReader input,
-    int wireType, FieldInfo fi, int tagNumber, ExtensionRegistry registry) {
+void _readPackableToListEnum(
+    BuilderInfo meta,
+    _FieldSet fs,
+    CodedBufferReader input,
+    int wireType,
+    FieldInfo fi,
+    int tagNumber,
+    ExtensionRegistry registry) {
   void readToList(List list) {
     var rawValue = input.readEnum();
-    var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
+    var value = meta._decodeEnum(tagNumber, registry, rawValue);
     if (value == null) {
       var unknown = fs._ensureUnknownFields();
       unknown.mergeVarintField(tagNumber, Int64(rawValue));
@@ -209,12 +217,12 @@ void _readPackableToListEnum(_FieldSet fs, CodedBufferReader input,
     }
   }
 
-  _readPackableToList(fs, input, wireType, fi, readToList);
+  _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
 
-void _readPackableToList(_FieldSet fs, CodedBufferReader input, int wireType,
-    FieldInfo fi, Function readToList) {
-  var list = fs._ensureRepeatedField(fi);
+void _readPackableToList(BuilderInfo meta, _FieldSet fs,
+    CodedBufferReader input, int wireType, FieldInfo fi, Function readToList) {
+  var list = fs._ensureRepeatedField(meta, fi);
 
   if (wireType == WIRETYPE_LENGTH_DELIMITED) {
     // Packed.

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -182,8 +182,8 @@ void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
         fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
       case PbFieldType._MAP:
-        final mapEntryMeta =
-            (meta.byIndex[fi.index] as MapFieldInfo).mapEntryBuilderInfo;
+        final mapFieldInfo = fi as MapFieldInfo;
+        final mapEntryMeta = mapFieldInfo.mapEntryBuilderInfo;
         fs._ensureMapField(meta, fi)._mergeEntry(mapEntryMeta, input, registry);
         break;
       default:

--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -176,8 +176,8 @@ class FieldInfo<T> {
 
   /// Convenience method to thread this FieldInfo's reified type parameter to
   /// _FieldSet._ensureRepeatedField.
-  List<T> _ensureRepeatedField(_FieldSet fs) {
-    return fs._ensureRepeatedField<T>(this);
+  List<T> _ensureRepeatedField(BuilderInfo meta, _FieldSet fs) {
+    return fs._ensureRepeatedField<T>(meta, this);
   }
 
   @override
@@ -192,6 +192,9 @@ String _unCamelCase(String name) {
 }
 
 class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
+  static dynamic throwYouShouldNotCallThis() =>
+      throw 'you should not call this';
+
   final int keyFieldType;
   final int valueFieldType;
 
@@ -213,9 +216,7 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
       this.valueCreator,
       {String protoName})
       : super(name, tagNumber, index, type,
-            defaultOrMaker: () =>
-                PbMap<K, V>(keyFieldType, valueFieldType, mapEntryBuilderInfo),
-            protoName: protoName) {
+            defaultOrMaker: throwYouShouldNotCallThis, protoName: protoName) {
     assert(name != null);
     assert(tagNumber != null);
     assert(_isMapField(type));
@@ -225,8 +226,8 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>> {
   FieldInfo get valueFieldInfo =>
       mapEntryBuilderInfo.fieldInfo[PbMap._valueFieldNumber];
 
-  Map<K, V> _ensureMapField(_FieldSet fs) {
-    return fs._ensureMapField<K, V>(this);
+  Map<K, V> _ensureMapField(BuilderInfo meta, _FieldSet fs) {
+    return fs._ensureMapField<K, V>(meta, this);
   }
 
   Map<K, V> _createMapField(GeneratedMessage m) {

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -172,7 +172,7 @@ abstract class GeneratedMessage {
 
   void mergeFromCodedBufferReader(CodedBufferReader input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
-    final meta = _fieldSet._message.info_;
+    final meta = _fieldSet._meta;
     _mergeFromCodedBufferReader(meta, _fieldSet, input, extensionRegistry);
   }
 
@@ -187,7 +187,7 @@ abstract class GeneratedMessage {
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
     var codedInput = CodedBufferReader(input);
-    final meta = _fieldSet._message.info_;
+    final meta = _fieldSet._meta;
     _mergeFromCodedBufferReader(meta, _fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);
   }

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -171,8 +171,10 @@ abstract class GeneratedMessage {
       _writeToCodedBufferWriter(_fieldSet, output);
 
   void mergeFromCodedBufferReader(CodedBufferReader input,
-          [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) =>
-      _mergeFromCodedBufferReader(_fieldSet, input, extensionRegistry);
+      [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
+    final meta = _fieldSet._message.info_;
+    _mergeFromCodedBufferReader(meta, _fieldSet, input, extensionRegistry);
+  }
 
   /// Merges serialized protocol buffer data into this message.
   ///
@@ -185,7 +187,8 @@ abstract class GeneratedMessage {
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
     var codedInput = CodedBufferReader(input);
-    _mergeFromCodedBufferReader(_fieldSet, codedInput, extensionRegistry);
+    final meta = _fieldSet._message.info_;
+    _mergeFromCodedBufferReader(meta, _fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);
   }
 
@@ -339,8 +342,7 @@ abstract class GeneratedMessage {
 
   /// Creates a Map representing a map field.
   Map<K, V> createMapField<K, V>(int tagNumber, MapFieldInfo<K, V> fi) {
-    return PbMap<K, V>(
-        fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo);
+    return PbMap<K, V>(fi.keyFieldType, fi.valueFieldType);
   }
 
   /// Returns the value of a field, ignoring any defaults.
@@ -426,7 +428,7 @@ abstract class GeneratedMessage {
   List<T> $_getList<T>(int index) => _fieldSet._$getList<T>(index);
 
   /// For generated code only.
-  Map<K, V> $_getMap<K, V>(int index) => _fieldSet._$getMap<K, V>(index);
+  Map<K, V> $_getMap<K, V>(int index) => _fieldSet._$getMap<K, V>(this, index);
 
   /// For generated code only.
   bool $_getB(int index, bool defaultValue) =>

--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -12,19 +12,17 @@ class PbMap<K, V> extends MapBase<K, V> {
   static const int _valueFieldNumber = 2;
 
   final Map<K, V> _wrappedMap;
-  final BuilderInfo _entryBuilderInfo;
 
   bool _isReadonly = false;
-  _FieldSet _entryFieldSet() => _FieldSet(null, _entryBuilderInfo, null);
 
-  PbMap(this.keyFieldType, this.valueFieldType, this._entryBuilderInfo)
+  // The provided [info] will be ignored.
+  PbMap(this.keyFieldType, this.valueFieldType, [BuilderInfo info])
       : _wrappedMap = <K, V>{};
 
   PbMap.unmodifiable(PbMap other)
       : keyFieldType = other.keyFieldType,
         valueFieldType = other.valueFieldType,
         _wrappedMap = Map.unmodifiable(other._wrappedMap),
-        _entryBuilderInfo = other._entryBuilderInfo,
         _isReadonly = other._isReadonly;
 
   @override
@@ -93,18 +91,13 @@ class PbMap<K, V> extends MapBase<K, V> {
     return _wrappedMap.remove(key);
   }
 
-  @Deprecated('This function was not intended to be public. '
-      'It will be removed from the public api in next major version. ')
-  void add(CodedBufferReader input, [ExtensionRegistry registry]) {
-    _mergeEntry(input, registry);
-  }
-
-  void _mergeEntry(CodedBufferReader input, [ExtensionRegistry registry]) {
+  void _mergeEntry(BuilderInfo mapEntryMeta, CodedBufferReader input,
+      [ExtensionRegistry registry]) {
     var length = input.readInt32();
     var oldLimit = input._currentLimit;
     input._currentLimit = input._bufferPos + length;
-    var entryFieldSet = _entryFieldSet();
-    _mergeFromCodedBufferReader(entryFieldSet, input, registry);
+    final entryFieldSet = _FieldSet(null, mapEntryMeta, null);
+    _mergeFromCodedBufferReader(mapEntryMeta, entryFieldSet, input, registry);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;
     var key = entryFieldSet._$get<K>(0, null);

--- a/protobuf/lib/src/protobuf/proto3_json.dart
+++ b/protobuf/lib/src/protobuf/proto3_json.dart
@@ -81,8 +81,9 @@ Object _writeToProto3Json(_FieldSet fs, TypeRegistry typeRegistry) {
     }
   }
 
-  if (fs._meta.toProto3Json != null) {
-    return fs._meta.toProto3Json(fs._message, typeRegistry);
+  final meta = fs._meta;
+  if (meta.toProto3Json != null) {
+    return meta.toProto3Json(fs._message, typeRegistry);
   }
 
   var result = <String, dynamic>{};
@@ -319,14 +320,13 @@ void _mergeFromProto3Json(
       return;
     }
 
-    var info = fieldSet._meta;
-
-    final wellKnownConverter = info.fromProto3Json;
+    final meta = fieldSet._meta;
+    final wellKnownConverter = meta.fromProto3Json;
     if (wellKnownConverter != null) {
       wellKnownConverter(fieldSet._message, json, typeRegistry, context);
     } else {
       if (json is Map) {
-        var byName = info.byName;
+        final byName = meta.byName;
 
         json.forEach((key, value) {
           if (key is! String) {
@@ -353,7 +353,7 @@ void _mergeFromProto3Json(
           if (_isMapField(fieldInfo.type)) {
             if (value is Map) {
               MapFieldInfo mapFieldInfo = fieldInfo;
-              Map fieldValues = fieldSet._ensureMapField(fieldInfo);
+              Map fieldValues = fieldSet._ensureMapField(meta, fieldInfo);
               value.forEach((subKey, subValue) {
                 if (subKey is! String) {
                   throw context.parseException('Expected a String key', subKey);
@@ -372,9 +372,9 @@ void _mergeFromProto3Json(
           } else if (_isRepeated(fieldInfo.type)) {
             if (value == null) {
               // `null` is accepted as the empty list [].
-              fieldSet._ensureRepeatedField(fieldInfo);
+              fieldSet._ensureRepeatedField(meta, fieldInfo);
             } else if (value is List) {
-              var values = fieldSet._ensureRepeatedField(fieldInfo);
+              var values = fieldSet._ensureRepeatedField(meta, fieldInfo);
               for (var i = 0; i < value.length; i++) {
                 final entry = value[i];
                 context.addListIndex(i);
@@ -391,13 +391,13 @@ void _mergeFromProto3Json(
             GeneratedMessage original = fieldSet._values[fieldInfo.index];
             if (original == null) {
               fieldSet._setNonExtensionFieldUnchecked(
-                  fieldInfo, parsedSubMessage);
+                  meta, fieldInfo, parsedSubMessage);
             } else {
               original.mergeFromMessage(parsedSubMessage);
             }
           } else {
             fieldSet._setFieldUnchecked(
-                fieldInfo, convertProto3JsonValue(value, fieldInfo));
+                meta, fieldInfo, convertProto3JsonValue(value, fieldInfo));
           }
           context.popIndex();
         });

--- a/protoc_plugin/test/send_protos_via_sendports_test.dart
+++ b/protoc_plugin/test/send_protos_via_sendports_test.dart
@@ -1,0 +1,59 @@
+#!/usr/bin/env dart
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:test/test.dart';
+
+import '../out/protos/foo.pb.dart';
+import '../out/protos/map_field.pb.dart' as map;
+
+Future<T> sendReceive<T>(T object) async {
+  final rp = ReceivePort();
+  rp.sendPort.send(object);
+  return (await rp.first) as T;
+}
+
+Future main() async {
+  test('Normal proto can be transferred via ports', () async {
+    final object = Outer()
+      ..inner = (Inner()..value = 'pip')
+      ..inners.add(Inner()..value = 'pop');
+
+    final clone = await sendReceive(object);
+
+    // Ensure the clone is actually containing the same data.
+    expect(clone, equals(object));
+    expect(clone.toString(), equals(object.toString()));
+    expect(clone.toDebugString(), equals(object.toDebugString()));
+    expect(clone.writeToBuffer(), equals(object.writeToBuffer()));
+
+    // Ensure the actual objects got transitively cloned, but the metadata in
+    // the `_info_` did not get cloned.
+    expect(!identical(object, clone), true);
+    expect(!identical(object.inner, clone.inner), true);
+    expect(identical(object.info_, clone.info_), true);
+  }, onPlatform: {'js': Skip('dart:isolate only works on Dart VM')});
+
+  test('Map-using proto can be transferred via ports', () async {
+    final object = map.TestMap()
+      ..int32ToMessageField[42] = (map.TestMap_MessageValue()
+        ..value = 1
+        ..secondValue = 2);
+
+    final clone = await sendReceive(object);
+
+    // Ensure the clone is actually containing the same data.
+    expect(clone, equals(object));
+    expect(clone.toString(), equals(object.toString()));
+    expect(clone.toDebugString(), equals(object.toDebugString()));
+    expect(clone.writeToBuffer(), equals(object.writeToBuffer()));
+
+    // Ensure the actual objects got transitively cloned, but the metadata in
+    // the `_info_` did not get cloned.
+    expect(!identical(object, clone), true);
+    expect(identical(object.info_, clone.info_), true);
+  }, onPlatform: {'js': Skip('dart:isolate only works on Dart VM')});
+}


### PR DESCRIPTION
Decoded protos in Dart are represented in memory as instances of
`GeneratedMessage` subclasses. The `GeneratedMessage` stores the field
state in a `_FieldSet` and `UnknownFieldSet`.

The `_FieldSet._meta` field points to a `BuilderInfo` object, which
represents the metadata of the proto message.

Having this reference to `BuilderInfo` makes it hard to send dart
protos to other isolates, because

  a) `BuilderInfo` hangs on to non-static closures, which cannot
      be sent to to other isolates atm

  b) Sending a transitive copy would copy the `BuilderInfo` object (and
     it's transitive closure). That can cause big waste of memory
     since an isolate would have this metadata possibly many times.

To avoid these two issues, this CL does the following:

  * We replace `_FieldSet._meta` with a getter that accesses the
    `BuilderInfo` via the `_FieldSet._message.info_` getter. This getter
    is implemented in `GeneratedMessage` subclasses and reads from a
    static field.

    => We effectively replace a load of the `_meta` field with load +
       interface call + static field load.

  * To avoid performance regressions we avoid accessing the new
    `_FieldSet._meta` getter in the hot decoding loops. Instead we
    obtain this metadata once and pass it down to various methods that
    are part of decoding.

  * For similar reasons, we remove the `PbMap._entryBuilderInfo`
    field - which also refers to a `BuilderInfo`. Instead we obtain the
    neccessary map-specific `BuilderInfo` in the main decoder loop.

This CL has to remove the 2 year long deprecated `PbMap.add()` function.

Closes https://github.com/dart-lang/protobuf/issues/167