### PR TITLE
Widen fixnum range

### DIFF
--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
+  fixnum: '>=0.10.9 <2.0.0'
 
 dev_dependencies:
   test: '>=1.2.0'


### PR DESCRIPTION
I'm hitting a problem getting pub to solve with Dart 2.13.4 on our codebase due to not being able to use fixnum 1.0.0. I've tracked it back to this repo that limits fixnum to `^0.10.9` but specifies a SDK range of `>=2.7.0 <3.0.0`. 
It seems like if you wanted to use this library with null safety, you'd want to be able to solve to fixnum 1.0.0 which is null-safe.

Indeed when running the migration tool it reports that the version of fixnum isn't nullsafe.
`pub outdated --mode=null-safety` shows
![image](https://user-images.githubusercontent.com/6053699/125119206-fdfb4900-e0ad-11eb-9d2e-f69bb795ab48.png)

So, it seems like a good change in order support both older and newer SDK version. 

If this ends up merging, I would need this released as a patch version on the 1x line.