### PR TITLE
Add default value for strings in pb_map _mergeEntry to fix issue #508

### DIFF
--- a/protobuf/lib/src/protobuf/pb_map.dart
+++ b/protobuf/lib/src/protobuf/pb_map.dart
@@ -100,8 +100,11 @@ class PbMap<K, V> extends MapBase<K, V> {
     _mergeFromCodedBufferReader(mapEntryMeta, entryFieldSet, input, registry!);
     input.checkLastTagWas(0);
     input._currentLimit = oldLimit;
-    var key = entryFieldSet._$get<K>(0, null);
-    var value = entryFieldSet._$get<V>(1, null);
+    // Provide default value for strings here, as empty strings are not
+    // serialized into the message due to empty string being the default
+    // value of the string type
+    var key = entryFieldSet._$get<K>(0, K == String ? '' as K : null);
+    var value = entryFieldSet._$get<V>(1, V == String ? '' as V : null);
     _wrappedMap[key] = value;
   }
 


### PR DESCRIPTION
Disclaimer - I'm no expert in this code base, but I was hit with the issue https://github.com/dart-lang/protobuf/issues/508 and decided to try and fix it today.

In the null_safety release, deserialising a protobuf message that includes empty strings within a map results in an error, as they aren't serialised which results in null values. This is then causing an error when field_set _meta function is called. This can be avoided by ensuring a default value of '' for strings in the _mergeEntry function
