### PR TITLE
Restore possibility to use reflective API to create default field values using getField()

### DIFF
--- a/protobuf/lib/src/protobuf/field_info.dart
+++ b/protobuf/lib/src/protobuf/field_info.dart
@@ -192,9 +192,6 @@ String _unCamelCase(String name) {
 }
 
 class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>?> {
-  static dynamic throwYouShouldNotCallThis() =>
-      throw StateError('You should not call this.');
-
   final int? keyFieldType;
   final int? valueFieldType;
 
@@ -216,7 +213,7 @@ class MapFieldInfo<K, V> extends FieldInfo<PbMap<K, V>?> {
       this.valueCreator,
       {String? protoName})
       : super(name, tagNumber, index, type,
-            defaultOrMaker: () => throwYouShouldNotCallThis,
+            defaultOrMaker: () => PbMap<K, V>(keyFieldType, valueFieldType),
             protoName: protoName) {
     ArgumentError.checkNotNull(name, 'name');
     ArgumentError.checkNotNull(tagNumber, 'tagNumber');

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -331,4 +331,14 @@ void main() {
     testValues(TestMap.fromBuffer(testMap.writeToBuffer()));
     testValues(TestMap.fromJson(testMap.writeToJson()));
   });
+
+  test('Calling getField on map fields using reflective API works.', () {
+    final testMap = TestMap();
+    final mapFieldInfo = testMap.info_.fieldInfo.values
+        .where((fieldInfo) =>
+            fieldInfo is MapFieldInfo && fieldInfo.name == 'int32ToBytesField')
+        .single;
+    final value = testMap.getField(mapFieldInfo.tagNumber);
+    expect(value is Map<int, List<int>>, true);
+  });
 }


### PR DESCRIPTION
We do not actually have to prevent/throw when trying to create a default
value for a PbMap field.

Initially when working on removing BuilderInfo references it was
necessary to remove default creation of map fields due to not
having the [BuilderInfo] object for the map which was required for the
PbMap constructor.

Though a later iteration of that CL removed the 3rd parameter to PbMap
(or rather made that parameter optional and ignored):

```diff
  -  PbMap(this.keyFieldType, this.valueFieldType, this._entryBuilderInfo)
  +  // The provided [info] will be ignored.
  +  PbMap(this.keyFieldType, this.valueFieldType, [BuilderInfo? info])
```

So we can restore `defaultOrMake()`, which fixes the reflective API usage.