### PR TITLE
Use null-safe bootstrap protos

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -279,16 +279,16 @@ jobs:
       - job_003
       - job_004
   job_009:
-    name: "format_analyze; linux; PKGS: api_benchmark, query_benchmark; `./../tool/setup.sh`, `./compile_protos.sh`, `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings .`"
+    name: "format_analyze; linux; PKG: api_benchmark; `./../tool/setup.sh`, `./compile_protos.sh`, `dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-warnings .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark-query_benchmark;commands:command_0-command_1-dartfmt-dartanalyzer_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark;commands:command_0-command_1-dartfmt-dartanalyzer_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark-query_benchmark
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark
             os:ubuntu-latest;pub-cache-hosted;dart:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -318,11 +318,43 @@ jobs:
         if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: api_benchmark
         run: dartanalyzer --fatal-warnings .
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+      - job_005
+      - job_006
+      - job_007
+      - job_008
+  job_010:
+    name: "format_analyze; linux; PKG: query_benchmark; `dartfmt -n --set-exit-if-changed .`, `./../tool/setup.sh`, `./compile_protos.sh`, `dartanalyzer --fatal-warnings .`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:query_benchmark;commands:dartfmt-command_0-command_1-dartanalyzer_0"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:query_benchmark
+            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v0.3
+        with:
+          sdk: dev
+      - id: checkout
+        uses: actions/checkout@v2
       - id: query_benchmark_pub_upgrade
         name: "query_benchmark; pub upgrade --no-precompile"
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: query_benchmark
         run: pub upgrade --no-precompile
+      - name: "query_benchmark; dartfmt -n --set-exit-if-changed ."
+        if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
+        working-directory: query_benchmark
+        run: dartfmt -n --set-exit-if-changed .
       - name: query_benchmark; ./../tool/setup.sh
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark
@@ -331,10 +363,6 @@ jobs:
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark
         run: ./compile_protos.sh
-      - name: "query_benchmark; dartfmt -n --set-exit-if-changed ."
-        if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
-        working-directory: query_benchmark
-        run: dartfmt -n --set-exit-if-changed .
       - name: "query_benchmark; dartanalyzer --fatal-warnings ."
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Protobuf support for Dart
 
