### PR TITLE
Fix comparison of empty lists from frozen messages.

### DIFF
--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -238,7 +238,7 @@ class _FieldSet {
 
   List<T> _getDefaultList<T>(FieldInfo<T> fi) {
     assert(fi.isRepeated);
-    if (_isReadOnly) return List.unmodifiable(const []);
+    if (_isReadOnly) return FrozenPbList._(const []);
 
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:

--- a/protobuf/test/list_equality_test.dart
+++ b/protobuf/test/list_equality_test.dart
@@ -1,0 +1,52 @@
+// Test for ensuring that protobuf lists compare using value semantics.
+library list_equality_test;
+
+import 'package:test/test.dart';
+
+import 'mock_util.dart' show T;
+
+void main() {
+  test('empty lists compare as equal', () {
+    final first = T();
+    final second = T();
+    expect(first.int32s == second.int32s, isTrue);
+  });
+
+  test('empty frozen lists compare as equal', () {
+    final first = T()..freeze();
+    final second = T()..freeze();
+    expect(first.int32s == second.int32s, isTrue);
+  });
+
+  test('non-empty lists compare as equal', () {
+    final first = T()..int32s.add(1);
+    final second = T()..int32s.add(1);
+    expect(first.int32s == second.int32s, isTrue);
+  });
+
+  test('non-empty frozen lists compare as equal', () {
+    final first = T()
+      ..int32s.add(1)
+      ..freeze();
+    final second = T()
+      ..int32s.add(1)
+      ..freeze();
+    expect(first.int32s == second.int32s, isTrue);
+  });
+
+  test('different lists do not compare as equal', () {
+    final first = T()..int32s.add(1);
+    final second = T()..int32s.add(2);
+    expect(first.int32s == second.int32s, isFalse);
+  });
+
+  test('different frozen lists do not compare as equal', () {
+    final first = T()
+      ..int32s.add(1)
+      ..freeze();
+    final second = T()
+      ..int32s.add(2)
+      ..freeze();
+    expect(first.int32s == second.int32s, isFalse);
+  });
+}


### PR DESCRIPTION
The existing implementation returns an unmodifiable list, which does not obey the value-comparison semantics expected for protobuf lists. Returning a `FrozenPbList` instead resolves this.