### PR TITLE
Generate null-safe .pbgrpc files

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Support optional proto3 fields
 * Emit binary coded descriptors, which can be used to reflect over the options
   given to the descriptor.
+* Generate null-safe .pbgrpc.dart files
 
 ## 20.0.0-nullsafety.1
 

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -489,7 +489,7 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     if (!_linked) throw StateError("not linked");
     var out = makeWriter();
-    _writeHeading(out, nullSafe: false);
+    _writeHeading(out);
 
     out.println(_asyncImport);
     out.println();
@@ -584,8 +584,7 @@ class FileGenerator extends ProtobufContainer {
 
   /// Writes the header at the top of the dart file.
   void _writeHeading(IndentingWriter out,
-      {bool nullSafe = true, Set<String> extraIgnores = const <String>{}}) {
-    var version = nullSafe ? '2.12' : '2.7';
+      {Set<String> extraIgnores = const <String>{}}) {
     var extraIgnoresString =
         extraIgnores.isEmpty ? '' : ',${extraIgnores.join(',')}';
 
@@ -594,7 +593,7 @@ class FileGenerator extends ProtobufContainer {
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 //
-// @dart = $version
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields$extraIgnoresString
 ''');
   }

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -114,9 +114,9 @@ class GrpcServiceGenerator {
       }
       out.println();
       out.println('$_clientClassname($_clientChannel channel,');
-      out.println('    {$_callOptions options,');
+      out.println('    {$_callOptions? options,');
       out.println(
-          '    $_coreImportPrefix.Iterable<$_interceptor> interceptors})');
+          '    $_coreImportPrefix.Iterable<$_interceptor>? interceptors})');
       out.println('    : super(channel, options: options,');
       out.println('      interceptors: interceptors);');
       for (final method in _methods) {
@@ -227,7 +227,7 @@ class _GrpcMethod {
   void generateClientStub(IndentingWriter out) {
     out.println();
     out.addBlock(
-        '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
+        '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions}? options}) {',
         '}', () {
       if (_clientStreaming && _serverStreaming) {
         out.println(

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -32,31 +32,31 @@ class TestClient extends $grpc.Client {
       ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
 
   TestClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$unary, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
       $async.Stream<$0.Input> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$clientStreaming, request, options: options)
         .single;
   }
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(
         _$serverStreaming, $async.Stream.fromIterable([request]),
         options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$bidirectional, request, options: options);
   }
 }


### PR DESCRIPTION
Now as grpc-dart migrated to null safety, we can generate null-safe .pbgrpc files