+[![CI status](https://github.com/dart-lang/protobuf/workflows/Dart%20CI/badge.svg?branch=null_safety)](https://github.com/dart-lang/protobuf/actions?query=workflow%3A%22Dart%22+branch%3Anull_safety)
+[![pub package](https://img.shields.io/pub/v/protobuf.svg)](https://pub.dev/packages/protobuf)
+
 [Protocol Buffers](https://developers.google.com/protocol-buffers) (protobuf)
 are Google's language-neutral, platform-neutral, extensible mechanism for
 serializing structured data.

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -9,7 +9,6 @@ github:
       - cron: "0 0 * * 0"
 
 merge_stages:
-- format_analyze
 - format
 - analyze
 - run_tests

--- a/protoc_plugin/bin/protoc_plugin.dart
+++ b/protoc_plugin/bin/protoc_plugin.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 import 'package:protoc_plugin/protoc.dart';
 

--- a/protoc_plugin/bin/protoc_plugin_bazel.dart
+++ b/protoc_plugin/bin/protoc_plugin_bazel.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 import 'package:protoc_plugin/bazel.dart';
 import 'package:protoc_plugin/protoc.dart';

--- a/protoc_plugin/lib/base_type.dart
+++ b/protoc_plugin/lib/base_type.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Represents the base type of a particular field in a proto definition.

--- a/protoc_plugin/lib/bazel.dart
+++ b/protoc_plugin/lib/bazel.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 /// Bazel support for protoc_plugin.
 library protoc_bazel;
 

--- a/protoc_plugin/lib/client_generator.dart
+++ b/protoc_plugin/lib/client_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ClientApiGenerator {

--- a/protoc_plugin/lib/code_generator.dart
+++ b/protoc_plugin/lib/code_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 abstract class ProtobufContainer {

--- a/protoc_plugin/lib/const_generator.dart
+++ b/protoc_plugin/lib/const_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc.const_generator;
 
 import "indenting_writer.dart";

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class EnumAlias {

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ExtensionGenerator {

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 final _dartIdentifier = RegExp(r'^\w+$');

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class GrpcServiceGenerator {

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc.indenting_writer;
 
 import 'src/descriptor.pb.dart';

--- a/protoc_plugin/lib/linker.dart
+++ b/protoc_plugin/lib/linker.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Resolves all cross-references in a set of proto files.

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Generates the Dart enum corresponding to a oneof declaration.

--- a/protoc_plugin/lib/mixins.dart
+++ b/protoc_plugin/lib/mixins.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 /// Provides metadata about mixins to dart-protoc-plugin.
 /// (Experimental API; subject to change.)
 import 'indenting_writer.dart';

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:math' as math;
 
 import 'package:protobuf/meta.dart';

--- a/protoc_plugin/lib/options.dart
+++ b/protoc_plugin/lib/options.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 typedef OnError = void Function(String details);

--- a/protoc_plugin/lib/output_config.dart
+++ b/protoc_plugin/lib/output_config.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Configures where output of the protoc compiler should be placed and how to

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ProtobufField {

--- a/protoc_plugin/lib/protoc.dart
+++ b/protoc_plugin/lib/protoc.dart
@@ -1,3 +1,5 @@
+// @dart=2.11
+
 library protoc;
 
 import 'dart:convert';

--- a/protoc_plugin/lib/service_generator.dart
+++ b/protoc_plugin/lib/service_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ServiceGenerator {

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: dart_options.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -38,9 +38,9 @@ class DartMixin extends $pb.GeneratedMessage {
 
   DartMixin._() : super();
   factory DartMixin({
-    $core.String name,
-    $core.String importFrom,
-    $core.String parent,
+    $core.String? name,
+    $core.String? importFrom,
+    $core.String? parent,
   }) {
     final _result = create();
     if (name != null) {
@@ -68,8 +68,8 @@ class DartMixin extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DartMixin copyWith(void Function(DartMixin) updates) =>
-      super.copyWith((message) =>
-          updates(message as DartMixin)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DartMixin))
+          as DartMixin; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DartMixin create() => DartMixin._();
@@ -78,7 +78,7 @@ class DartMixin extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DartMixin getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DartMixin>(create);
-  static DartMixin _defaultInstance;
+  static DartMixin? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -138,7 +138,7 @@ class Imports extends $pb.GeneratedMessage {
 
   Imports._() : super();
   factory Imports({
-    $core.Iterable<DartMixin> mixins,
+    $core.Iterable<DartMixin>? mixins,
   }) {
     final _result = create();
     if (mixins != null) {
@@ -160,8 +160,8 @@ class Imports extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Imports copyWith(void Function(Imports) updates) =>
-      super.copyWith((message) =>
-          updates(message as Imports)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Imports))
+          as Imports; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Imports create() => Imports._();
@@ -170,7 +170,7 @@ class Imports extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Imports getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Imports>(create);
-  static Imports _defaultInstance;
+  static Imports? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<DartMixin> get mixins => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -34,7 +34,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
 
   FileDescriptorSet._() : super();
   factory FileDescriptorSet({
-    $core.Iterable<FileDescriptorProto> file,
+    $core.Iterable<FileDescriptorProto>? file,
   }) {
     final _result = create();
     if (file != null) {
@@ -56,8 +56,8 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileDescriptorSet copyWith(void Function(FileDescriptorSet) updates) =>
-      super.copyWith((message) => updates(
-          message as FileDescriptorSet)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileDescriptorSet))
+          as FileDescriptorSet; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet create() => FileDescriptorSet._();
@@ -67,7 +67,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorSet>(create);
-  static FileDescriptorSet _defaultInstance;
+  static FileDescriptorSet? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<FileDescriptorProto> get file => $_getList(0);
@@ -110,18 +110,18 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
   FileDescriptorProto._() : super();
   factory FileDescriptorProto({
-    $core.String name,
-    $core.String package,
-    $core.Iterable<$core.String> dependency,
-    $core.Iterable<DescriptorProto> messageType,
-    $core.Iterable<EnumDescriptorProto> enumType,
-    $core.Iterable<ServiceDescriptorProto> service,
-    $core.Iterable<FieldDescriptorProto> extension,
-    FileOptions options,
-    SourceCodeInfo sourceCodeInfo,
-    $core.Iterable<$core.int> publicDependency,
-    $core.Iterable<$core.int> weakDependency,
-    $core.String syntax,
+    $core.String? name,
+    $core.String? package,
+    $core.Iterable<$core.String>? dependency,
+    $core.Iterable<DescriptorProto>? messageType,
+    $core.Iterable<EnumDescriptorProto>? enumType,
+    $core.Iterable<ServiceDescriptorProto>? service,
+    $core.Iterable<FieldDescriptorProto>? extension,
+    FileOptions? options,
+    SourceCodeInfo? sourceCodeInfo,
+    $core.Iterable<$core.int>? publicDependency,
+    $core.Iterable<$core.int>? weakDependency,
+    $core.String? syntax,
   }) {
     final _result = create();
     if (name != null) {
@@ -176,8 +176,8 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileDescriptorProto copyWith(void Function(FileDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as FileDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileDescriptorProto))
+          as FileDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto create() => FileDescriptorProto._();
@@ -187,7 +187,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorProto>(create);
-  static FileDescriptorProto _defaultInstance;
+  static FileDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -303,9 +303,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
 
   DescriptorProto_ExtensionRange._() : super();
   factory DescriptorProto_ExtensionRange({
-    $core.int start,
-    $core.int end,
-    ExtensionRangeOptions options,
+    $core.int? start,
+    $core.int? end,
+    ExtensionRangeOptions? options,
   }) {
     final _result = create();
     if (start != null) {
@@ -335,8 +335,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   DescriptorProto_ExtensionRange copyWith(
           void Function(DescriptorProto_ExtensionRange) updates) =>
-      super.copyWith((message) => updates(message
-          as DescriptorProto_ExtensionRange)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as DescriptorProto_ExtensionRange))
+          as DescriptorProto_ExtensionRange; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange create() =>
@@ -347,7 +348,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ExtensionRange>(create);
-  static DescriptorProto_ExtensionRange _defaultInstance;
+  static DescriptorProto_ExtensionRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -414,8 +415,8 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
 
   DescriptorProto_ReservedRange._() : super();
   factory DescriptorProto_ReservedRange({
-    $core.int start,
-    $core.int end,
+    $core.int? start,
+    $core.int? end,
   }) {
     final _result = create();
     if (start != null) {
@@ -442,8 +443,9 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   DescriptorProto_ReservedRange copyWith(
           void Function(DescriptorProto_ReservedRange) updates) =>
-      super.copyWith((message) => updates(message
-          as DescriptorProto_ReservedRange)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as DescriptorProto_ReservedRange))
+          as DescriptorProto_ReservedRange; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange create() =>
@@ -454,7 +456,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ReservedRange>(create);
-  static DescriptorProto_ReservedRange _defaultInstance;
+  static DescriptorProto_ReservedRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -511,16 +513,16 @@ class DescriptorProto extends $pb.GeneratedMessage {
 
   DescriptorProto._() : super();
   factory DescriptorProto({
-    $core.String name,
-    $core.Iterable<FieldDescriptorProto> field,
-    $core.Iterable<DescriptorProto> nestedType,
-    $core.Iterable<EnumDescriptorProto> enumType,
-    $core.Iterable<DescriptorProto_ExtensionRange> extensionRange,
-    $core.Iterable<FieldDescriptorProto> extension,
-    MessageOptions options,
-    $core.Iterable<OneofDescriptorProto> oneofDecl,
-    $core.Iterable<DescriptorProto_ReservedRange> reservedRange,
-    $core.Iterable<$core.String> reservedName,
+    $core.String? name,
+    $core.Iterable<FieldDescriptorProto>? field,
+    $core.Iterable<DescriptorProto>? nestedType,
+    $core.Iterable<EnumDescriptorProto>? enumType,
+    $core.Iterable<DescriptorProto_ExtensionRange>? extensionRange,
+    $core.Iterable<FieldDescriptorProto>? extension,
+    MessageOptions? options,
+    $core.Iterable<OneofDescriptorProto>? oneofDecl,
+    $core.Iterable<DescriptorProto_ReservedRange>? reservedRange,
+    $core.Iterable<$core.String>? reservedName,
   }) {
     final _result = create();
     if (name != null) {
@@ -569,8 +571,8 @@ class DescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   DescriptorProto copyWith(void Function(DescriptorProto) updates) =>
-      super.copyWith((message) =>
-          updates(message as DescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as DescriptorProto))
+          as DescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DescriptorProto create() => DescriptorProto._();
@@ -580,7 +582,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto>(create);
-  static DescriptorProto _defaultInstance;
+  static DescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -654,7 +656,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
 
   ExtensionRangeOptions._() : super();
   factory ExtensionRangeOptions({
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (uninterpretedOption != null) {
@@ -678,8 +680,8 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ExtensionRangeOptions copyWith(
           void Function(ExtensionRangeOptions) updates) =>
-      super.copyWith((message) => updates(
-          message as ExtensionRangeOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ExtensionRangeOptions))
+          as ExtensionRangeOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ExtensionRangeOptions create() => ExtensionRangeOptions._();
@@ -689,7 +691,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ExtensionRangeOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ExtensionRangeOptions>(create);
-  static ExtensionRangeOptions _defaultInstance;
+  static ExtensionRangeOptions? _defaultInstance;
 
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
@@ -737,17 +739,17 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
 
   FieldDescriptorProto._() : super();
   factory FieldDescriptorProto({
-    $core.String name,
-    $core.String extendee,
-    $core.int number,
-    FieldDescriptorProto_Label label,
-    FieldDescriptorProto_Type type,
-    $core.String typeName,
-    $core.String defaultValue,
-    FieldOptions options,
-    $core.int oneofIndex,
-    $core.String jsonName,
-    $core.bool proto3Optional,
+    $core.String? name,
+    $core.String? extendee,
+    $core.int? number,
+    FieldDescriptorProto_Label? label,
+    FieldDescriptorProto_Type? type,
+    $core.String? typeName,
+    $core.String? defaultValue,
+    FieldOptions? options,
+    $core.int? oneofIndex,
+    $core.String? jsonName,
+    $core.bool? proto3Optional,
   }) {
     final _result = create();
     if (name != null) {
@@ -800,8 +802,8 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FieldDescriptorProto copyWith(void Function(FieldDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as FieldDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FieldDescriptorProto))
+          as FieldDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto create() => FieldDescriptorProto._();
@@ -811,7 +813,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldDescriptorProto>(create);
-  static FieldDescriptorProto _defaultInstance;
+  static FieldDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -972,8 +974,8 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
 
   OneofDescriptorProto._() : super();
   factory OneofDescriptorProto({
-    $core.String name,
-    OneofOptions options,
+    $core.String? name,
+    OneofOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -999,8 +1001,8 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   OneofDescriptorProto copyWith(void Function(OneofDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as OneofDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as OneofDescriptorProto))
+          as OneofDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto create() => OneofDescriptorProto._();
@@ -1010,7 +1012,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofDescriptorProto>(create);
-  static OneofDescriptorProto _defaultInstance;
+  static OneofDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1065,8 +1067,8 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
 
   EnumDescriptorProto_EnumReservedRange._() : super();
   factory EnumDescriptorProto_EnumReservedRange({
-    $core.int start,
-    $core.int end,
+    $core.int? start,
+    $core.int? end,
   }) {
     final _result = create();
     if (start != null) {
@@ -1094,8 +1096,9 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumDescriptorProto_EnumReservedRange copyWith(
           void Function(EnumDescriptorProto_EnumReservedRange) updates) =>
-      super.copyWith((message) => updates(message
-          as EnumDescriptorProto_EnumReservedRange)); // ignore: deprecated_member_use
+      super.copyWith((message) =>
+              updates(message as EnumDescriptorProto_EnumReservedRange))
+          as EnumDescriptorProto_EnumReservedRange; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto_EnumReservedRange create() =>
@@ -1107,7 +1110,7 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
   static EnumDescriptorProto_EnumReservedRange getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
           EnumDescriptorProto_EnumReservedRange>(create);
-  static EnumDescriptorProto_EnumReservedRange _defaultInstance;
+  static EnumDescriptorProto_EnumReservedRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -1161,11 +1164,11 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
 
   EnumDescriptorProto._() : super();
   factory EnumDescriptorProto({
-    $core.String name,
-    $core.Iterable<EnumValueDescriptorProto> value,
-    EnumOptions options,
-    $core.Iterable<EnumDescriptorProto_EnumReservedRange> reservedRange,
-    $core.Iterable<$core.String> reservedName,
+    $core.String? name,
+    $core.Iterable<EnumValueDescriptorProto>? value,
+    EnumOptions? options,
+    $core.Iterable<EnumDescriptorProto_EnumReservedRange>? reservedRange,
+    $core.Iterable<$core.String>? reservedName,
   }) {
     final _result = create();
     if (name != null) {
@@ -1199,8 +1202,8 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumDescriptorProto copyWith(void Function(EnumDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as EnumDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumDescriptorProto))
+          as EnumDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto create() => EnumDescriptorProto._();
@@ -1210,7 +1213,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumDescriptorProto>(create);
-  static EnumDescriptorProto _defaultInstance;
+  static EnumDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1276,9 +1279,9 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
 
   EnumValueDescriptorProto._() : super();
   factory EnumValueDescriptorProto({
-    $core.String name,
-    $core.int number,
-    EnumValueOptions options,
+    $core.String? name,
+    $core.int? number,
+    EnumValueOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -1308,8 +1311,8 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   EnumValueDescriptorProto copyWith(
           void Function(EnumValueDescriptorProto) updates) =>
-      super.copyWith((message) => updates(message
-          as EnumValueDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumValueDescriptorProto))
+          as EnumValueDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto create() => EnumValueDescriptorProto._();
@@ -1319,7 +1322,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueDescriptorProto>(create);
-  static EnumValueDescriptorProto _defaultInstance;
+  static EnumValueDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1384,9 +1387,9 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
 
   ServiceDescriptorProto._() : super();
   factory ServiceDescriptorProto({
-    $core.String name,
-    $core.Iterable<MethodDescriptorProto> method,
-    ServiceOptions options,
+    $core.String? name,
+    $core.Iterable<MethodDescriptorProto>? method,
+    ServiceOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -1416,8 +1419,8 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   ServiceDescriptorProto copyWith(
           void Function(ServiceDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as ServiceDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ServiceDescriptorProto))
+          as ServiceDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto create() => ServiceDescriptorProto._();
@@ -1427,7 +1430,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceDescriptorProto>(create);
-  static ServiceDescriptorProto _defaultInstance;
+  static ServiceDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1492,12 +1495,12 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
 
   MethodDescriptorProto._() : super();
   factory MethodDescriptorProto({
-    $core.String name,
-    $core.String inputType,
-    $core.String outputType,
-    MethodOptions options,
-    $core.bool clientStreaming,
-    $core.bool serverStreaming,
+    $core.String? name,
+    $core.String? inputType,
+    $core.String? outputType,
+    MethodOptions? options,
+    $core.bool? clientStreaming,
+    $core.bool? serverStreaming,
   }) {
     final _result = create();
     if (name != null) {
@@ -1536,8 +1539,8 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   MethodDescriptorProto copyWith(
           void Function(MethodDescriptorProto) updates) =>
-      super.copyWith((message) => updates(
-          message as MethodDescriptorProto)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MethodDescriptorProto))
+          as MethodDescriptorProto; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto create() => MethodDescriptorProto._();
@@ -1547,7 +1550,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodDescriptorProto>(create);
-  static MethodDescriptorProto _defaultInstance;
+  static MethodDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1675,28 +1678,28 @@ class FileOptions extends $pb.GeneratedMessage {
 
   FileOptions._() : super();
   factory FileOptions({
-    $core.String javaPackage,
-    $core.String javaOuterClassname,
-    FileOptions_OptimizeMode optimizeFor,
-    $core.bool javaMultipleFiles,
-    $core.String goPackage,
-    $core.bool ccGenericServices,
-    $core.bool javaGenericServices,
-    $core.bool pyGenericServices,
+    $core.String? javaPackage,
+    $core.String? javaOuterClassname,
+    FileOptions_OptimizeMode? optimizeFor,
+    $core.bool? javaMultipleFiles,
+    $core.String? goPackage,
+    $core.bool? ccGenericServices,
+    $core.bool? javaGenericServices,
+    $core.bool? pyGenericServices,
     @$core.Deprecated('This field is deprecated.')
-        $core.bool javaGenerateEqualsAndHash,
-    $core.bool deprecated,
-    $core.bool javaStringCheckUtf8,
-    $core.bool ccEnableArenas,
-    $core.String objcClassPrefix,
-    $core.String csharpNamespace,
-    $core.String swiftPrefix,
-    $core.String phpClassPrefix,
-    $core.String phpNamespace,
-    $core.bool phpGenericServices,
-    $core.String phpMetadataNamespace,
-    $core.String rubyPackage,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+        $core.bool? javaGenerateEqualsAndHash,
+    $core.bool? deprecated,
+    $core.bool? javaStringCheckUtf8,
+    $core.bool? ccEnableArenas,
+    $core.String? objcClassPrefix,
+    $core.String? csharpNamespace,
+    $core.String? swiftPrefix,
+    $core.String? phpClassPrefix,
+    $core.String? phpNamespace,
+    $core.bool? phpGenericServices,
+    $core.String? phpMetadataNamespace,
+    $core.String? rubyPackage,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (javaPackage != null) {
@@ -1779,8 +1782,8 @@ class FileOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FileOptions copyWith(void Function(FileOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as FileOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FileOptions))
+          as FileOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FileOptions create() => FileOptions._();
@@ -1789,7 +1792,7 @@ class FileOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileOptions>(create);
-  static FileOptions _defaultInstance;
+  static FileOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get javaPackage => $_getSZ(0);
@@ -2071,11 +2074,11 @@ class MessageOptions extends $pb.GeneratedMessage {
 
   MessageOptions._() : super();
   factory MessageOptions({
-    $core.bool messageSetWireFormat,
-    $core.bool noStandardDescriptorAccessor,
-    $core.bool deprecated,
-    $core.bool mapEntry,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? messageSetWireFormat,
+    $core.bool? noStandardDescriptorAccessor,
+    $core.bool? deprecated,
+    $core.bool? mapEntry,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (messageSetWireFormat != null) {
@@ -2109,8 +2112,8 @@ class MessageOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   MessageOptions copyWith(void Function(MessageOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as MessageOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MessageOptions))
+          as MessageOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MessageOptions create() => MessageOptions._();
@@ -2120,7 +2123,7 @@ class MessageOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MessageOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MessageOptions>(create);
-  static MessageOptions _defaultInstance;
+  static MessageOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get messageSetWireFormat => $_getBF(0);
@@ -2204,13 +2207,13 @@ class FieldOptions extends $pb.GeneratedMessage {
 
   FieldOptions._() : super();
   factory FieldOptions({
-    FieldOptions_CType ctype,
-    $core.bool packed,
-    $core.bool deprecated,
-    $core.bool lazy,
-    FieldOptions_JSType jstype,
-    $core.bool weak,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    FieldOptions_CType? ctype,
+    $core.bool? packed,
+    $core.bool? deprecated,
+    $core.bool? lazy,
+    FieldOptions_JSType? jstype,
+    $core.bool? weak,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (ctype != null) {
@@ -2250,8 +2253,8 @@ class FieldOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   FieldOptions copyWith(void Function(FieldOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as FieldOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as FieldOptions))
+          as FieldOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FieldOptions create() => FieldOptions._();
@@ -2261,7 +2264,7 @@ class FieldOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldOptions>(create);
-  static FieldOptions _defaultInstance;
+  static FieldOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   FieldOptions_CType get ctype => $_getN(0);
@@ -2360,7 +2363,7 @@ class OneofOptions extends $pb.GeneratedMessage {
 
   OneofOptions._() : super();
   factory OneofOptions({
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (uninterpretedOption != null) {
@@ -2382,8 +2385,8 @@ class OneofOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   OneofOptions copyWith(void Function(OneofOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as OneofOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as OneofOptions))
+          as OneofOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static OneofOptions create() => OneofOptions._();
@@ -2393,7 +2396,7 @@ class OneofOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofOptions>(create);
-  static OneofOptions _defaultInstance;
+  static OneofOptions? _defaultInstance;
 
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
@@ -2430,9 +2433,9 @@ class EnumOptions extends $pb.GeneratedMessage {
 
   EnumOptions._() : super();
   factory EnumOptions({
-    $core.bool allowAlias,
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? allowAlias,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (allowAlias != null) {
@@ -2460,8 +2463,8 @@ class EnumOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumOptions copyWith(void Function(EnumOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as EnumOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumOptions))
+          as EnumOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumOptions create() => EnumOptions._();
@@ -2470,7 +2473,7 @@ class EnumOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumOptions>(create);
-  static EnumOptions _defaultInstance;
+  static EnumOptions? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.bool get allowAlias => $_getBF(0);
@@ -2526,8 +2529,8 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 
   EnumValueOptions._() : super();
   factory EnumValueOptions({
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -2552,8 +2555,8 @@ class EnumValueOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   EnumValueOptions copyWith(void Function(EnumValueOptions) updates) =>
-      super.copyWith((message) => updates(
-          message as EnumValueOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as EnumValueOptions))
+          as EnumValueOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions create() => EnumValueOptions._();
@@ -2563,7 +2566,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueOptions>(create);
-  static EnumValueOptions _defaultInstance;
+  static EnumValueOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deprecated => $_getBF(0);
@@ -2607,8 +2610,8 @@ class ServiceOptions extends $pb.GeneratedMessage {
 
   ServiceOptions._() : super();
   factory ServiceOptions({
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -2633,8 +2636,8 @@ class ServiceOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   ServiceOptions copyWith(void Function(ServiceOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as ServiceOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as ServiceOptions))
+          as ServiceOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceOptions create() => ServiceOptions._();
@@ -2644,7 +2647,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceOptions>(create);
-  static ServiceOptions _defaultInstance;
+  static ServiceOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -2691,9 +2694,9 @@ class MethodOptions extends $pb.GeneratedMessage {
 
   MethodOptions._() : super();
   factory MethodOptions({
-    $core.bool deprecated,
-    MethodOptions_IdempotencyLevel idempotencyLevel,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    MethodOptions_IdempotencyLevel? idempotencyLevel,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -2721,8 +2724,8 @@ class MethodOptions extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   MethodOptions copyWith(void Function(MethodOptions) updates) =>
-      super.copyWith((message) =>
-          updates(message as MethodOptions)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as MethodOptions))
+          as MethodOptions; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static MethodOptions create() => MethodOptions._();
@@ -2732,7 +2735,7 @@ class MethodOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodOptions>(create);
-  static MethodOptions _defaultInstance;
+  static MethodOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -2786,8 +2789,8 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
 
   UninterpretedOption_NamePart._() : super();
   factory UninterpretedOption_NamePart({
-    $core.String namePart,
-    $core.bool isExtension,
+    $core.String? namePart,
+    $core.bool? isExtension,
   }) {
     final _result = create();
     if (namePart != null) {
@@ -2814,8 +2817,9 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   UninterpretedOption_NamePart copyWith(
           void Function(UninterpretedOption_NamePart) updates) =>
-      super.copyWith((message) => updates(message
-          as UninterpretedOption_NamePart)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as UninterpretedOption_NamePart))
+          as UninterpretedOption_NamePart; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart create() =>
@@ -2826,7 +2830,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption_NamePart>(create);
-  static UninterpretedOption_NamePart _defaultInstance;
+  static UninterpretedOption_NamePart? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get namePart => $_getSZ(0);
@@ -2879,13 +2883,13 @@ class UninterpretedOption extends $pb.GeneratedMessage {
 
   UninterpretedOption._() : super();
   factory UninterpretedOption({
-    $core.Iterable<UninterpretedOption_NamePart> name,
-    $core.String identifierValue,
-    $fixnum.Int64 positiveIntValue,
-    $fixnum.Int64 negativeIntValue,
-    $core.double doubleValue,
-    $core.List<$core.int> stringValue,
-    $core.String aggregateValue,
+    $core.Iterable<UninterpretedOption_NamePart>? name,
+    $core.String? identifierValue,
+    $fixnum.Int64? positiveIntValue,
+    $fixnum.Int64? negativeIntValue,
+    $core.double? doubleValue,
+    $core.List<$core.int>? stringValue,
+    $core.String? aggregateValue,
   }) {
     final _result = create();
     if (name != null) {
@@ -2925,8 +2929,8 @@ class UninterpretedOption extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   UninterpretedOption copyWith(void Function(UninterpretedOption) updates) =>
-      super.copyWith((message) => updates(
-          message as UninterpretedOption)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as UninterpretedOption))
+          as UninterpretedOption; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption create() => UninterpretedOption._();
@@ -2936,7 +2940,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption>(create);
-  static UninterpretedOption _defaultInstance;
+  static UninterpretedOption? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.List<UninterpretedOption_NamePart> get name => $_getList(0);
@@ -3044,11 +3048,11 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
 
   SourceCodeInfo_Location._() : super();
   factory SourceCodeInfo_Location({
-    $core.Iterable<$core.int> path,
-    $core.Iterable<$core.int> span,
-    $core.String leadingComments,
-    $core.String trailingComments,
-    $core.Iterable<$core.String> leadingDetachedComments,
+    $core.Iterable<$core.int>? path,
+    $core.Iterable<$core.int>? span,
+    $core.String? leadingComments,
+    $core.String? trailingComments,
+    $core.Iterable<$core.String>? leadingDetachedComments,
   }) {
     final _result = create();
     if (path != null) {
@@ -3084,8 +3088,8 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   SourceCodeInfo_Location copyWith(
           void Function(SourceCodeInfo_Location) updates) =>
-      super.copyWith((message) => updates(
-          message as SourceCodeInfo_Location)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SourceCodeInfo_Location))
+          as SourceCodeInfo_Location; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location create() => SourceCodeInfo_Location._();
@@ -3095,7 +3099,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo_Location>(create);
-  static SourceCodeInfo_Location _defaultInstance;
+  static SourceCodeInfo_Location? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -3152,7 +3156,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
 
   SourceCodeInfo._() : super();
   factory SourceCodeInfo({
-    $core.Iterable<SourceCodeInfo_Location> location,
+    $core.Iterable<SourceCodeInfo_Location>? location,
   }) {
     final _result = create();
     if (location != null) {
@@ -3174,8 +3178,8 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   SourceCodeInfo copyWith(void Function(SourceCodeInfo) updates) =>
-      super.copyWith((message) =>
-          updates(message as SourceCodeInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as SourceCodeInfo))
+          as SourceCodeInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo create() => SourceCodeInfo._();
@@ -3185,7 +3189,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo>(create);
-  static SourceCodeInfo _defaultInstance;
+  static SourceCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<SourceCodeInfo_Location> get location => $_getList(0);
@@ -3221,10 +3225,10 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
 
   GeneratedCodeInfo_Annotation._() : super();
   factory GeneratedCodeInfo_Annotation({
-    $core.Iterable<$core.int> path,
-    $core.String sourceFile,
-    $core.int begin,
-    $core.int end,
+    $core.Iterable<$core.int>? path,
+    $core.String? sourceFile,
+    $core.int? begin,
+    $core.int? end,
   }) {
     final _result = create();
     if (path != null) {
@@ -3257,8 +3261,9 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   GeneratedCodeInfo_Annotation copyWith(
           void Function(GeneratedCodeInfo_Annotation) updates) =>
-      super.copyWith((message) => updates(message
-          as GeneratedCodeInfo_Annotation)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as GeneratedCodeInfo_Annotation))
+          as GeneratedCodeInfo_Annotation; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation create() =>
@@ -3269,7 +3274,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo_Annotation>(create);
-  static GeneratedCodeInfo_Annotation _defaultInstance;
+  static GeneratedCodeInfo_Annotation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -3332,7 +3337,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
 
   GeneratedCodeInfo._() : super();
   factory GeneratedCodeInfo({
-    $core.Iterable<GeneratedCodeInfo_Annotation> annotation,
+    $core.Iterable<GeneratedCodeInfo_Annotation>? annotation,
   }) {
     final _result = create();
     if (annotation != null) {
@@ -3354,8 +3359,8 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   GeneratedCodeInfo copyWith(void Function(GeneratedCodeInfo) updates) =>
-      super.copyWith((message) => updates(
-          message as GeneratedCodeInfo)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as GeneratedCodeInfo))
+          as GeneratedCodeInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo create() => GeneratedCodeInfo._();
@@ -3365,7 +3370,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo>(create);
-  static GeneratedCodeInfo _defaultInstance;
+  static GeneratedCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/descriptor.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -143,7 +143,7 @@ class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Type> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Type valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Type? valueOf($core.int value) => _byValue[value];
 
   const FieldDescriptorProto_Type._($core.int v, $core.String n) : super(v, n);
 }
@@ -177,7 +177,8 @@ class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Label> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Label valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Label? valueOf($core.int value) =>
+      _byValue[value];
 
   const FieldDescriptorProto_Label._($core.int v, $core.String n) : super(v, n);
 }
@@ -209,7 +210,7 @@ class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FileOptions_OptimizeMode> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FileOptions_OptimizeMode valueOf($core.int value) => _byValue[value];
+  static FileOptions_OptimizeMode? valueOf($core.int value) => _byValue[value];
 
   const FileOptions_OptimizeMode._($core.int v, $core.String n) : super(v, n);
 }
@@ -239,7 +240,7 @@ class FieldOptions_CType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_CType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_CType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_CType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_CType._($core.int v, $core.String n) : super(v, n);
 }
@@ -269,7 +270,7 @@ class FieldOptions_JSType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_JSType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_JSType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_JSType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_JSType._($core.int v, $core.String n) : super(v, n);
 }
@@ -303,7 +304,7 @@ class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, MethodOptions_IdempotencyLevel> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static MethodOptions_IdempotencyLevel valueOf($core.int value) =>
+  static MethodOptions_IdempotencyLevel? valueOf($core.int value) =>
       _byValue[value];
 
   const MethodOptions_IdempotencyLevel._($core.int v, $core.String n)

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -45,10 +45,10 @@ class Version extends $pb.GeneratedMessage {
 
   Version._() : super();
   factory Version({
-    $core.int major,
-    $core.int minor,
-    $core.int patch,
-    $core.String suffix,
+    $core.int? major,
+    $core.int? minor,
+    $core.int? patch,
+    $core.String? suffix,
   }) {
     final _result = create();
     if (major != null) {
@@ -79,8 +79,8 @@ class Version extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   Version copyWith(void Function(Version) updates) =>
-      super.copyWith((message) =>
-          updates(message as Version)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as Version))
+          as Version; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Version create() => Version._();
@@ -89,7 +89,7 @@ class Version extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Version getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Version>(create);
-  static Version _defaultInstance;
+  static Version? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get major => $_getIZ(0);
@@ -169,10 +169,10 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
 
   CodeGeneratorRequest._() : super();
   factory CodeGeneratorRequest({
-    $core.Iterable<$core.String> fileToGenerate,
-    $core.String parameter,
-    Version compilerVersion,
-    $core.Iterable<$0.FileDescriptorProto> protoFile,
+    $core.Iterable<$core.String>? fileToGenerate,
+    $core.String? parameter,
+    Version? compilerVersion,
+    $core.Iterable<$0.FileDescriptorProto>? protoFile,
   }) {
     final _result = create();
     if (fileToGenerate != null) {
@@ -204,8 +204,8 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
       'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
       'Will be removed in next major version')
   CodeGeneratorRequest copyWith(void Function(CodeGeneratorRequest) updates) =>
-      super.copyWith((message) => updates(
-          message as CodeGeneratorRequest)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as CodeGeneratorRequest))
+          as CodeGeneratorRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest create() => CodeGeneratorRequest._();
@@ -215,7 +215,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorRequest>(create);
-  static CodeGeneratorRequest _defaultInstance;
+  static CodeGeneratorRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.String> get fileToGenerate => $_getList(0);
@@ -282,10 +282,10 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
 
   CodeGeneratorResponse_File._() : super();
   factory CodeGeneratorResponse_File({
-    $core.String name,
-    $core.String insertionPoint,
-    $core.String content,
-    $0.GeneratedCodeInfo generatedCodeInfo,
+    $core.String? name,
+    $core.String? insertionPoint,
+    $core.String? content,
+    $0.GeneratedCodeInfo? generatedCodeInfo,
   }) {
     final _result = create();
     if (name != null) {
@@ -318,8 +318,9 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   CodeGeneratorResponse_File copyWith(
           void Function(CodeGeneratorResponse_File) updates) =>
-      super.copyWith((message) => updates(message
-          as CodeGeneratorResponse_File)); // ignore: deprecated_member_use
+      super.copyWith(
+              (message) => updates(message as CodeGeneratorResponse_File))
+          as CodeGeneratorResponse_File; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File create() => CodeGeneratorResponse_File._();
@@ -329,7 +330,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse_File>(create);
-  static CodeGeneratorResponse_File _defaultInstance;
+  static CodeGeneratorResponse_File? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -408,9 +409,9 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
 
   CodeGeneratorResponse._() : super();
   factory CodeGeneratorResponse({
-    $core.String error,
-    $fixnum.Int64 supportedFeatures,
-    $core.Iterable<CodeGeneratorResponse_File> file,
+    $core.String? error,
+    $fixnum.Int64? supportedFeatures,
+    $core.Iterable<CodeGeneratorResponse_File>? file,
   }) {
     final _result = create();
     if (error != null) {
@@ -440,8 +441,8 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
       'Will be removed in next major version')
   CodeGeneratorResponse copyWith(
           void Function(CodeGeneratorResponse) updates) =>
-      super.copyWith((message) => updates(
-          message as CodeGeneratorResponse)); // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as CodeGeneratorResponse))
+          as CodeGeneratorResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse create() => CodeGeneratorResponse._();
@@ -451,7 +452,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse>(create);
-  static CodeGeneratorResponse _defaultInstance;
+  static CodeGeneratorResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get error => $_getSZ(0);

--- a/protoc_plugin/lib/src/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/plugin.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -31,7 +31,7 @@ class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, CodeGeneratorResponse_Feature> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static CodeGeneratorResponse_Feature valueOf($core.int value) =>
+  static CodeGeneratorResponse_Feature? valueOf($core.int value) =>
       _byValue[value];
 
   const CodeGeneratorResponse_Feature._($core.int v, $core.String n)

--- a/protoc_plugin/lib/string_escape.dart
+++ b/protoc_plugin/lib/string_escape.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 /// Returns a quoted version of [input] with contents escaped as a Dart literal.
 String quoted(String input) {
   final sb = StringBuffer();

--- a/protoc_plugin/lib/testing/mixins.dart
+++ b/protoc_plugin/lib/testing/mixins.dart
@@ -1,3 +1,5 @@
+// @dart=2.11
+
 abstract class Mixin1 {
   String get overriddenString => "mixin1";
 

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 PbMixin wellKnownMixinForFullName(String qualifiedName) =>

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -4,18 +4,17 @@ description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.11.0 <3.0.0'
 
 dependencies:
   fixnum: '>=0.10.9 <2.0.0'
-  path: ^1.0.0
+  path: ^1.8.0-nullsafety
   protobuf: '^2.0.0-nullsafety.1'
   dart_style: ^1.0.6
 
 dev_dependencies:
-  test: ^1.3.0
-  pedantic: ^1.9.2
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety
 
 executables:
   protoc-gen-dart: protoc_plugin
-dependency_overrides: {protobuf: {path: ../protobuf}}

--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc_plugin_all_tests;
 
 import 'bazel_test.dart' as bazel;

--- a/protoc_plugin/test/any_test.dart
+++ b/protoc_plugin/test/any_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/bazel_test.dart
+++ b/protoc_plugin/test/bazel_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library bazel_test;
 
 import 'package:protoc_plugin/bazel.dart';

--- a/protoc_plugin/test/client_generator_test.dart
+++ b/protoc_plugin/test/client_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library client_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/const_generator_test.dart
+++ b/protoc_plugin/test/const_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library const_generator_test;
 
 import 'package:protoc_plugin/const_generator.dart';

--- a/protoc_plugin/test/default_value_escape_test.dart
+++ b/protoc_plugin/test/default_value_escape_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import '../out/protos/default_value_escape.pb.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/descriptor_test.dart
+++ b/protoc_plugin/test/descriptor_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:protoc_plugin/src/descriptor.pb.dart';
 import 'package:protobuf/protobuf.dart';
 import '../out/protos/google/protobuf/unittest.pbjson.dart';

--- a/protoc_plugin/test/enum_generator_test.dart
+++ b/protoc_plugin/test/enum_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library enum_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/extension_generator_test.dart
+++ b/protoc_plugin/test/extension_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library extension_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library extension_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library file_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library generated_message_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/golden_file.dart
+++ b/protoc_plugin/test/golden_file.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/protoc_plugin/test/hash_code_test.dart
+++ b/protoc_plugin/test/hash_code_test.dart
@@ -3,6 +3,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
 library hash_code_tests;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/high_tagnumber_test.dart
+++ b/protoc_plugin/test/high_tagnumber_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import '../out/protos/high_tagnumber.pb.dart';
 import '../out/protos/google/protobuf/empty.pb.dart';
 import 'package:test/test.dart';

--- a/protoc_plugin/test/import_public_test.dart
+++ b/protoc_plugin/test/import_public_test.dart
@@ -1,8 +1,10 @@
 #!/usr/bin/env dart
-
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.11
+
 import 'package:test/test.dart';
 
 import '../out/protos/import_public.pb.dart';

--- a/protoc_plugin/test/import_test.dart
+++ b/protoc_plugin/test/import_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library import_test;
 
 import 'package:test/test.dart';

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library indenting_writer_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library json_test;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/leading_underscores_test.dart
+++ b/protoc_plugin/test/leading_underscores_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:test/test.dart';
 import 'package:fixnum/fixnum.dart';
 

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library map_field_test;
 
 import 'dart:convert';

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library map_test;
 
 import 'package:matcher/src/interfaces.dart';

--- a/protoc_plugin/test/merge_test.dart
+++ b/protoc_plugin/test/merge_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library merge_test;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library message_generator_test;
 
 import 'dart:collection';

--- a/protoc_plugin/test/message_test.dart
+++ b/protoc_plugin/test/message_test.dart
@@ -3,6 +3,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
 // ignore_for_file: deprecated_member_use_from_same_package
 
 library message_test;

--- a/protoc_plugin/test/mirror_util.dart
+++ b/protoc_plugin/test/mirror_util.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library mirror_util;
 
 import 'dart:mirrors';

--- a/protoc_plugin/test/mixin_test.dart
+++ b/protoc_plugin/test/mixin_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.11
+
 import 'package:test/test.dart';
 
 import '../out/protos/mixins.pb.dart' as pb;

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library dart_name_test;
 
 import 'package:test/test.dart';

--- a/protoc_plugin/test/omit_enum_names_test.dart
+++ b/protoc_plugin/test/omit_enum_names_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:test/test.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 

--- a/protoc_plugin/test/omit_field_names_test.dart
+++ b/protoc_plugin/test/omit_field_names_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:test/test.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 

--- a/protoc_plugin/test/omit_message_names_test.dart
+++ b/protoc_plugin/test/omit_message_names_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:test/test.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 

--- a/protoc_plugin/test/oneof_test.dart
+++ b/protoc_plugin/test/oneof_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library one_of_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:core' hide Duration;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/proto3_optional_test.dart
+++ b/protoc_plugin/test/proto3_optional_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:core' hide Duration;
 
 import 'package:test/test.dart';

--- a/protoc_plugin/test/protoc_options_test.dart
+++ b/protoc_plugin/test/protoc_options_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc_options_test;
 
 import 'package:protoc_plugin/src/plugin.pb.dart';

--- a/protoc_plugin/test/repeated_field_test.dart
+++ b/protoc_plugin/test/repeated_field_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library repeated_field_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 @TestOn("vm")
 library reserved_names_test;
 

--- a/protoc_plugin/test/send_protos_via_sendports_test.dart
+++ b/protoc_plugin/test/send_protos_via_sendports_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:isolate';
 
 import 'package:test/test.dart';

--- a/protoc_plugin/test/service_generator_test.dart
+++ b/protoc_plugin/test/service_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library service_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/service_test.dart
+++ b/protoc_plugin/test/service_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.11
+
 library service_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/service_util.dart
+++ b/protoc_plugin/test/service_util.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library service_util;
 
 import 'package:protoc_plugin/src/descriptor.pb.dart';

--- a/protoc_plugin/test/test_util.dart
+++ b/protoc_plugin/test/test_util.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library test_util;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/timestamp_test.dart
+++ b/protoc_plugin/test/timestamp_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/to_builder_test.dart
+++ b/protoc_plugin/test/to_builder_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:convert';
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';

--- a/protoc_plugin/test/unknown_field_set_test.dart
+++ b/protoc_plugin/test/unknown_field_set_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library unknown_field_set_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/validate_fail_test.dart
+++ b/protoc_plugin/test/validate_fail_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library validate_fail_test;
 
 import 'package:test/test.dart';

--- a/protoc_plugin/test/wire_format_test.dart
+++ b/protoc_plugin/test/wire_format_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library wire_format_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/query_benchmark/mono_pkg.yaml
+++ b/query_benchmark/mono_pkg.yaml
@@ -3,8 +3,8 @@
 stages:
   - format_analyze:
     - group:
+      - dartfmt
       - command: ./../tool/setup.sh
       - command: ./compile_protos.sh
-      - dartfmt
       - dartanalyzer: --fatal-warnings .
       dart: [dev]


### PR DESCRIPTION
- Upgrade dependencies to null safety version where possible
- Remove accidentally committed dependency_override
- Regenerate bootstrap protos with null-safe version of protoc_plugin
- Bump sdk to 2.11 and add `@dart=2.11` to all own sources of protoc_plugin
- Further speed up build by not checking format of query_benchmark
  generated protos and by testing api_benchmark and query_benchmark in
  parallel
- Merge Add badges to readme (#462)