### PR TITLE
protoc_plugin: drop version back to 19.3.2-dev

### DIFF
--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 19.3.3
+## 19.3.2-dev
 
 * Add the test for fixed32 int that could be negative.
-
-## 19.3.2
-
 * Add tests for the repeated and map enum value fields where the 
   enum value is unknown.
 

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 19.3.3
+version: 19.3.2-dev
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 


### PR DESCRIPTION
19.3.1 was the last stable release in the not-null-safe chain
