### PR TITLE
merge null safety

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -2,13 +2,9 @@
 name: Dart CI
 on:
   push:
-    branches:
-      - master
-      - null_safety
+    branches: master
   pull_request:
-    branches:
-      - master
-      - null_safety
+    branches: master
   schedule:
     - cron: "0 0 * * 0"
 defaults:
@@ -19,22 +15,43 @@ env:
 
 jobs:
   job_001:
-    name: "format_analyze; linux; Dart 2.10.5; PKG: protobuf; `dart analyze lib`, `dart analyze test`"
+    name: mono_repo self validate
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf;commands:analyze_3-analyze_4"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.1
         with:
-          sdk: "2.10.5"
+          sdk: stable
+      - id: checkout
+        uses: actions/checkout@v2.3.4
+      - name: mono_repo self validate
+        run: dart pub global activate mono_repo 5.0.1
+      - name: mono_repo self validate
+        run: dart pub global run mono_repo generate --validate
+  job_002:
+    name: "format_analyze; linux; Dart 2.12.0; PKG: protobuf; `dart analyze lib`, `dart analyze test`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v2.1.6
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf;commands:analyze_1-analyze_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - uses: dart-lang/setup-dart@v1.1
+        with:
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2.3.4
       - id: protobuf_pub_upgrade
@@ -50,51 +67,15 @@ jobs:
         if: "always() && steps.protobuf_pub_upgrade.conclusion == 'success'"
         working-directory: protobuf
         run: dart analyze test
-  job_002:
-    name: "format_analyze; linux; Dart 2.10.5; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart analyze`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protoc_plugin;commands:command_0-command_2-analyze_0"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protoc_plugin
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - uses: dart-lang/setup-dart@v1.1
-        with:
-          sdk: "2.10.5"
-      - id: checkout
-        uses: actions/checkout@v2.3.4
-      - id: protoc_plugin_pub_upgrade
-        name: protoc_plugin; dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: protoc_plugin
-        run: dart pub upgrade
-      - name: protoc_plugin; ./../tool/setup.sh
-        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
-        working-directory: protoc_plugin
-        run: ./../tool/setup.sh
-      - name: protoc_plugin; make protos
-        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
-        working-directory: protoc_plugin
-        run: make protos
-      - name: protoc_plugin; dart analyze
-        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
-        working-directory: protoc_plugin
-        run: dart analyze
   job_003:
-    name: "format_analyze; linux; Dart dev; PKGS: api_benchmark, query_benchmark; `./../tool/setup.sh`, `./compile_protos.sh`, `dart format --output=none --set-exit-if-changed .`, `dart analyze`"
+    name: "format_analyze; linux; Dart dev; PKGS: api_benchmark, query_benchmark; `dart format --output=none --set-exit-if-changed .`, `./../tool/setup.sh`, `./compile_protos.sh`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark-query_benchmark;commands:command_0-command_1-format-analyze_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark-query_benchmark;commands:format-command_0-command_1-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:api_benchmark-query_benchmark
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -110,6 +91,10 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: api_benchmark
         run: dart pub upgrade
+      - name: "api_benchmark; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
+        working-directory: api_benchmark
+        run: "dart format --output=none --set-exit-if-changed ."
       - name: api_benchmark; ./../tool/setup.sh
         if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: api_benchmark
@@ -118,19 +103,19 @@ jobs:
         if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: api_benchmark
         run: ./compile_protos.sh
-      - name: "api_benchmark; dart format --output=none --set-exit-if-changed ."
+      - name: "api_benchmark; dart analyze --fatal-infos"
         if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: api_benchmark
-        run: "dart format --output=none --set-exit-if-changed ."
-      - name: api_benchmark; dart analyze
-        if: "always() && steps.api_benchmark_pub_upgrade.conclusion == 'success'"
-        working-directory: api_benchmark
-        run: dart analyze
+        run: dart analyze --fatal-infos
       - id: query_benchmark_pub_upgrade
         name: query_benchmark; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: query_benchmark
         run: dart pub upgrade
+      - name: "query_benchmark; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
+        working-directory: query_benchmark
+        run: "dart format --output=none --set-exit-if-changed ."
       - name: query_benchmark; ./../tool/setup.sh
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark
@@ -139,23 +124,19 @@ jobs:
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark
         run: ./compile_protos.sh
-      - name: "query_benchmark; dart format --output=none --set-exit-if-changed ."
+      - name: "query_benchmark; dart analyze --fatal-infos"
         if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
         working-directory: query_benchmark
-        run: "dart format --output=none --set-exit-if-changed ."
-      - name: query_benchmark; dart analyze
-        if: "always() && steps.query_benchmark_pub_upgrade.conclusion == 'success'"
-        working-directory: query_benchmark
-        run: dart analyze
+        run: dart analyze --fatal-infos
   job_004:
-    name: "format_analyze; linux; Dart dev; PKG: protobuf; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos lib`, `dart analyze --fatal-infos test`"
+    name: "format_analyze; linux; Dart dev; PKG: protobuf; `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protobuf;commands:format-analyze_1-analyze_2"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protobuf;commands:format-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protobuf
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -175,23 +156,19 @@ jobs:
         if: "always() && steps.protobuf_pub_upgrade.conclusion == 'success'"
         working-directory: protobuf
         run: "dart format --output=none --set-exit-if-changed ."
-      - name: "protobuf; dart analyze --fatal-infos lib"
+      - name: "protobuf; dart analyze --fatal-infos"
         if: "always() && steps.protobuf_pub_upgrade.conclusion == 'success'"
         working-directory: protobuf
-        run: dart analyze --fatal-infos lib
-      - name: "protobuf; dart analyze --fatal-infos test"
-        if: "always() && steps.protobuf_pub_upgrade.conclusion == 'success'"
-        working-directory: protobuf
-        run: dart analyze --fatal-infos test
+        run: dart analyze --fatal-infos
   job_005:
-    name: "format_analyze; linux; Dart dev; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart format --output=none --set-exit-if-changed .`, `dart analyze --fatal-infos`"
+    name: "format_analyze; linux; Dart dev; PKG: protoc_plugin; `dart format --output=none --set-exit-if-changed .`, `./../tool/setup.sh`, `make protos`, `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protoc_plugin;commands:command_0-command_2-format-analyze_5"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protoc_plugin;commands:format-command_0-command_2-analyze_0"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:protoc_plugin
             os:ubuntu-latest;pub-cache-hosted;dart:dev
@@ -207,6 +184,10 @@ jobs:
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: protoc_plugin
         run: dart pub upgrade
+      - name: "protoc_plugin; dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
+        working-directory: protoc_plugin
+        run: "dart format --output=none --set-exit-if-changed ."
       - name: protoc_plugin; ./../tool/setup.sh
         if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
         working-directory: protoc_plugin
@@ -215,31 +196,27 @@ jobs:
         if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
         working-directory: protoc_plugin
         run: make protos
-      - name: "protoc_plugin; dart format --output=none --set-exit-if-changed ."
-        if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
-        working-directory: protoc_plugin
-        run: "dart format --output=none --set-exit-if-changed ."
       - name: "protoc_plugin; dart analyze --fatal-infos"
         if: "always() && steps.protoc_plugin_pub_upgrade.conclusion == 'success'"
         working-directory: protoc_plugin
         run: dart analyze --fatal-infos
   job_006:
-    name: "run_tests; linux; Dart 2.10.5; PKG: protobuf; `dart test`"
+    name: "run_tests; linux; Dart 2.12.0; PKG: protobuf; `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.1
         with:
-          sdk: "2.10.5"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2.3.4
       - id: protobuf_pub_upgrade
@@ -258,22 +235,22 @@ jobs:
       - job_004
       - job_005
   job_007:
-    name: "run_tests; linux; Dart 2.10.5; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test`"
+    name: "run_tests; linux; Dart 2.12.0; PKG: protoc_plugin; `./../tool/setup.sh`, `make protos`, `dart test`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protoc_plugin;commands:command_0-command_2-test"
+          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protoc_plugin;commands:command_0-command_2-test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5;packages:protoc_plugin
-            os:ubuntu-latest;pub-cache-hosted;dart:2.10.5
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:protoc_plugin
+            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.1
         with:
-          sdk: "2.10.5"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2.3.4
       - id: protoc_plugin_pub_upgrade
@@ -376,22 +353,22 @@ jobs:
       - job_004
       - job_005
   job_010:
-    name: "run_tests; osx; Dart 2.10.5; PKG: protobuf; `dart test`"
+    name: "run_tests; osx; Dart 2.12.0; PKG: protobuf; `dart test`"
     runs-on: macos-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@v2.1.6
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:macos-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf;commands:test"
+          key: "os:macos-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf;commands:test"
           restore-keys: |
-            os:macos-latest;pub-cache-hosted;dart:2.10.5;packages:protobuf
-            os:macos-latest;pub-cache-hosted;dart:2.10.5
+            os:macos-latest;pub-cache-hosted;dart:2.12.0;packages:protobuf
+            os:macos-latest;pub-cache-hosted;dart:2.12.0
             os:macos-latest;pub-cache-hosted
             os:macos-latest
       - uses: dart-lang/setup-dart@v1.1
         with:
-          sdk: "2.10.5"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2.3.4
       - id: protobuf_pub_upgrade
@@ -444,12 +421,12 @@ jobs:
       - job_004
       - job_005
   job_012:
-    name: "run_tests; windows; Dart 2.10.5; PKG: protobuf; `dart test`"
+    name: "run_tests; windows; Dart 2.12.0; PKG: protobuf; `dart test`"
     runs-on: windows-latest
     steps:
       - uses: dart-lang/setup-dart@v1.1
         with:
-          sdk: "2.10.5"
+          sdk: "2.12.0"
       - id: checkout
         uses: actions/checkout@v2.3.4
       - id: protobuf_pub_upgrade

--- a/api_benchmark/lib/suite.dart
+++ b/api_benchmark/lib/suite.dart
@@ -5,6 +5,8 @@
 library protoc.benchmark.suite;
 
 import 'package:api_benchmark/benchmark.dart';
+import 'package:protobuf/protobuf.dart';
+
 import 'benchmarks/index.dart' show createBenchmark;
 import 'generated/benchmark.pb.dart' as pb;
 
@@ -31,7 +33,7 @@ Iterable<pb.Report> runSuite(List<pb.Request> requests,
   }
   pb.Report progress() {
     report.message = "Running ($sampleCount/$totalSamples)";
-    return report.clone();
+    return report.deepCopy();
   }
 
   // Send first progress message before starting.

--- a/api_benchmark/mono_pkg.yaml
+++ b/api_benchmark/mono_pkg.yaml
@@ -3,8 +3,8 @@
 stages:
   - format_analyze:
     - group:
+      - format
       - command: ./../tool/setup.sh
       - command: ./compile_protos.sh
-      - format
-      - analyze
+      - analyze: --fatal-infos
       dart: [dev]

--- a/api_benchmark/pubspec.yaml
+++ b/api_benchmark/pubspec.yaml
@@ -6,22 +6,20 @@ name: api_benchmark
 description: Benchmarking a number of different api calls.
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.11.99 <3.0.0'
 
 dependencies:
   protobuf:
 
 dev_dependencies:
-  build: ^1.0.0
-  build_runner: ^1.0.0
-  build_web_compilers: ^2.0.0
-  glob: ^1.1.7
-  yaml: ^2.1.15
+  build: ^2.0.0
+  build_runner: ^2.0.6
+  build_web_compilers: ^3.0.0
+  glob: ^2.0.0
+  yaml: ^3.0.0
   protoc_plugin:
     path: "../protoc_plugin"
 
 dependency_overrides:
-  # Due to version issues
-  meta: <1.5.0
   protobuf:
     path: "../protobuf"

--- a/mono_repo.yaml
+++ b/mono_repo.yaml
@@ -1,10 +1,13 @@
+# See https://github.com/google/mono_repo.dart for details on this file
+self_validate: format_analyze
+
 github:
   on:
     # Run CI on pushes to the master branch, and on PRs against master.
     push:
-      branches: [master, null_safety]
+      branches: master
     pull_request:
-      branches: [master, null_safety]
+      branches: master
     schedule:
       - cron: "0 0 * * 0"
 

--- a/protobuf/CHANGELOG.md
+++ b/protobuf/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.1-dev
+
+* Merge fixes from version `1.1.2` - `1.1.4` into v2.
+
+## 2.0.0
+
+* Stable null safety release.
+
 ## 1.1.4
 
 *   Fix comparison of empty lists from frozen messages.

--- a/protobuf/benchmarks/common.dart
+++ b/protobuf/benchmarks/common.dart
@@ -93,7 +93,7 @@ class Factories {
         fromJson: (String json) => GoogleMessage4.fromJson(json)),
   };
 
-  Factories._({this.fromBuffer, this.fromJson});
+  Factories._({required this.fromBuffer, required this.fromJson});
 }
 
 /// Base for all protobuf benchmarks.

--- a/protobuf/lib/src/protobuf/builder_info.dart
+++ b/protobuf/lib/src/protobuf/builder_info.dart
@@ -16,16 +16,16 @@ class BuilderInfo {
   final Map<int, int> oneofs = <int, int>{};
   bool hasExtensions = false;
   bool hasRequiredFields = true;
-  List<FieldInfo> _sortedByTag;
+  List<FieldInfo>? _sortedByTag;
 
   // For well-known types.
-  final Object Function(GeneratedMessage message, TypeRegistry typeRegistry)
+  final Object? Function(GeneratedMessage message, TypeRegistry typeRegistry)?
       toProto3Json;
   final Function(GeneratedMessage targetMessage, Object json,
-      TypeRegistry typeRegistry, JsonParsingContext context) fromProto3Json;
-  final CreateBuilderFunc createEmptyInstance;
+      TypeRegistry typeRegistry, JsonParsingContext context)? fromProto3Json;
+  final CreateBuilderFunc? createEmptyInstance;
 
-  BuilderInfo(String messageName,
+  BuilderInfo(String? messageName,
       {PackageName package = const PackageName(''),
       this.createEmptyInstance,
       this.toProto3Json,
@@ -35,16 +35,16 @@ class BuilderInfo {
   void add<T>(
       int tagNumber,
       String name,
-      int fieldType,
+      int? fieldType,
       dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      {String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      {String? protoName}) {
     var index = byIndex.length;
     final fieldInfo = (tagNumber == 0)
         ? FieldInfo.dummy(index)
-        : FieldInfo<T>(name, tagNumber, index, fieldType,
+        : FieldInfo<T>(name, tagNumber, index, fieldType!,
             defaultOrMaker: defaultOrMaker,
             subBuilder: subBuilder,
             valueOf: valueOf,
@@ -56,12 +56,12 @@ class BuilderInfo {
   void addMapField<K, V>(
       int tagNumber,
       String name,
-      int keyFieldType,
-      int valueFieldType,
+      int? keyFieldType,
+      int? valueFieldType,
       BuilderInfo mapEntryBuilderInfo,
-      CreateBuilderFunc valueCreator,
-      {ProtobufEnum defaultEnumValue,
-      String protoName}) {
+      CreateBuilderFunc? valueCreator,
+      {ProtobufEnum? defaultEnumValue,
+      String? protoName}) {
     var index = byIndex.length;
     _addField(MapFieldInfo<K, V>(name, tagNumber, index, PbFieldType.M,
         keyFieldType, valueFieldType, mapEntryBuilderInfo, valueCreator,
@@ -73,11 +73,11 @@ class BuilderInfo {
       String name,
       int fieldType,
       CheckFunc<T> check,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      {ProtobufEnum defaultEnumValue,
-      String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      {ProtobufEnum? defaultEnumValue,
+      String? protoName}) {
     var index = byIndex.length;
     _addField(FieldInfo<T>.repeated(
         name, tagNumber, index, fieldType, check, subBuilder,
@@ -89,7 +89,7 @@ class BuilderInfo {
 
   void _addField(FieldInfo fi) {
     byIndex.add(fi);
-    assert(byIndex[fi.index] == fi);
+    assert(byIndex[fi.index!] == fi);
     // Fields with tag number 0 are considered dummy fields added to avoid
     // index calculations add up. They should not be reflected in the following
     // maps.
@@ -102,10 +102,10 @@ class BuilderInfo {
 
   void a<T>(int tagNumber, String name, int fieldType,
       {dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName}) {
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName}) {
     add<T>(tagNumber, name, fieldType, defaultOrMaker, subBuilder, valueOf,
         enumValues,
         protoName: protoName);
@@ -113,32 +113,32 @@ class BuilderInfo {
 
   /// Adds PbFieldType.OS String with no default value to reduce generated
   /// code size.
-  void aOS(int tagNumber, String name, {String protoName}) {
+  void aOS(int tagNumber, String name, {String? protoName}) {
     add<String>(tagNumber, name, PbFieldType.OS, null, null, null, null,
         protoName: protoName);
   }
 
   /// Adds PbFieldType.PS String with no default value.
-  void pPS(int tagNumber, String name, {String protoName}) {
+  void pPS(int tagNumber, String name, {String? protoName}) {
     addRepeated<String>(tagNumber, name, PbFieldType.PS,
         getCheckFunction(PbFieldType.PS), null, null, null,
         protoName: protoName);
   }
 
   /// Adds PbFieldType.QS String with no default value.
-  void aQS(int tagNumber, String name, {String protoName}) {
+  void aQS(int tagNumber, String name, {String? protoName}) {
     add<String>(tagNumber, name, PbFieldType.QS, null, null, null, null,
         protoName: protoName);
   }
 
   /// Adds Int64 field with Int64.ZERO default.
-  void aInt64(int tagNumber, String name, {String protoName}) {
+  void aInt64(int tagNumber, String name, {String? protoName}) {
     add<Int64>(tagNumber, name, PbFieldType.O6, Int64.ZERO, null, null, null,
         protoName: protoName);
   }
 
   /// Adds a boolean with no default value.
-  void aOB(int tagNumber, String name, {String protoName}) {
+  void aOB(int tagNumber, String name, {String? protoName}) {
     add<bool>(tagNumber, name, PbFieldType.OB, null, null, null, null,
         protoName: protoName);
   }
@@ -146,16 +146,16 @@ class BuilderInfo {
   // Enum.
   void e<T>(int tagNumber, String name, int fieldType,
       {dynamic defaultOrMaker,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName}) {
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName}) {
     add<T>(
         tagNumber, name, fieldType, defaultOrMaker, null, valueOf, enumValues,
         protoName: protoName);
   }
 
   // Repeated, not a message, group, or enum.
-  void p<T>(int tagNumber, String name, int fieldType, {String protoName}) {
+  void p<T>(int tagNumber, String name, int fieldType, {String? protoName}) {
     assert(!_isGroupOrMessage(fieldType) && !_isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, getCheckFunction(fieldType),
         null, null, null,
@@ -164,11 +164,11 @@ class BuilderInfo {
 
   // Repeated message, group, or enum.
   void pc<T>(int tagNumber, String name, int fieldType,
-      {CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      ProtobufEnum defaultEnumValue,
-      String protoName}) {
+      {CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      ProtobufEnum? defaultEnumValue,
+      String? protoName}) {
     assert(_isGroupOrMessage(fieldType) || _isEnum(fieldType));
     addRepeated<T>(tagNumber, name, fieldType, _checkNotNull, subBuilder,
         valueOf, enumValues,
@@ -176,7 +176,7 @@ class BuilderInfo {
   }
 
   void aOM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function() subBuilder, String protoName}) {
+      {T Function()? subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,
@@ -189,7 +189,7 @@ class BuilderInfo {
   }
 
   void aQM<T extends GeneratedMessage>(int tagNumber, String name,
-      {T Function() subBuilder, String protoName}) {
+      {T Function()? subBuilder, String? protoName}) {
     add<T>(
         tagNumber,
         name,
@@ -208,15 +208,15 @@ class BuilderInfo {
 
   // Map field.
   void m<K, V>(int tagNumber, String name,
-      {String entryClassName,
-      int keyFieldType,
-      int valueFieldType,
-      CreateBuilderFunc valueCreator,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      ProtobufEnum defaultEnumValue,
+      {String? entryClassName,
+      int? keyFieldType,
+      int? valueFieldType,
+      CreateBuilderFunc? valueCreator,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      ProtobufEnum? defaultEnumValue,
       PackageName packageName = const PackageName(''),
-      String protoName}) {
+      String? protoName}) {
     var mapEntryBuilderInfo = BuilderInfo(entryClassName, package: packageName)
       ..add(PbMap._keyFieldNumber, 'key', keyFieldType, null, null, null, null)
       ..add(PbMap._valueFieldNumber, 'value', valueFieldType, null,
@@ -235,32 +235,32 @@ class BuilderInfo {
   }
 
   // Returns the field name for a given tag number, for debugging purposes.
-  String fieldName(int tagNumber) {
+  String? fieldName(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.name : null;
   }
 
-  int fieldType(int tagNumber) {
+  int? fieldType(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.type : null;
   }
 
-  MakeDefaultFunc makeDefault(int tagNumber) {
+  MakeDefaultFunc? makeDefault(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.makeDefault : null;
   }
 
-  CreateBuilderFunc subBuilder(int tagNumber) {
+  CreateBuilderFunc? subBuilder(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.subBuilder : null;
   }
 
-  int tagNumber(String fieldName) {
+  int? tagNumber(String fieldName) {
     var i = byName[fieldName];
     return i != null ? i.tagNumber : null;
   }
 
-  ValueOfFunc valueOfFunc(int tagNumber) {
+  ValueOfFunc? valueOfFunc(int tagNumber) {
     var i = fieldInfo[tagNumber];
     return i != null ? i.valueOf : null;
   }
@@ -284,23 +284,23 @@ class BuilderInfo {
   }
 
   GeneratedMessage _makeEmptyMessage(
-      int tagNumber, ExtensionRegistry extensionRegistry) {
+      int tagNumber, ExtensionRegistry? extensionRegistry) {
     var subBuilderFunc = subBuilder(tagNumber);
     if (subBuilderFunc == null && extensionRegistry != null) {
       subBuilderFunc = extensionRegistry
-          .getExtension(qualifiedMessageName, tagNumber)
+          .getExtension(qualifiedMessageName, tagNumber)!
           .subBuilder;
     }
-    return subBuilderFunc();
+    return subBuilderFunc!();
   }
 
-  ProtobufEnum _decodeEnum(
-      int tagNumber, ExtensionRegistry registry, int rawValue) {
+  ProtobufEnum? _decodeEnum(
+      int tagNumber, ExtensionRegistry? registry, int rawValue) {
     var f = valueOfFunc(tagNumber);
     if (f == null && registry != null) {
-      f = registry.getExtension(qualifiedMessageName, tagNumber).valueOf;
+      f = registry.getExtension(qualifiedMessageName, tagNumber)!.valueOf;
     }
-    return f(rawValue);
+    return f!(rawValue);
   }
 }
 

--- a/protobuf/lib/src/protobuf/coded_buffer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer.dart
@@ -10,34 +10,33 @@ void _writeToCodedBufferWriter(_FieldSet fs, CodedBufferWriter out) {
   // https://developers.google.com/protocol-buffers/docs/encoding?hl=en#order
 
   for (var fi in fs._infosSortedByTag) {
-    var value = fs._values[fi.index];
+    var value = fs._values[fi.index!];
     if (value == null) continue;
     out.writeField(fi.tagNumber, fi.type, value);
   }
 
   if (fs._hasExtensions) {
-    for (var tagNumber in _sorted(fs._extensions._tagNumbers)) {
-      var fi = fs._extensions._getInfoOrNull(tagNumber);
-      out.writeField(tagNumber, fi.type, fs._extensions._getFieldOrNull(fi));
+    for (var tagNumber in _sorted(fs._extensions!._tagNumbers)) {
+      var fi = fs._extensions!._getInfoOrNull(tagNumber)!;
+      out.writeField(tagNumber, fi.type, fs._extensions!._getFieldOrNull(fi));
     }
   }
   if (fs._hasUnknownFields) {
-    fs._unknownFields.writeToCodedBufferWriter(out);
+    fs._unknownFields!.writeToCodedBufferWriter(out);
   }
 }
 
-void _mergeFromCodedBufferReader(
-    _FieldSet fs, CodedBufferReader input, ExtensionRegistry registry) {
-  assert(registry != null);
-
+void _mergeFromCodedBufferReader(BuilderInfo meta, _FieldSet fs,
+    CodedBufferReader input, ExtensionRegistry registry) {
+  ArgumentError.checkNotNull(registry);
   while (true) {
     var tag = input.readTag();
     if (tag == 0) return;
     var wireType = tag & 0x7;
     var tagNumber = tag >> 3;
 
-    var fi = fs._nonExtensionInfo(tagNumber);
-    fi ??= registry.getExtension(fs._messageName, tagNumber);
+    var fi = fs._nonExtensionInfo(meta, tagNumber);
+    fi ??= registry.getExtension(meta.qualifiedMessageName, tagNumber);
 
     if (fi == null || !_wireTypeMatches(fi.type, wireType)) {
       if (!fs._ensureUnknownFields().mergeFieldFromBuffer(tag, input)) {
@@ -51,138 +50,143 @@ void _mergeFromCodedBufferReader(
     fieldType &= ~(PbFieldType._PACKED_BIT | PbFieldType._REQUIRED_BIT);
     switch (fieldType) {
       case PbFieldType._OPTIONAL_BOOL:
-        fs._setFieldUnchecked(fi, input.readBool());
+        fs._setFieldUnchecked(meta, fi, input.readBool());
         break;
       case PbFieldType._OPTIONAL_BYTES:
-        fs._setFieldUnchecked(fi, input.readBytes());
+        fs._setFieldUnchecked(meta, fi, input.readBytes());
         break;
       case PbFieldType._OPTIONAL_STRING:
-        fs._setFieldUnchecked(fi, input.readString());
+        fs._setFieldUnchecked(meta, fi, input.readString());
         break;
       case PbFieldType._OPTIONAL_FLOAT:
-        fs._setFieldUnchecked(fi, input.readFloat());
+        fs._setFieldUnchecked(meta, fi, input.readFloat());
         break;
       case PbFieldType._OPTIONAL_DOUBLE:
-        fs._setFieldUnchecked(fi, input.readDouble());
+        fs._setFieldUnchecked(meta, fi, input.readDouble());
         break;
       case PbFieldType._OPTIONAL_ENUM:
         var rawValue = input.readEnum();
-        var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
+        var value = meta._decodeEnum(tagNumber, registry, rawValue);
         if (value == null) {
           var unknown = fs._ensureUnknownFields();
           unknown.mergeVarintField(tagNumber, Int64(rawValue));
         } else {
-          fs._setFieldUnchecked(fi, value);
+          fs._setFieldUnchecked(meta, fi, value);
         }
         break;
       case PbFieldType._OPTIONAL_GROUP:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         var oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           subMessage.mergeFromMessage(oldValue);
         }
         input.readGroup(tagNumber, subMessage, registry);
-        fs._setFieldUnchecked(fi, subMessage);
+        fs._setFieldUnchecked(meta, fi, subMessage);
         break;
       case PbFieldType._OPTIONAL_INT32:
-        fs._setFieldUnchecked(fi, input.readInt32());
+        fs._setFieldUnchecked(meta, fi, input.readInt32());
         break;
       case PbFieldType._OPTIONAL_INT64:
-        fs._setFieldUnchecked(fi, input.readInt64());
+        fs._setFieldUnchecked(meta, fi, input.readInt64());
         break;
       case PbFieldType._OPTIONAL_SINT32:
-        fs._setFieldUnchecked(fi, input.readSint32());
+        fs._setFieldUnchecked(meta, fi, input.readSint32());
         break;
       case PbFieldType._OPTIONAL_SINT64:
-        fs._setFieldUnchecked(fi, input.readSint64());
+        fs._setFieldUnchecked(meta, fi, input.readSint64());
         break;
       case PbFieldType._OPTIONAL_UINT32:
-        fs._setFieldUnchecked(fi, input.readUint32());
+        fs._setFieldUnchecked(meta, fi, input.readUint32());
         break;
       case PbFieldType._OPTIONAL_UINT64:
-        fs._setFieldUnchecked(fi, input.readUint64());
+        fs._setFieldUnchecked(meta, fi, input.readUint64());
         break;
       case PbFieldType._OPTIONAL_FIXED32:
-        fs._setFieldUnchecked(fi, input.readFixed32());
+        fs._setFieldUnchecked(meta, fi, input.readFixed32());
         break;
       case PbFieldType._OPTIONAL_FIXED64:
-        fs._setFieldUnchecked(fi, input.readFixed64());
+        fs._setFieldUnchecked(meta, fi, input.readFixed64());
         break;
       case PbFieldType._OPTIONAL_SFIXED32:
-        fs._setFieldUnchecked(fi, input.readSfixed32());
+        fs._setFieldUnchecked(meta, fi, input.readSfixed32());
         break;
       case PbFieldType._OPTIONAL_SFIXED64:
-        fs._setFieldUnchecked(fi, input.readSfixed64());
+        fs._setFieldUnchecked(meta, fi, input.readSfixed64());
         break;
       case PbFieldType._OPTIONAL_MESSAGE:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         var oldValue = fs._getFieldOrNull(fi);
         if (oldValue != null) {
           subMessage.mergeFromMessage(oldValue);
         }
         input.readMessage(subMessage, registry);
-        fs._setFieldUnchecked(fi, subMessage);
+        fs._setFieldUnchecked(meta, fi, subMessage);
         break;
       case PbFieldType._REPEATED_BOOL:
-        _readPackable(fs, input, wireType, fi, input.readBool);
+        _readPackable(meta, fs, input, wireType, fi, input.readBool);
         break;
       case PbFieldType._REPEATED_BYTES:
-        fs._ensureRepeatedField(fi).add(input.readBytes());
+        fs._ensureRepeatedField(meta, fi).add(input.readBytes());
         break;
       case PbFieldType._REPEATED_STRING:
-        fs._ensureRepeatedField(fi).add(input.readString());
+        fs._ensureRepeatedField(meta, fi).add(input.readString());
         break;
       case PbFieldType._REPEATED_FLOAT:
-        _readPackable(fs, input, wireType, fi, input.readFloat);
+        _readPackable(meta, fs, input, wireType, fi, input.readFloat);
         break;
       case PbFieldType._REPEATED_DOUBLE:
-        _readPackable(fs, input, wireType, fi, input.readDouble);
+        _readPackable(meta, fs, input, wireType, fi, input.readDouble);
         break;
       case PbFieldType._REPEATED_ENUM:
-        _readPackableToListEnum(fs, input, wireType, fi, tagNumber, registry);
+        _readPackableToListEnum(
+            meta, fs, input, wireType, fi, tagNumber, registry);
         break;
       case PbFieldType._REPEATED_GROUP:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readGroup(tagNumber, subMessage, registry);
-        fs._ensureRepeatedField(fi).add(subMessage);
+        fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
       case PbFieldType._REPEATED_INT32:
-        _readPackable(fs, input, wireType, fi, input.readInt32);
+        _readPackable(meta, fs, input, wireType, fi, input.readInt32);
         break;
       case PbFieldType._REPEATED_INT64:
-        _readPackable(fs, input, wireType, fi, input.readInt64);
+        _readPackable(meta, fs, input, wireType, fi, input.readInt64);
         break;
       case PbFieldType._REPEATED_SINT32:
-        _readPackable(fs, input, wireType, fi, input.readSint32);
+        _readPackable(meta, fs, input, wireType, fi, input.readSint32);
         break;
       case PbFieldType._REPEATED_SINT64:
-        _readPackable(fs, input, wireType, fi, input.readSint64);
+        _readPackable(meta, fs, input, wireType, fi, input.readSint64);
         break;
       case PbFieldType._REPEATED_UINT32:
-        _readPackable(fs, input, wireType, fi, input.readUint32);
+        _readPackable(meta, fs, input, wireType, fi, input.readUint32);
         break;
       case PbFieldType._REPEATED_UINT64:
-        _readPackable(fs, input, wireType, fi, input.readUint64);
+        _readPackable(meta, fs, input, wireType, fi, input.readUint64);
         break;
       case PbFieldType._REPEATED_FIXED32:
-        _readPackable(fs, input, wireType, fi, input.readFixed32);
+        _readPackable(meta, fs, input, wireType, fi, input.readFixed32);
         break;
       case PbFieldType._REPEATED_FIXED64:
-        _readPackable(fs, input, wireType, fi, input.readFixed64);
+        _readPackable(meta, fs, input, wireType, fi, input.readFixed64);
         break;
       case PbFieldType._REPEATED_SFIXED32:
-        _readPackable(fs, input, wireType, fi, input.readSfixed32);
+        _readPackable(meta, fs, input, wireType, fi, input.readSfixed32);
         break;
       case PbFieldType._REPEATED_SFIXED64:
-        _readPackable(fs, input, wireType, fi, input.readSfixed64);
+        _readPackable(meta, fs, input, wireType, fi, input.readSfixed64);
         break;
       case PbFieldType._REPEATED_MESSAGE:
-        var subMessage = fs._meta._makeEmptyMessage(tagNumber, registry);
+        var subMessage = meta._makeEmptyMessage(tagNumber, registry);
         input.readMessage(subMessage, registry);
-        fs._ensureRepeatedField(fi).add(subMessage);
+        fs._ensureRepeatedField(meta, fi).add(subMessage);
         break;
       case PbFieldType._MAP:
-        fs._ensureMapField(fi)._mergeEntry(input, registry);
+        final mapFieldInfo = fi as MapFieldInfo;
+        final mapEntryMeta = mapFieldInfo.mapEntryBuilderInfo;
+        fs
+            ._ensureMapField(meta, mapFieldInfo)
+            ._mergeEntry(mapEntryMeta, input, registry);
         break;
       default:
         throw 'Unknown field type $fieldType';
@@ -190,17 +194,23 @@ void _mergeFromCodedBufferReader(
   }
 }
 
-void _readPackable(_FieldSet fs, CodedBufferReader input, int wireType,
-    FieldInfo fi, Function readFunc) {
+void _readPackable(BuilderInfo meta, _FieldSet fs, CodedBufferReader input,
+    int wireType, FieldInfo fi, Function readFunc) {
   void readToList(List list) => list.add(readFunc());
-  _readPackableToList(fs, input, wireType, fi, readToList);
+  _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
 
-void _readPackableToListEnum(_FieldSet fs, CodedBufferReader input,
-    int wireType, FieldInfo fi, int tagNumber, ExtensionRegistry registry) {
+void _readPackableToListEnum(
+    BuilderInfo meta,
+    _FieldSet fs,
+    CodedBufferReader input,
+    int wireType,
+    FieldInfo fi,
+    int tagNumber,
+    ExtensionRegistry registry) {
   void readToList(List list) {
     var rawValue = input.readEnum();
-    var value = fs._meta._decodeEnum(tagNumber, registry, rawValue);
+    var value = meta._decodeEnum(tagNumber, registry, rawValue);
     if (value == null) {
       var unknown = fs._ensureUnknownFields();
       unknown.mergeVarintField(tagNumber, Int64(rawValue));
@@ -209,12 +219,12 @@ void _readPackableToListEnum(_FieldSet fs, CodedBufferReader input,
     }
   }
 
-  _readPackableToList(fs, input, wireType, fi, readToList);
+  _readPackableToList(meta, fs, input, wireType, fi, readToList);
 }
 
-void _readPackableToList(_FieldSet fs, CodedBufferReader input, int wireType,
-    FieldInfo fi, Function readToList) {
-  var list = fs._ensureRepeatedField(fi);
+void _readPackableToList(BuilderInfo meta, _FieldSet fs,
+    CodedBufferReader input, int wireType, FieldInfo fi, Function readToList) {
+  var list = fs._ensureRepeatedField(meta, fi);
 
   if (wireType == WIRETYPE_LENGTH_DELIMITED) {
     // Packed.

--- a/protobuf/lib/src/protobuf/coded_buffer_writer.dart
+++ b/protobuf/lib/src/protobuf/coded_buffer_writer.dart
@@ -37,14 +37,14 @@ class CodedBufferWriter {
 
   /// Current chunk used to write data into. Once it is full it is
   /// pushed into [_outputChunks] and a new one is allocated.
-  Uint8List _outputChunk;
+  Uint8List? _outputChunk;
 
   /// Number of bytes written into the [_outputChunk].
   int _bytesInChunk = 0;
 
   /// ByteData pointing to [_outputChunk]. Used to write primitive values
   /// more efficiently.
-  ByteData _outputChunkAsByteData;
+  ByteData? _outputChunkAsByteData;
 
   /// Array of pairs <Uint8List chunk, int bytesInChunk> - chunks are
   /// pushed into this array once they are full.
@@ -186,7 +186,7 @@ class CodedBufferWriter {
     if (allocateNew) {
       _outputChunk = Uint8List(_chunkLength);
       _bytesInChunk = 0;
-      _outputChunkAsByteData = ByteData.view(_outputChunk.buffer);
+      _outputChunkAsByteData = ByteData.view(_outputChunk!.buffer);
     } else {
       _outputChunk = _outputChunkAsByteData = null;
       _bytesInChunk = 0;
@@ -242,7 +242,7 @@ class CodedBufferWriter {
   }
 
   void _endLengthDelimited(int index) {
-    final int writtenSizeInBytes = _bytesTotal - _splices[index];
+    final writtenSizeInBytes = _bytesTotal - _splices[index] as int;
     // Note: 0 - writtenSizeInBytes to avoid -0.0 in JavaScript.
     _splices[index] = 0 - writtenSizeInBytes;
     _bytesTotal += _varint32LengthInBytes(writtenSizeInBytes);
@@ -261,10 +261,10 @@ class CodedBufferWriter {
     _ensureBytes(5);
     var i = _bytesInChunk;
     while (value >= 0x80) {
-      _outputChunk[i++] = 0x80 | (value & 0x7f);
+      _outputChunk![i++] = 0x80 | (value & 0x7f);
       value >>= 7;
     }
-    _outputChunk[i++] = value;
+    _outputChunk![i++] = value;
     _bytesTotal += (i - _bytesInChunk);
     _bytesInChunk = i;
   }
@@ -275,11 +275,11 @@ class CodedBufferWriter {
     var lo = value.toUnsigned(32).toInt();
     var hi = (value >> 32).toUnsigned(32).toInt();
     while (hi > 0 || lo >= 0x80) {
-      _outputChunk[i++] = 0x80 | (lo & 0x7f);
+      _outputChunk![i++] = 0x80 | (lo & 0x7f);
       lo = (lo >> 7) | ((hi & 0x7f) << 25);
       hi >>= 7;
     }
-    _outputChunk[i++] = lo;
+    _outputChunk![i++] = lo;
     _bytesTotal += (i - _bytesInChunk);
     _bytesInChunk = i;
   }
@@ -291,7 +291,7 @@ class CodedBufferWriter {
       return;
     }
     _ensureBytes(8);
-    _outputChunkAsByteData.setFloat64(_bytesInChunk, value, Endian.little);
+    _outputChunkAsByteData!.setFloat64(_bytesInChunk, value, Endian.little);
     _bytesInChunk += 8;
     _bytesTotal += 8;
   }
@@ -308,7 +308,7 @@ class CodedBufferWriter {
     } else {
       const sz = 4;
       _ensureBytes(sz);
-      _outputChunkAsByteData.setFloat32(_bytesInChunk, value, Endian.little);
+      _outputChunkAsByteData!.setFloat32(_bytesInChunk, value, Endian.little);
       _bytesInChunk += sz;
       _bytesTotal += sz;
     }
@@ -317,8 +317,8 @@ class CodedBufferWriter {
   void _writeInt32(int value) {
     const sizeInBytes = 4;
     _ensureBytes(sizeInBytes);
-    _outputChunkAsByteData.setInt32(
-        _bytesInChunk, value & 0xFFFFFFFF, Endian.little);
+    _outputChunkAsByteData!
+        .setInt32(_bytesInChunk, value & 0xFFFFFFFF, Endian.little);
     _bytesInChunk += sizeInBytes;
     _bytesTotal += sizeInBytes;
   }

--- a/protobuf/lib/src/protobuf/extension.dart
+++ b/protobuf/lib/src/protobuf/extension.dart
@@ -10,10 +10,10 @@ class Extension<T> extends FieldInfo<T> {
 
   Extension(this.extendee, String name, int tagNumber, int fieldType,
       {dynamic defaultOrMaker,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName})
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName})
       : super(name, tagNumber, null, fieldType,
             defaultOrMaker: defaultOrMaker,
             subBuilder: subBuilder,
@@ -22,11 +22,11 @@ class Extension<T> extends FieldInfo<T> {
             protoName: protoName);
 
   Extension.repeated(this.extendee, String name, int tagNumber, int fieldType,
-      {CheckFunc<T> check,
-      CreateBuilderFunc subBuilder,
-      ValueOfFunc valueOf,
-      List<ProtobufEnum> enumValues,
-      String protoName})
+      {CheckFunc<T>? check,
+      CreateBuilderFunc? subBuilder,
+      ValueOfFunc? valueOf,
+      List<ProtobufEnum>? enumValues,
+      String? protoName})
       : super.repeated(name, tagNumber, null, fieldType, check, subBuilder,
             valueOf: valueOf, enumValues: enumValues, protoName: protoName);
 
@@ -37,7 +37,7 @@ class Extension<T> extends FieldInfo<T> {
   bool operator ==(other) {
     if (other is! Extension) return false;
 
-    Extension o = other;
+    var o = other;
     return extendee == o.extendee && tagNumber == o.tagNumber;
   }
 }

--- a/protobuf/lib/src/protobuf/extension_field_set.dart
+++ b/protobuf/lib/src/protobuf/extension_field_set.dart
@@ -12,7 +12,7 @@ class _ExtensionFieldSet {
 
   _ExtensionFieldSet(this._parent);
 
-  Extension _getInfoOrNull(int tagNumber) => _info[tagNumber];
+  Extension? _getInfoOrNull(int? tagNumber) => _info[tagNumber];
 
   dynamic _getFieldOrDefault(Extension fi) {
     if (fi.isRepeated) return _getList(fi);
@@ -23,7 +23,7 @@ class _ExtensionFieldSet {
     var value = _getFieldOrNull(fi);
     if (value == null) {
       _checkNotInUnknown(fi);
-      return fi.makeDefault();
+      return fi.makeDefault!();
     }
     return value;
   }
@@ -39,7 +39,7 @@ class _ExtensionFieldSet {
   ///
   /// If it doesn't exist, creates the list and saves the extension.
   /// Suitable for public API and decoders.
-  List<T> _ensureRepeatedField<T>(Extension<T> fi) {
+  List<T?> _ensureRepeatedField<T>(Extension<T?> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     assert(fi.extendee == '' || fi.extendee == _parent._messageName);
@@ -47,20 +47,20 @@ class _ExtensionFieldSet {
     var list = _values[fi.tagNumber];
     if (list != null) return list as List<T>;
 
-    return _addInfoAndCreateList(fi);
+    return _addInfoAndCreateList(fi) as List<T?>;
   }
 
-  List<T> _getList<T>(Extension<T> fi) {
+  List<T?> _getList<T>(Extension<T?> fi) {
     var value = _values[fi.tagNumber];
     if (value != null) return value as List<T>;
     _checkNotInUnknown(fi);
     if (_isReadOnly) return List<T>.unmodifiable(const []);
-    return _addInfoAndCreateList(fi);
+    return _addInfoAndCreateList(fi) as List<T?>;
   }
 
   List _addInfoAndCreateList(Extension fi) {
     _validateInfo(fi);
-    var newList = fi._createRepeatedField(_parent._message);
+    var newList = fi._createRepeatedField(_parent._message!);
     _addInfoUnchecked(fi);
     _setFieldUnchecked(fi, newList);
     return newList;
@@ -76,7 +76,7 @@ class _ExtensionFieldSet {
   void _clearField(Extension fi) {
     _ensureWritable();
     _validateInfo(fi);
-    if (_parent._hasObservers) _parent._eventPlugin.beforeClearField(fi);
+    if (_parent._hasObservers) _parent._eventPlugin!.beforeClearField(fi);
     _values.remove(fi.tagNumber);
   }
 
@@ -130,7 +130,7 @@ class _ExtensionFieldSet {
 
   void _setFieldUnchecked(Extension fi, value) {
     if (_parent._hasObservers) {
-      _parent._eventPlugin.beforeSetField(fi, value);
+      _parent._eventPlugin!.beforeSetField(fi, value);
     }
     _values[fi.tagNumber] = value;
   }
@@ -142,7 +142,7 @@ class _ExtensionFieldSet {
 
   bool get _hasValues => _values.isNotEmpty;
 
-  bool _equalValues(_ExtensionFieldSet other) =>
+  bool _equalValues(_ExtensionFieldSet? other) =>
       other != null && _areMapsEqual(_values, other._values);
 
   void _clearValues() => _values.clear();
@@ -153,7 +153,7 @@ class _ExtensionFieldSet {
   /// Extensions cannot contain map fields.
   void _shallowCopyValues(_ExtensionFieldSet original) {
     for (var tagNumber in original._tagNumbers) {
-      var extension = original._getInfoOrNull(tagNumber);
+      var extension = original._getInfoOrNull(tagNumber)!;
       _addInfoUnchecked(extension);
 
       final value = original._getFieldOrNull(extension);
@@ -191,7 +191,7 @@ class _ExtensionFieldSet {
 
   void _checkNotInUnknown(Extension extension) {
     if (_parent._hasUnknownFields &&
-        _parent._unknownFields.hasField(extension.tagNumber)) {
+        _parent._unknownFields!.hasField(extension.tagNumber)) {
       throw StateError(
           'Trying to get $extension that is present as an unknown field. '
           'Parse the message with this extension in the extension registry or '

--- a/protobuf/lib/src/protobuf/extension_registry.dart
+++ b/protobuf/lib/src/protobuf/extension_registry.dart
@@ -26,7 +26,7 @@ class ExtensionRegistry {
 
   /// Retrieves an extension from the registry that adds tag number [tagNumber]
   /// to the [messageName] message type.
-  Extension getExtension(String messageName, int tagNumber) {
+  Extension? getExtension(String messageName, int tagNumber) {
     var map = _extensions[messageName];
     if (map != null) {
       return map[tagNumber];
@@ -92,18 +92,18 @@ class ExtensionRegistry {
 
 T _reparseMessage<T extends GeneratedMessage>(
     T message, ExtensionRegistry extensionRegistry) {
-  T result;
+  T? result;
   T ensureResult() {
     if (result == null) {
-      result ??= message.createEmptyInstance();
-      result._fieldSet._shallowCopyValues(message._fieldSet);
+      result ??= message.info_.createEmptyInstance!() as T;
+      result!._fieldSet._shallowCopyValues(message._fieldSet);
     }
-    return result;
+    return result!;
   }
 
-  UnknownFieldSet resultUnknownFields;
+  UnknownFieldSet? resultUnknownFields;
   UnknownFieldSet ensureUnknownFields() =>
-      resultUnknownFields ??= ensureResult()._fieldSet._unknownFields;
+      resultUnknownFields ??= ensureResult()._fieldSet._unknownFields!;
 
   var messageUnknownFields = message._fieldSet._unknownFields;
   if (messageUnknownFields != null) {
@@ -124,16 +124,16 @@ T _reparseMessage<T extends GeneratedMessage>(
   }
 
   message._fieldSet._meta.byIndex.forEach((FieldInfo field) {
-    PbList resultEntries;
+    PbList? resultEntries;
     PbList ensureEntries() =>
-        resultEntries ??= ensureResult()._fieldSet._values[field.index];
+        resultEntries ??= ensureResult()._fieldSet._values[field.index!];
 
-    PbMap resultMap;
+    PbMap? resultMap;
     PbMap ensureMap() =>
-        resultMap ??= ensureResult()._fieldSet._values[field.index];
+        resultMap ??= ensureResult()._fieldSet._values[field.index!];
 
     if (field.isRepeated) {
-      final messageEntries = message._fieldSet._values[field.index];
+      final messageEntries = message._fieldSet._values[field.index!];
       if (messageEntries == null) return;
       if (field.isGroupOrMessage) {
         for (var i = 0; i < messageEntries.length; i++) {
@@ -145,9 +145,9 @@ T _reparseMessage<T extends GeneratedMessage>(
         }
       }
     } else if (field is MapFieldInfo) {
-      final messageMap = message._fieldSet._values[field.index];
+      final messageMap = message._fieldSet._values[field.index!];
       if (messageMap == null) return;
-      if (_isGroupOrMessage(field.valueFieldType)) {
+      if (_isGroupOrMessage(field.valueFieldType!)) {
         for (var key in messageMap.keys) {
           final GeneratedMessage value = messageMap[key];
           final reparsedValue = _reparseMessage(value, extensionRegistry);
@@ -157,18 +157,18 @@ T _reparseMessage<T extends GeneratedMessage>(
         }
       }
     } else if (field.isGroupOrMessage) {
-      final messageSubField = message._fieldSet._values[field.index];
+      final messageSubField = message._fieldSet._values[field.index!];
       if (messageSubField == null) return;
       final reparsedSubField =
           _reparseMessage<GeneratedMessage>(messageSubField, extensionRegistry);
       if (!identical(messageSubField, reparsedSubField)) {
-        ensureResult()._fieldSet._values[field.index] = reparsedSubField;
+        ensureResult()._fieldSet._values[field.index!] = reparsedSubField;
       }
     }
   });
 
   if (result != null && message.isFrozen) {
-    result.freeze();
+    result!.freeze();
   }
 
   return result ?? message;
@@ -192,7 +192,7 @@ class _EmptyExtensionRegistry implements ExtensionRegistry {
   }
 
   @override
-  Extension getExtension(String messageName, int tagNumber) => null;
+  Extension? getExtension(String messageName, int tagNumber) => null;
 
   @override
   T reparseMessage<T extends GeneratedMessage>(T message) =>

--- a/protobuf/lib/src/protobuf/field_error.dart
+++ b/protobuf/lib/src/protobuf/field_error.dart
@@ -9,7 +9,7 @@ part of protobuf;
 ///
 /// For enums, group, and message fields, this check is only approximate,
 /// because the exact type isn't included in [fieldType].
-String _getFieldError(int fieldType, var value) {
+String? _getFieldError(int fieldType, var value) {
   switch (PbFieldType._baseType(fieldType)) {
     case PbFieldType._BOOL_BIT:
       if (value is! bool) return 'not type bool';
@@ -112,22 +112,24 @@ CheckFunc getCheckFunction(int fieldType) {
 
 // check functions for repeated fields
 
-void _checkNotNull(Object val) {
+void _checkNotNull(Object? val) {
   if (val == null) {
     throw ArgumentError("Can't add a null to a repeated field");
   }
 }
 
-void _checkFloat(Object val) {
-  if (!_isFloat32(val)) throw _createFieldRangeError(val, 'a float');
+void _checkFloat(Object? val) {
+  if (!_isFloat32(val as double)) throw _createFieldRangeError(val, 'a float');
 }
 
-void _checkSigned32(Object val) {
-  if (!_isSigned32(val)) throw _createFieldRangeError(val, 'a signed int32');
+void _checkSigned32(Object? val) {
+  if (!_isSigned32(val as int)) {
+    throw _createFieldRangeError(val, 'a signed int32');
+  }
 }
 
-void _checkUnsigned32(Object val) {
-  if (!_isUnsigned32(val)) {
+void _checkUnsigned32(Object? val) {
+  if (!_isUnsigned32(val as int)) {
     throw _createFieldRangeError(val, 'an unsigned int32');
   }
 }

--- a/protobuf/lib/src/protobuf/field_set.dart
+++ b/protobuf/lib/src/protobuf/field_set.dart
@@ -5,10 +5,10 @@
 part of protobuf;
 
 typedef FrozenMessageErrorHandler = void Function(String messageName,
-    [String methodName]);
+    [String? methodName]);
 
 void defaultFrozenMessageModificationHandler(String messageName,
-    [String methodName]) {
+    [String? methodName]) {
   if (methodName != null) {
     throw UnsupportedError(
         'Attempted to call $methodName on a read-only message ($messageName)');
@@ -48,9 +48,8 @@ bool _hashCodesCanBeMemoized = true;
 /// polymorphic access due to inheritance. This turns out to
 /// be faster when compiled to JavaScript.
 class _FieldSet {
-  final GeneratedMessage _message;
-  final BuilderInfo _meta;
-  final EventPlugin _eventPlugin;
+  final GeneratedMessage? _message;
+  final EventPlugin? _eventPlugin;
 
   /// The value of each non-extension field in a fixed-length array.
   /// The index of a field can be found in [FieldInfo.index].
@@ -58,10 +57,10 @@ class _FieldSet {
   final List _values;
 
   /// Contains all the extension fields, or null if there aren't any.
-  _ExtensionFieldSet _extensions;
+  _ExtensionFieldSet? _extensions;
 
   /// Contains all the unknown fields, or null if there aren't any.
-  UnknownFieldSet _unknownFields;
+  UnknownFieldSet? _unknownFields;
 
   /// Encodes whether `this` has been frozen, and if so, also memoizes the
   /// hash code.
@@ -74,12 +73,18 @@ class _FieldSet {
   /// code as an `int`.
   Object _frozenState = false;
 
+  /// The [BuilderInfo] for the [GeneratedMessage] this [_FieldSet] belongs to.
+  ///
+  /// WARNING: Avoid calling this for any performance critical code, instead
+  /// obtain the [BuilderInfo] on the call site.
+  BuilderInfo get _meta => _message!.info_;
+
   /// Returns the value of [_frozenState] as if it were a boolean indicator
   /// for whether `this` is read-only (has been frozen).
   ///
   /// If the value is not a `bool`, then it must contain the memoized hash code
   /// value, in which case the proto must be read-only.
-  bool get _isReadOnly => _frozenState is bool ? _frozenState : true;
+  bool get _isReadOnly => _frozenState is bool ? _frozenState as bool : true;
 
   /// Returns the value of [_frozenState] if it contains the pre-computed value
   /// of the hashCode for the frozen field sets.
@@ -90,15 +95,15 @@ class _FieldSet {
   ///
   /// If [_frozenState] contains a boolean, the hashCode hasn't been memoized,
   /// so it will return null.
-  int get _memoizedHashCode => _frozenState is int ? _frozenState : null;
+  int? get _memoizedHashCode =>
+      _frozenState is int ? _frozenState as int : null;
 
   // Maps a oneof decl index to the tag number which is currently set. If the
   // index is not present, the oneof field is unset.
-  final Map<int, int> _oneofCases;
+  final Map<int, int>? _oneofCases;
 
   _FieldSet(this._message, BuilderInfo meta, this._eventPlugin)
-      : _meta = meta,
-        _values = _makeValueList(meta.byIndex.length),
+      : _values = _makeValueList(meta.byIndex.length),
         _oneofCases = meta.oneofs.isEmpty ? null : <int, int>{};
 
   static List _makeValueList(int length) {
@@ -122,14 +127,14 @@ class _FieldSet {
   Iterable<FieldInfo> get _infosSortedByTag => _meta.sortedByTag;
 
   /// Returns true if we should send events to the plugin.
-  bool get _hasObservers => _eventPlugin != null && _eventPlugin.hasObservers;
+  bool get _hasObservers => _eventPlugin != null && _eventPlugin!.hasObservers;
 
   bool get _hasExtensions => _extensions != null;
   bool get _hasUnknownFields => _unknownFields != null;
 
   _ExtensionFieldSet _ensureExtensions() {
     if (!_hasExtensions) _extensions = _ExtensionFieldSet(this);
-    return _extensions;
+    return _extensions!;
   }
 
   UnknownFieldSet _ensureUnknownFields() {
@@ -137,13 +142,14 @@ class _FieldSet {
       if (_isReadOnly) return UnknownFieldSet.emptyUnknownFieldSet;
       _unknownFields = UnknownFieldSet();
     }
-    return _unknownFields;
+    return _unknownFields!;
   }
 
   // Metadata about single fields
 
   /// Returns FieldInfo for a non-extension field, or null if not found.
-  FieldInfo _nonExtensionInfo(int tagNumber) => _meta.fieldInfo[tagNumber];
+  FieldInfo? _nonExtensionInfo(BuilderInfo meta, int? tagNumber) =>
+      meta.fieldInfo[tagNumber];
 
   /// Returns FieldInfo for a non-extension field.
   FieldInfo _nonExtensionInfoByIndex(int index) => _meta.byIndex[index];
@@ -157,11 +163,11 @@ class _FieldSet {
   }
 
   /// Returns the FieldInfo for a regular or extension field.
-  FieldInfo _getFieldInfoOrNull(int tagNumber) {
-    var fi = _nonExtensionInfo(tagNumber);
+  FieldInfo? _getFieldInfoOrNull(int tagNumber) {
+    var fi = _nonExtensionInfo(_meta, tagNumber);
     if (fi != null) return fi;
     if (!_hasExtensions) return null;
-    return _extensions._getInfoOrNull(tagNumber);
+    return _extensions!._getInfoOrNull(tagNumber);
   }
 
   void _markReadOnly() {
@@ -169,20 +175,20 @@ class _FieldSet {
     _frozenState = true;
     for (var field in _meta.sortedByTag) {
       if (field.isRepeated) {
-        final entries = _values[field.index];
+        final entries = _values[field.index!];
         if (entries == null) continue;
         if (field.isGroupOrMessage) {
           for (var subMessage in entries as List<GeneratedMessage>) {
             subMessage.freeze();
           }
         }
-        _values[field.index] = entries.toFrozenPbList();
+        _values[field.index!] = entries.toFrozenPbList();
       } else if (field.isMapField) {
-        PbMap map = _values[field.index];
+        PbMap? map = _values[field.index!];
         if (map == null) continue;
-        _values[field.index] = map.freeze();
+        _values[field.index!] = map.freeze();
       } else if (field.isGroupOrMessage) {
-        final entry = _values[field.index];
+        final entry = _values[field.index!];
         if (entry != null) {
           (entry as GeneratedMessage).freeze();
         }
@@ -209,30 +215,30 @@ class _FieldSet {
   /// Creates repeated fields (unless read-only).
   /// Suitable for public API.
   dynamic _getField(int tagNumber) {
-    var fi = _nonExtensionInfo(tagNumber);
+    var fi = _nonExtensionInfo(_meta, tagNumber);
     if (fi != null) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       if (value != null) return value;
       return _getDefault(fi);
     }
     if (_hasExtensions) {
-      var fi = _extensions._getInfoOrNull(tagNumber);
+      var fi = _extensions!._getInfoOrNull(tagNumber);
       if (fi != null) {
-        return _extensions._getFieldOrDefault(fi);
+        return _extensions!._getFieldOrDefault(fi);
       }
     }
     throw ArgumentError('tag $tagNumber not defined in $_messageName');
   }
 
   dynamic _getDefault(FieldInfo fi) {
-    if (!fi.isRepeated) return fi.makeDefault();
+    if (!fi.isRepeated) return fi.makeDefault!();
     if (_isReadOnly) return fi.readonlyDefault;
 
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:
     //   msg.mutableFoo().add(123);
-    var value = fi._createRepeatedField(_message);
-    _setNonExtensionFieldUnchecked(fi, value);
+    var value = fi._createRepeatedField(_message!);
+    _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;
   }
 
@@ -243,8 +249,8 @@ class _FieldSet {
     // TODO(skybrian) we could avoid this by generating another
     // method for repeated fields:
     //   msg.mutableFoo().add(123);
-    var value = fi._createRepeatedFieldWithType<T>(_message);
-    _setNonExtensionFieldUnchecked(fi, value);
+    var value = fi._createRepeatedFieldWithType<T>(_message!);
+    _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;
   }
 
@@ -252,12 +258,12 @@ class _FieldSet {
     assert(fi.isMapField);
 
     if (_isReadOnly) {
-      return PbMap<K, V>.unmodifiable(PbMap<K, V>(
-          fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo));
+      return PbMap<K, V>.unmodifiable(
+          PbMap<K, V>(fi.keyFieldType, fi.valueFieldType));
     }
 
-    var value = fi._createMapField(_message);
-    _setNonExtensionFieldUnchecked(fi, value);
+    var value = fi._createMapField(_message!);
+    _setNonExtensionFieldUnchecked(_meta, fi, value);
     return value;
   }
 
@@ -272,39 +278,40 @@ class _FieldSet {
   /// Works for both extended and non-extend fields.
   /// Works for both repeated and non-repeated fields.
   dynamic _getFieldOrNull(FieldInfo fi) {
-    if (fi.index != null) return _values[fi.index];
+    if (fi.index != null) return _values[fi.index!];
     if (!_hasExtensions) return null;
-    return _extensions._getFieldOrNull(fi);
+    return _extensions!._getFieldOrNull(fi as Extension<dynamic>);
   }
 
   bool _hasField(int tagNumber) {
-    var fi = _nonExtensionInfo(tagNumber);
-    if (fi != null) return _$has(fi.index);
+    var fi = _nonExtensionInfo(_meta, tagNumber);
+    if (fi != null) return _$has(fi.index!);
     if (!_hasExtensions) return false;
-    return _extensions._hasField(tagNumber);
+    return _extensions!._hasField(tagNumber);
   }
 
-  void _clearField(int tagNumber) {
+  void _clearField(int? tagNumber) {
     _ensureWritable();
-    var fi = _nonExtensionInfo(tagNumber);
+    final meta = _meta;
+    var fi = _nonExtensionInfo(meta, tagNumber);
     if (fi != null) {
       // clear a non-extension field
-      if (_hasObservers) _eventPlugin.beforeClearField(fi);
-      _values[fi.index] = null;
+      if (_hasObservers) _eventPlugin!.beforeClearField(fi);
+      _values[fi.index!] = null;
 
-      if (_meta.oneofs.containsKey(fi.tagNumber)) {
-        _oneofCases.remove(_meta.oneofs[fi.tagNumber]);
+      if (meta.oneofs.containsKey(fi.tagNumber)) {
+        _oneofCases!.remove(meta.oneofs[fi.tagNumber]);
       }
 
-      var oneofIndex = _meta.oneofs[fi.tagNumber];
-      if (oneofIndex != null) _oneofCases[oneofIndex] = 0;
+      var oneofIndex = meta.oneofs[fi.tagNumber];
+      if (oneofIndex != null) _oneofCases![oneofIndex] = 0;
       return;
     }
 
     if (_hasExtensions) {
-      var fi = _extensions._getInfoOrNull(tagNumber);
+      var fi = _extensions!._getInfoOrNull(tagNumber);
       if (fi != null) {
-        _extensions._clearField(fi);
+        _extensions!._clearField(fi);
         return;
       }
     }
@@ -317,15 +324,16 @@ class _FieldSet {
   ///
   /// Works for both extended and non-extended fields.
   /// Suitable for public API.
-  void _setField(int tagNumber, value) {
-    if (value == null) throw ArgumentError('value is null');
+  void _setField(int tagNumber, Object value) {
+    ArgumentError.checkNotNull(value, 'value');
 
-    var fi = _nonExtensionInfo(tagNumber);
+    final meta = _meta;
+    var fi = _nonExtensionInfo(meta, tagNumber);
     if (fi == null) {
       if (!_hasExtensions) {
         throw ArgumentError('tag $tagNumber not defined in $_messageName');
       }
-      _extensions._setField(tagNumber, value);
+      _extensions!._setField(tagNumber, value);
       return;
     }
 
@@ -334,22 +342,22 @@ class _FieldSet {
           fi, value, 'repeating field (use get + .add())'));
     }
     _validateField(fi, value);
-    _setNonExtensionFieldUnchecked(fi, value);
+    _setNonExtensionFieldUnchecked(meta, fi, value);
   }
 
   /// Sets a non-repeated field without validating it.
   ///
   /// Works for both extended and non-extended fields.
   /// Suitable for decoders that do their own validation.
-  void _setFieldUnchecked(FieldInfo fi, value) {
-    assert(fi != null);
+  void _setFieldUnchecked(BuilderInfo meta, FieldInfo fi, value) {
+    ArgumentError.checkNotNull(fi, 'fi');
     assert(!fi.isRepeated);
     if (fi.index == null) {
       _ensureExtensions()
-        .._addInfoUnchecked(fi)
+        .._addInfoUnchecked(fi as Extension<dynamic>)
         .._setFieldUnchecked(fi, value);
     } else {
-      _setNonExtensionFieldUnchecked(fi, value);
+      _setNonExtensionFieldUnchecked(meta, fi, value);
     }
   }
 
@@ -359,40 +367,40 @@ class _FieldSet {
   /// Creates and stores the repeated field if it doesn't exist.
   /// If it's an extension and the list doesn't exist, validates and stores it.
   /// Suitable for decoders.
-  List<T> _ensureRepeatedField<T>(FieldInfo<T> fi) {
+  List<T?> _ensureRepeatedField<T>(BuilderInfo meta, FieldInfo<T> fi) {
     assert(!_isReadOnly);
     assert(fi.isRepeated);
     if (fi.index == null) {
-      return _ensureExtensions()._ensureRepeatedField(fi);
+      return _ensureExtensions()._ensureRepeatedField(fi as Extension<T>);
     }
     var value = _getFieldOrNull(fi);
     if (value != null) return value as List<T>;
 
-    var newValue = fi._createRepeatedField(_message);
-    _setNonExtensionFieldUnchecked(fi, newValue);
+    var newValue = fi._createRepeatedField(_message!);
+    _setNonExtensionFieldUnchecked(meta, fi, newValue);
     return newValue;
   }
 
-  PbMap<K, V> _ensureMapField<K, V>(MapFieldInfo<K, V> fi) {
+  PbMap<K, V> _ensureMapField<K, V>(BuilderInfo meta, MapFieldInfo<K, V> fi) {
     assert(!_isReadOnly);
     assert(fi.isMapField);
     assert(fi.index != null); // Map fields are not allowed to be extensions.
 
     var value = _getFieldOrNull(fi);
-    if (value != null) return value as Map<K, V>;
+    if (value != null) return (value as Map<K, V>) as PbMap<K, V>;
 
-    var newValue = fi._createMapField(_message);
-    _setNonExtensionFieldUnchecked(fi, newValue);
-    return newValue;
+    var newValue = fi._createMapField(_message!);
+    _setNonExtensionFieldUnchecked(meta, fi, newValue);
+    return newValue as PbMap<K, V>;
   }
 
   /// Sets a non-extended field and fires events.
-  void _setNonExtensionFieldUnchecked(FieldInfo fi, value) {
+  void _setNonExtensionFieldUnchecked(BuilderInfo meta, FieldInfo fi, value) {
     var tag = fi.tagNumber;
-    var oneofIndex = _meta.oneofs[tag];
+    var oneofIndex = meta.oneofs[tag];
     if (oneofIndex != null) {
-      _clearField(_oneofCases[oneofIndex]);
-      _oneofCases[oneofIndex] = tag;
+      _clearField(_oneofCases![oneofIndex]);
+      _oneofCases![oneofIndex] = tag;
     }
 
     // It is important that the callback to the observers is not moved to the
@@ -400,15 +408,15 @@ class _FieldSet {
     // Otherwise the observers will be notified about 'clearField' and
     // 'setField' events in an incorrect order.
     if (_hasObservers) {
-      _eventPlugin.beforeSetField(fi, value);
+      _eventPlugin!.beforeSetField(fi, value);
     }
-    _values[fi.index] = value;
+    _values[fi.index!] = value;
   }
 
   // Generated method implementations
 
   /// The implementation of a generated getter.
-  T _$get<T>(int index, T defaultValue) {
+  T _$get<T>(int index, T? defaultValue) {
     var value = _values[index];
     if (value != null) return value as T;
     if (defaultValue != null) return defaultValue;
@@ -426,7 +434,7 @@ class _FieldSet {
 
   T _$ensure<T>(int index) {
     if (!_$has(index)) {
-      dynamic value = _nonExtensionInfoByIndex(index).subBuilder();
+      dynamic value = _nonExtensionInfoByIndex(index).subBuilder!();
       _$set(index, value);
       return value;
     }
@@ -439,18 +447,19 @@ class _FieldSet {
   List<T> _$getList<T>(int index) {
     var value = _values[index];
     if (value != null) return value as List<T>;
-    return _getDefaultList<T>(_nonExtensionInfoByIndex(index));
+    return _getDefaultList<T>(_nonExtensionInfoByIndex(index) as FieldInfo<T>);
   }
 
   /// The implementation of a generated getter for map fields.
-  Map<K, V> _$getMap<K, V>(int index) {
+  Map<K, V> _$getMap<K, V>(GeneratedMessage parentMessage, int index) {
     var value = _values[index];
     if (value != null) return value as Map<K, V>;
-    return _getDefaultMap<K, V>(_nonExtensionInfoByIndex(index));
+    return _getDefaultMap<K, V>(
+        _nonExtensionInfoByIndex(index) as MapFieldInfo<K, V>);
   }
 
   /// The implementation of a generated getter for `bool` fields.
-  bool _$getB(int index, bool defaultValue) {
+  bool _$getB(int index, bool? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -470,7 +479,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for int fields.
-  int _$getI(int index, int defaultValue) {
+  int _$getI(int index, int? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -490,7 +499,7 @@ class _FieldSet {
   }
 
   /// The implementation of a generated getter for String fields.
-  String _$getS(int index, String defaultValue) {
+  String _$getS(int index, String? defaultValue) {
     var value = _values[index];
     if (value == null) {
       if (defaultValue != null) return defaultValue;
@@ -530,7 +539,7 @@ class _FieldSet {
   /// In production, does no validation other than a null check.
   /// Only handles non-repeated, non-extension fields.
   /// Also, doesn't handle enums or messages which need per-type validation.
-  void _$set(int index, value) {
+  void _$set(int index, Object? value) {
     assert(!_nonExtensionInfoByIndex(index).isRepeated);
     assert(_$check(index, value));
     _ensureWritable();
@@ -538,14 +547,15 @@ class _FieldSet {
       _$check(index, value); // throw exception for null value
     }
     if (_hasObservers) {
-      _eventPlugin.beforeSetField(_nonExtensionInfoByIndex(index), value);
+      _eventPlugin!.beforeSetField(_nonExtensionInfoByIndex(index), value);
     }
-    var tag = _meta.byIndex[index].tagNumber;
-    var oneofIndex = _meta.oneofs[tag];
+    final meta = _meta;
+    var tag = meta.byIndex[index].tagNumber;
+    var oneofIndex = meta.oneofs[tag];
 
     if (oneofIndex != null) {
-      _clearField(_oneofCases[oneofIndex]);
-      _oneofCases[oneofIndex] = tag;
+      _clearField(_oneofCases![oneofIndex]);
+      _oneofCases![oneofIndex] = tag;
     }
     _values[index] = value;
   }
@@ -560,24 +570,24 @@ class _FieldSet {
   void _clear() {
     _ensureWritable();
     if (_unknownFields != null) {
-      _unknownFields.clear();
+      _unknownFields!.clear();
     }
 
     if (_hasObservers) {
       for (var fi in _infos) {
-        if (_values[fi.index] != null) {
-          _eventPlugin.beforeClearField(fi);
+        if (_values[fi.index!] != null) {
+          _eventPlugin!.beforeClearField(fi);
         }
       }
       if (_hasExtensions) {
-        for (var key in _extensions._tagNumbers) {
-          var fi = _extensions._getInfoOrNull(key);
-          _eventPlugin.beforeClearField(fi);
+        for (var key in _extensions!._tagNumbers) {
+          var fi = _extensions!._getInfoOrNull(key)!;
+          _eventPlugin!.beforeClearField(fi);
         }
       }
     }
     if (_values.isNotEmpty) _values.fillRange(0, _values.length, null);
-    if (_hasExtensions) _extensions._clearValues();
+    if (_hasExtensions) _extensions!._clearValues();
   }
 
   bool _equals(_FieldSet o) {
@@ -586,20 +596,22 @@ class _FieldSet {
       if (!_equalFieldValues(_values[i], o._values[i])) return false;
     }
 
-    if (!_hasExtensions || !_extensions._hasValues) {
+    if (!_hasExtensions || !_extensions!._hasValues) {
       // Check if other extensions are logically empty.
       // (Don't create them unnecessarily.)
-      if (o._hasExtensions && o._extensions._hasValues) {
+      if (o._hasExtensions && o._extensions!._hasValues) {
         return false;
       }
     } else {
-      if (!_extensions._equalValues(o._extensions)) return false;
+      if (!_extensions!._equalValues(o._extensions)) return false;
     }
 
-    if (_unknownFields == null || _unknownFields.isEmpty) {
+    if (_unknownFields == null || _unknownFields!.isEmpty) {
       // Check if other unknown fields is logically empty.
       // (Don't create them unnecessarily.)
-      if (o._unknownFields != null && o._unknownFields.isNotEmpty) return false;
+      if (o._unknownFields != null && o._unknownFields!.isNotEmpty) {
+        return false;
+      }
     } else {
       // Check if the other unknown fields has the same fields.
       if (_unknownFields != o._unknownFields) return false;
@@ -640,7 +652,7 @@ class _FieldSet {
   /// behavior, the hashCode can be memoized to speed up performance.
   int get _hashCode {
     if (_hashCodesCanBeMemoized && _memoizedHashCode != null) {
-      return _memoizedHashCode;
+      return _memoizedHashCode!;
     }
     // Hashes the value of one field (recursively).
     int hashField(int hash, FieldInfo fi, value) {
@@ -667,15 +679,15 @@ class _FieldSet {
 
     int hashEachField(int hash) {
       //non-extension fields
-      hash = _infosSortedByTag.where((fi) => _values[fi.index] != null).fold(
-          hash, (int h, FieldInfo fi) => hashField(h, fi, _values[fi.index]));
+      hash = _infosSortedByTag.where((fi) => _values[fi.index!] != null).fold(
+          hash, (int h, FieldInfo fi) => hashField(h, fi, _values[fi.index!]));
 
       if (!_hasExtensions) return hash;
 
       hash =
-          _sorted(_extensions._tagNumbers).fold(hash, (int h, int tagNumber) {
-        var fi = _extensions._getInfoOrNull(tagNumber);
-        return hashField(h, fi, _extensions._getFieldOrNull(fi));
+          _sorted(_extensions!._tagNumbers).fold(hash, (int h, int tagNumber) {
+        var fi = _extensions!._getInfoOrNull(tagNumber)!;
+        return hashField(h, fi, _extensions!._getFieldOrNull(fi));
       });
 
       return hash;
@@ -728,15 +740,15 @@ class _FieldSet {
       }
     }
 
-    _infosSortedByTag
-        .forEach((FieldInfo fi) => writeFieldValue(_values[fi.index], fi.name));
+    _infosSortedByTag.forEach(
+        (FieldInfo fi) => writeFieldValue(_values[fi.index!], fi.name));
 
     if (_hasExtensions) {
-      _extensions._info.keys.toList()
+      _extensions!._info.keys.toList()
         ..sort()
         ..forEach((int tagNumber) => writeFieldValue(
-            _extensions._values[tagNumber],
-            '[${_extensions._info[tagNumber].name}]'));
+            _extensions!._values[tagNumber],
+            '[${_extensions!._info[tagNumber]!.name}]'));
     }
     if (_hasUnknownFields) {
       out.write(_unknownFields.toString());
@@ -757,40 +769,41 @@ class _FieldSet {
     // validation checks.
 
     for (var fi in other._infosSortedByTag) {
-      var value = other._values[fi.index];
+      var value = other._values[fi.index!];
       if (value != null) _mergeField(fi, value, isExtension: false);
     }
     if (other._hasExtensions) {
-      var others = other._extensions;
+      var others = other._extensions!;
       for (var tagNumber in others._tagNumbers) {
-        var extension = others._getInfoOrNull(tagNumber);
+        var extension = others._getInfoOrNull(tagNumber)!;
         var value = others._getFieldOrNull(extension);
         _mergeField(extension, value, isExtension: true);
       }
     }
 
     if (other._hasUnknownFields) {
-      _ensureUnknownFields().mergeFromUnknownFieldSet(other._unknownFields);
+      _ensureUnknownFields().mergeFromUnknownFieldSet(other._unknownFields!);
     }
   }
 
-  void _mergeField(FieldInfo otherFi, fieldValue, {bool isExtension}) {
-    var tagNumber = otherFi.tagNumber;
+  void _mergeField(FieldInfo otherFi, fieldValue, {bool? isExtension}) {
+    final tagNumber = otherFi.tagNumber;
 
     // Determine the FieldInfo to use.
     // Don't allow regular fields to be overwritten by extensions.
-    var fi = _nonExtensionInfo(tagNumber);
-    if (fi == null && isExtension) {
+    final meta = _meta;
+    var fi = _nonExtensionInfo(meta, tagNumber);
+    if (fi == null && isExtension!) {
       // This will overwrite any existing extension field info.
       fi = otherFi;
     }
 
     var mustClone = _isGroupOrMessage(otherFi.type);
 
-    if (fi.isMapField) {
-      MapFieldInfo f = fi;
-      mustClone = _isGroupOrMessage(f.valueFieldType);
-      PbMap map = f._ensureMapField(this);
+    if (fi!.isMapField) {
+      var f = fi as MapFieldInfo<dynamic, dynamic>;
+      mustClone = _isGroupOrMessage(f.valueFieldType!);
+      var map = f._ensureMapField(meta, this) as PbMap<dynamic, dynamic>;
       if (mustClone) {
         for (MapEntry entry in fieldValue.entries) {
           map[entry.key] = (entry.value as GeneratedMessage).deepCopy();
@@ -805,22 +818,22 @@ class _FieldSet {
       if (mustClone) {
         // fieldValue must be a PbListBase of GeneratedMessage.
         PbListBase<GeneratedMessage> pbList = fieldValue;
-        var repeatedFields = fi._ensureRepeatedField(this);
+        var repeatedFields = fi._ensureRepeatedField(meta, this);
         for (var i = 0; i < pbList.length; ++i) {
           repeatedFields.add(pbList[i].deepCopy());
         }
       } else {
         // fieldValue must be at least a PbListBase.
         PbListBase pbList = fieldValue;
-        fi._ensureRepeatedField(this).addAll(pbList);
+        fi._ensureRepeatedField(meta, this).addAll(pbList);
       }
       return;
     }
 
     if (otherFi.isGroupOrMessage) {
-      final currentFi = isExtension
-          ? _ensureExtensions()._getFieldOrNull(fi)
-          : _values[fi.index];
+      final currentFi = isExtension!
+          ? _ensureExtensions()._getFieldOrNull(fi as Extension<dynamic>)
+          : _values[fi.index!];
 
       if (currentFi == null) {
         fieldValue = (fieldValue as GeneratedMessage).deepCopy();
@@ -829,11 +842,12 @@ class _FieldSet {
       }
     }
 
-    if (isExtension) {
-      _ensureExtensions()._setFieldAndInfo(fi, fieldValue);
+    if (isExtension!) {
+      _ensureExtensions()
+          ._setFieldAndInfo(fi as Extension<dynamic>, fieldValue);
     } else {
       _validateField(fi, fieldValue);
-      _setNonExtensionFieldUnchecked(fi, fieldValue);
+      _setNonExtensionFieldUnchecked(meta, fi, fieldValue);
     }
   }
 
@@ -856,7 +870,7 @@ class _FieldSet {
   bool _hasRequiredValues() {
     if (!_hasRequiredFields) return true;
     for (var fi in _infos) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       if (!fi._hasRequiredValues(value)) return false;
     }
     return _hasRequiredExtensionValues();
@@ -864,8 +878,8 @@ class _FieldSet {
 
   bool _hasRequiredExtensionValues() {
     if (!_hasExtensions) return true;
-    for (var fi in _extensions._infos) {
-      var value = _extensions._getFieldOrNull(fi);
+    for (var fi in _extensions!._infos) {
+      var value = _extensions!._getFieldOrNull(fi);
       if (!fi._hasRequiredValues(value)) return false;
     }
     return true; // No problems found.
@@ -875,7 +889,7 @@ class _FieldSet {
   void _appendInvalidFields(List<String> problems, String prefix) {
     if (!_hasRequiredFields) return;
     for (var fi in _infos) {
-      var value = _values[fi.index];
+      var value = _values[fi.index!];
       fi._appendInvalidFields(problems, value, prefix);
     }
     // TODO(skybrian): search extensions as well
@@ -887,31 +901,33 @@ class _FieldSet {
   /// Map fields and repeated fields are copied.
   void _shallowCopyValues(_FieldSet original) {
     _values.setRange(0, original._values.length, original._values);
-    for (var index = 0; index < _meta.byIndex.length; index++) {
-      var fieldInfo = _meta.byIndex[index];
+    final info = _meta;
+    for (var index = 0; index < info.byIndex.length; index++) {
+      var fieldInfo = info.byIndex[index];
       if (fieldInfo.isMapField) {
-        PbMap map = _values[index];
+        PbMap? map = _values[index];
         if (map != null) {
-          _values[index] = (fieldInfo as MapFieldInfo)._createMapField(_message)
+          _values[index] = (fieldInfo as MapFieldInfo)
+              ._createMapField(_message!)
             ..addAll(map);
         }
       } else if (fieldInfo.isRepeated) {
-        PbListBase list = _values[index];
+        PbListBase? list = _values[index];
         if (list != null) {
-          _values[index] = fieldInfo._createRepeatedField(_message)
+          _values[index] = fieldInfo._createRepeatedField(_message!)
             ..addAll(list);
         }
       }
     }
 
     if (original._hasExtensions) {
-      _ensureExtensions()._shallowCopyValues(original._extensions);
+      _ensureExtensions()._shallowCopyValues(original._extensions!);
     }
 
     if (original._hasUnknownFields) {
-      _ensureUnknownFields()._fields?.addAll(original._unknownFields._fields);
+      _ensureUnknownFields()._fields.addAll(original._unknownFields!._fields);
     }
 
-    _oneofCases?.addAll(original._oneofCases);
+    _oneofCases?.addAll(original._oneofCases!);
   }
 }

--- a/protobuf/lib/src/protobuf/field_type.dart
+++ b/protobuf/lib/src/protobuf/field_type.dart
@@ -26,7 +26,7 @@ class PbFieldType {
   static int _baseType(int fieldType) =>
       fieldType & ~(_REQUIRED_BIT | _REPEATED_BIT | _PACKED_BIT | _MAP_BIT);
 
-  static MakeDefaultFunc _defaultForType(int type) {
+  static MakeDefaultFunc? _defaultForType(int type) {
     switch (type) {
       case _OPTIONAL_BOOL:
       case _REQUIRED_BOOL:

--- a/protobuf/lib/src/protobuf/generated_message.dart
+++ b/protobuf/lib/src/protobuf/generated_message.dart
@@ -6,7 +6,7 @@ part of protobuf;
 
 typedef CreateBuilderFunc = GeneratedMessage Function();
 typedef MakeDefaultFunc = Function();
-typedef ValueOfFunc = ProtobufEnum Function(int value);
+typedef ValueOfFunc = ProtobufEnum? Function(int value);
 
 /// The base class for all protobuf message types.
 ///
@@ -17,23 +17,26 @@ typedef ValueOfFunc = ProtobufEnum Function(int value);
 /// GeneratedMessage_reservedNames and should be unlikely to be used in
 /// a proto file.
 abstract class GeneratedMessage {
-  _FieldSet _fieldSet;
+  _FieldSet? __fieldSet;
+
+  @pragma('dart2js:tryInline')
+  _FieldSet get _fieldSet => __fieldSet!;
 
   GeneratedMessage() {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
   }
 
   GeneratedMessage.fromBuffer(
       List<int> input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
     mergeFromBuffer(input, extensionRegistry);
   }
 
   GeneratedMessage.fromJson(String input, ExtensionRegistry extensionRegistry) {
-    _fieldSet = _FieldSet(this, info_, eventPlugin);
-    if (eventPlugin != null) eventPlugin.attach(this);
+    __fieldSet = _FieldSet(this, info_, eventPlugin);
+    if (eventPlugin != null) eventPlugin!.attach(this);
     mergeFromJson(input, extensionRegistry);
   }
 
@@ -42,7 +45,7 @@ abstract class GeneratedMessage {
 
   /// Subclasses can override this getter to be notified of changes
   /// to protobuf fields.
-  EventPlugin get eventPlugin => null;
+  EventPlugin? get eventPlugin => null;
 
   /// Creates a deep copy of the fields in this message.
   /// (The generated code uses [mergeFromMessage].)
@@ -114,7 +117,7 @@ abstract class GeneratedMessage {
   void clear() => _fieldSet._clear();
 
   // TODO(antonm): move to getters.
-  int getTagNumber(String fieldName) => info_.tagNumber(fieldName);
+  int? getTagNumber(String fieldName) => info_.tagNumber(fieldName);
 
   @override
   bool operator ==(other) {
@@ -171,8 +174,10 @@ abstract class GeneratedMessage {
       _writeToCodedBufferWriter(_fieldSet, output);
 
   void mergeFromCodedBufferReader(CodedBufferReader input,
-          [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) =>
-      _mergeFromCodedBufferReader(_fieldSet, input, extensionRegistry);
+      [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
+    final meta = _fieldSet._meta;
+    _mergeFromCodedBufferReader(meta, _fieldSet, input, extensionRegistry);
+  }
 
   /// Merges serialized protocol buffer data into this message.
   ///
@@ -185,7 +190,8 @@ abstract class GeneratedMessage {
   void mergeFromBuffer(List<int> input,
       [ExtensionRegistry extensionRegistry = ExtensionRegistry.EMPTY]) {
     var codedInput = CodedBufferReader(input);
-    _mergeFromCodedBufferReader(_fieldSet, codedInput, extensionRegistry);
+    final meta = _fieldSet._meta;
+    _mergeFromCodedBufferReader(meta, _fieldSet, codedInput, extensionRegistry);
     codedInput.checkLastTagWas(0);
   }
 
@@ -224,7 +230,7 @@ abstract class GeneratedMessage {
   /// The [typeRegistry] is be used for encoding `Any` messages. If an `Any`
   /// message encoding a type not in [typeRegistry] is encountered, an
   /// error is thrown.
-  Object toProto3Json(
+  Object? toProto3Json(
           {TypeRegistry typeRegistry = const TypeRegistry.empty()}) =>
       _writeToProto3Json(_fieldSet, typeRegistry);
 
@@ -254,7 +260,7 @@ abstract class GeneratedMessage {
   ///
   /// If the JSON is otherwise not formatted correctly (a String where a
   /// number was expected etc.) a [FormatException] is thrown.
-  void mergeFromProto3Json(Object json,
+  void mergeFromProto3Json(Object? json,
           {TypeRegistry typeRegistry = const TypeRegistry.empty(),
           bool ignoreUnknownFields = false,
           bool supportNamesWithUnderscores = true,
@@ -302,7 +308,7 @@ abstract class GeneratedMessage {
   /// Clears an extension field and also removes the extension.
   void clearExtension(Extension extension) {
     if (_fieldSet._hasExtensions) {
-      _fieldSet._extensions._clearFieldAndInfo(extension);
+      _fieldSet._extensions!._clearFieldAndInfo(extension);
     }
   }
 
@@ -312,7 +318,7 @@ abstract class GeneratedMessage {
   /// The tagNumber should be a valid tag or extension.
   void clearField(int tagNumber) => _fieldSet._clearField(tagNumber);
 
-  int $_whichOneof(int oneofIndex) => _fieldSet._oneofCases[oneofIndex] ?? 0;
+  int $_whichOneof(int oneofIndex) => _fieldSet._oneofCases![oneofIndex] ?? 0;
 
   bool extensionsAreInitialized() => _fieldSet._hasRequiredExtensionValues();
 
@@ -334,13 +340,12 @@ abstract class GeneratedMessage {
   /// validate all items added to it. This can most easily be done
   /// using the FieldInfo.check function.
   List<T> createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
-    return PbList<T>(check: fi.check);
+    return PbList<T>(check: fi.check!);
   }
 
   /// Creates a Map representing a map field.
   Map<K, V> createMapField<K, V>(int tagNumber, MapFieldInfo<K, V> fi) {
-    return PbMap<K, V>(
-        fi.keyFieldType, fi.valueFieldType, fi.mapEntryBuilderInfo);
+    return PbMap<K, V>(fi.keyFieldType, fi.valueFieldType);
   }
 
   /// Returns the value of a field, ignoring any defaults.
@@ -361,7 +366,7 @@ abstract class GeneratedMessage {
   /// Returns [:true:] if a value of [extension] is present.
   bool hasExtension(Extension extension) =>
       _fieldSet._hasExtensions &&
-      _fieldSet._extensions._getFieldOrNull(extension) != null;
+      _fieldSet._extensions!._getFieldOrNull(extension) != null;
 
   /// Returns [:true:] if this message has a field associated with [tagNumber].
   bool hasField(int tagNumber) => _fieldSet._hasField(tagNumber);
@@ -371,6 +376,7 @@ abstract class GeneratedMessage {
   /// Singular fields that are set in [other] overwrite the corresponding fields
   /// in this message. Repeated fields are appended. Singular sub-messages are
   /// recursively merged.
+  @pragma('dart2js:noInline')
   void mergeFromMessage(GeneratedMessage other) =>
       _fieldSet._mergeFromMessage(other._fieldSet);
 
@@ -379,8 +385,8 @@ abstract class GeneratedMessage {
       .mergeFromUnknownFieldSet(unknownFieldSet);
 
   /// Sets the value of a non-repeated extension field to [value].
-  void setExtension(Extension extension, value) {
-    if (value == null) throw ArgumentError('value is null');
+  void setExtension(Extension extension, Object value) {
+    ArgumentError.checkNotNull(value, 'value');
     if (_isRepeated(extension.type)) {
       throw ArgumentError(_fieldSet._setFieldFailedMessage(
           extension, value, 'repeating field (use get + .add())'));
@@ -395,7 +401,7 @@ abstract class GeneratedMessage {
   ///
   /// Throws an [:ArgumentError:] if [value] is [:null:]. To clear a field of
   /// it's current value, use [clearField] instead.
-  void setField(int tagNumber, value) {
+  void setField(int tagNumber, Object value) {
     _fieldSet._setField(tagNumber, value);
     return; // ignore: dead_code
     return; // ignore: dead_code
@@ -426,7 +432,7 @@ abstract class GeneratedMessage {
   List<T> $_getList<T>(int index) => _fieldSet._$getList<T>(index);
 
   /// For generated code only.
-  Map<K, V> $_getMap<K, V>(int index) => _fieldSet._$getMap<K, V>(index);
+  Map<K, V> $_getMap<K, V>(int index) => _fieldSet._$getMap<K, V>(this, index);
 
   /// For generated code only.
   bool $_getB(int index, bool defaultValue) =>
@@ -466,7 +472,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setFloat(int index, double value) {
-    if (value == null || !_isFloat32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isFloat32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -477,7 +484,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setSignedInt32(int index, int value) {
-    if (value == null || !_isSigned32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isSigned32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -485,7 +493,8 @@ abstract class GeneratedMessage {
 
   /// For generated code only.
   void $_setUnsignedInt32(int index, int value) {
-    if (value == null || !_isUnsigned32(value)) {
+    ArgumentError.checkNotNull(value, 'value');
+    if (!_isUnsigned32(value)) {
       _fieldSet._$check(index, value);
     }
     _fieldSet._$set(index, value);
@@ -496,16 +505,17 @@ abstract class GeneratedMessage {
 
   // Support for generating a read-only default singleton instance.
 
-  static final Map<Function, Function> _defaultMakers = {};
+  static final Map<Function?, Function> _defaultMakers = {};
 
   static T Function() _defaultMakerFor<T extends GeneratedMessage>(
-      T Function() createFn) {
-    return _defaultMakers[createFn] ??= _createDefaultMakerFor<T>(createFn);
+      T Function()? createFn) {
+    return (_defaultMakers[createFn] ??= _createDefaultMakerFor<T>(createFn!))
+        as T Function();
   }
 
   static T Function() _createDefaultMakerFor<T extends GeneratedMessage>(
       T Function() createFn) {
-    T defaultValue;
+    T? defaultValue;
     T defaultMaker() {
       return defaultValue ??= createFn()..freeze();
     }
@@ -537,10 +547,10 @@ extension GeneratedMessageGenericExtensions<T extends GeneratedMessage> on T {
       throw ArgumentError('Rebuilding only works on frozen messages.');
     }
     final t = toBuilder();
-    updates(t);
+    updates(t as T);
     return t..freeze();
   }
 
   /// Returns a writable deep copy of this message.
-  T deepCopy() => info_.createEmptyInstance()..mergeFromMessage(this);
+  T deepCopy() => info_.createEmptyInstance!() as T..mergeFromMessage(this);
 }

--- a/protobuf/lib/src/protobuf/json_parsing_context.dart
+++ b/protobuf/lib/src/protobuf/json_parsing_context.dart
@@ -25,7 +25,7 @@ class JsonParsingContext {
   }
 
   /// Returns a FormatException indicating the indices to the current [path].
-  Exception parseException(String message, Object source) {
+  Exception parseException(String message, Object? source) {
     var formattedPath = _path.map((s) => '[\"$s\"]').join();
     return FormatException(
         'Protobuf JSON decoding failed at: root$formattedPath. $message',

--- a/protobuf/lib/src/protobuf/mixins/event_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/event_mixin.dart
@@ -31,7 +31,7 @@ abstract class PbEventMixin {
 
 /// A change to a field in a GeneratedMessage.
 class PbFieldChange {
-  final GeneratedMessage message;
+  final GeneratedMessage? message;
   final FieldInfo info;
   final oldValue;
   final newValue;
@@ -47,33 +47,33 @@ class EventBuffer extends EventPlugin {
   // An EventBuffer is created for each GeneratedMessage, so
   // initialization should be fast; create fields lazily.
 
-  GeneratedMessage _parent;
-  StreamController<List<PbFieldChange>> _controller;
+  GeneratedMessage? _parent;
+  StreamController<List<PbFieldChange>>? _controller;
 
   // If _buffer is non-null, at least one event is in the buffer
   // and a microtask has been scheduled to empty it.
-  List<PbFieldChange> _buffer;
+  List<PbFieldChange>? _buffer;
 
   @override
   void attach(GeneratedMessage newParent) {
     assert(_parent == null);
-    assert(newParent != null);
+    ArgumentError.checkNotNull(newParent, 'newParent');
     _parent = newParent;
   }
 
   Stream<List<PbFieldChange>> get changes {
-    _controller ??= StreamController.broadcast(sync: true);
-    return _controller.stream;
+    var controller = _controller ??= StreamController.broadcast(sync: true);
+    return controller.stream;
   }
 
   @override
-  bool get hasObservers => _controller != null && _controller.hasListener;
+  bool get hasObservers => _controller != null && _controller!.hasListener;
 
   void deliverChanges() {
     var records = _buffer;
     _buffer = null;
     if (records != null && hasObservers) {
-      _controller.add(UnmodifiableListView<PbFieldChange>(records));
+      _controller!.add(UnmodifiableListView<PbFieldChange>(records));
     }
   }
 
@@ -83,12 +83,12 @@ class EventBuffer extends EventPlugin {
       _buffer = <PbFieldChange>[];
       scheduleMicrotask(deliverChanges);
     }
-    _buffer.add(change);
+    _buffer!.add(change);
   }
 
   @override
   void beforeSetField(FieldInfo fi, newValue) {
-    var oldValue = _parent.getFieldOrNull(fi.tagNumber);
+    var oldValue = _parent!.getFieldOrNull(fi.tagNumber);
     oldValue ??= fi.readonlyDefault;
     if (identical(oldValue, newValue)) return;
     addEvent(PbFieldChange(_parent, fi, oldValue, newValue));
@@ -96,7 +96,7 @@ class EventBuffer extends EventPlugin {
 
   @override
   void beforeClearField(FieldInfo fi) {
-    var oldValue = _parent.getFieldOrNull(fi.tagNumber);
+    var oldValue = _parent!.getFieldOrNull(fi.tagNumber);
     if (oldValue == null) return;
     var newValue = fi.readonlyDefault;
     addEvent(PbFieldChange(_parent, fi, oldValue, newValue));

--- a/protobuf/lib/src/protobuf/mixins/map_mixin.dart
+++ b/protobuf/lib/src/protobuf/mixins/map_mixin.dart
@@ -17,9 +17,9 @@ abstract class PbMapMixin {
 
   BuilderInfo get info_;
   void clear();
-  int getTagNumber(String fieldName);
+  int? getTagNumber(String fieldName);
   dynamic getField(int tagNumber);
-  void setField(int tagNumber, var value);
+  void setField(int tagNumber, Object value);
 
   dynamic operator [](key) {
     if (key is! String) return null;
@@ -39,7 +39,7 @@ abstract class PbMapMixin {
 
   Iterable<String> get keys => info_.byName.keys;
 
-  bool containsKey(Object key) => info_.byName.containsKey(key);
+  bool containsKey(Object? key) => info_.byName.containsKey(key);
 
   int get length => info_.byName.length;
 

--- a/protobuf/lib/src/protobuf/mixins/well_known.dart
+++ b/protobuf/lib/src/protobuf/mixins/well_known.dart
@@ -85,7 +85,7 @@ abstract class AnyMixin implements GeneratedMessage {
       throw ArgumentError(
           'The type of the Any message (${any.typeUrl}) is not in the given typeRegistry.');
     }
-    var unpacked = info.createEmptyInstance()..mergeFromBuffer(any.value);
+    var unpacked = info.createEmptyInstance!()..mergeFromBuffer(any.value);
     var proto3Json = unpacked.toProto3Json();
     if (info.toProto3Json == null) {
       var map = proto3Json as Map<String, dynamic>;
@@ -102,7 +102,7 @@ abstract class AnyMixin implements GeneratedMessage {
       throw context.parseException(
           'Expected Any message encoded as {@type,...},', json);
     }
-    final object = json as Map<String, dynamic>;
+    final object = json;
     final typeUrl = object['@type'];
 
     if (typeUrl is String) {
@@ -114,12 +114,12 @@ abstract class AnyMixin implements GeneratedMessage {
             json);
       }
 
-      Object subJson = info.fromProto3Json == null
+      Object? subJson = info.fromProto3Json == null
           // TODO(sigurdm): avoid cloning [object] here.
           ? (Map<String, dynamic>.from(object)..remove('@type'))
           : object['value'];
       // TODO(sigurdm): We lose [context.path].
-      var packedMessage = info.createEmptyInstance()
+      var packedMessage = info.createEmptyInstance!()
         ..mergeFromProto3Json(subJson,
             typeRegistry: typeRegistry,
             supportNamesWithUnderscores: context.supportNamesWithUnderscores,
@@ -231,9 +231,9 @@ abstract class TimestampMixin {
     if (json is String) {
       var jsonWithoutFracSec = json;
       var nanos = 0;
-      Match fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
+      Match? fracSecsMatch = RegExp(r'\.(\d+)').firstMatch(json);
       if (fracSecsMatch != null) {
-        var fracSecs = fracSecsMatch[1];
+        var fracSecs = fracSecsMatch[1]!;
         if (fracSecs.length > 9) {
           throw context.parseException(
               'Timestamp can have at most than 9 decimal digits', json);
@@ -290,7 +290,7 @@ abstract class DurationMixin {
         throw context.parseException(
             'Expected a String of the form `<seconds>.<nanos>s`', json);
       } else {
-        var secondsString = match[1];
+        var secondsString = match[1]!;
         var seconds =
             secondsString == '' ? Int64.ZERO : Int64.parseInt(secondsString);
         duration.seconds = seconds;
@@ -326,13 +326,13 @@ abstract class StructMixin implements GeneratedMessage {
         var fields = (message as StructMixin).fields;
         var valueCreator =
             (message.info_.fieldInfo[_fieldsFieldTagNumber] as MapFieldInfo)
-                .valueCreator;
+                .valueCreator!;
 
         json.forEach((key, value) {
           if (key is! String) {
             throw context.parseException('Expected String key', json);
           }
-          ValueMixin v = valueCreator();
+          var v = valueCreator() as ValueMixin;
           context.addMapIndex(key);
           ValueMixin.fromProto3JsonHelper(v, value, typeRegistry, context);
           context.popIndex();
@@ -368,7 +368,7 @@ abstract class ValueMixin implements GeneratedMessage {
 
   // From google/protobuf/struct.proto:
   // The JSON representation for `Value` is JSON value
-  static Object toProto3JsonHelper(
+  static Object? toProto3JsonHelper(
       GeneratedMessage message, TypeRegistry typeRegistry) {
     var value = message as ValueMixin;
     // This would ideally be a switch, but we cannot import the enum we are
@@ -390,7 +390,7 @@ abstract class ValueMixin implements GeneratedMessage {
     }
   }
 
-  static void fromProto3JsonHelper(GeneratedMessage message, Object json,
+  static void fromProto3JsonHelper(GeneratedMessage message, Object? json,
       TypeRegistry typeRegistry, JsonParsingContext context) {
     var value = message as ValueMixin;
     if (json == null) {
@@ -441,10 +441,10 @@ abstract class ListValueMixin implements GeneratedMessage {
       TypeRegistry typeRegistry, JsonParsingContext context) {
     var list = message as ListValueMixin;
     if (json is List) {
-      var subBuilder = message.info_.subBuilder(_valueFieldTagNumber);
+      var subBuilder = message.info_.subBuilder(_valueFieldTagNumber)!;
       for (var i = 0; i < json.length; i++) {
         Object element = json[i];
-        ValueMixin v = subBuilder();
+        var v = subBuilder() as ValueMixin;
         context.addListIndex(i);
         ValueMixin.fromProto3JsonHelper(v, element, typeRegistry, context);
         context.popIndex();
@@ -499,12 +499,12 @@ abstract class FieldMaskMixin {
 
   static String _toCamelCase(String name) {
     return name.replaceAllMapped(
-        RegExp('_([a-z])'), (Match m) => '${m.group(1).toUpperCase()}');
+        RegExp('_([a-z])'), (Match m) => '${m.group(1)!.toUpperCase()}');
   }
 
   static String _fromCamelCase(String name) {
     return name.replaceAllMapped(
-        RegExp('[A-Z]'), (Match m) => '_${m.group(0).toLowerCase()}');
+        RegExp('[A-Z]'), (Match m) => '_${m.group(0)!.toLowerCase()}');
   }
 }
 

--- a/protobuf/lib/src/protobuf/pb_list.dart
+++ b/protobuf/lib/src/protobuf/pb_list.dart
@@ -4,7 +4,7 @@
 
 part of protobuf;
 
-typedef CheckFunc<E> = void Function(E x);
+typedef CheckFunc<E> = void Function(E? x);
 
 class FrozenPbList<E> extends PbListBase<E> {
   FrozenPbList._(List<E> wrappedList) : super._(wrappedList);
@@ -22,7 +22,7 @@ class FrozenPbList<E> extends PbListBase<E> {
   @override
   void setAll(int at, Iterable<E> iterable) => throw _unsupported('setAll');
   @override
-  void add(E value) => throw _unsupported('add');
+  void add(E? value) => throw _unsupported('add');
   @override
   void addAll(Iterable<E> iterable) => throw _unsupported('addAll');
   @override
@@ -31,7 +31,7 @@ class FrozenPbList<E> extends PbListBase<E> {
   void insertAll(int at, Iterable<E> iterable) =>
       throw _unsupported('insertAll');
   @override
-  bool remove(Object element) => throw _unsupported('remove');
+  bool remove(Object? element) => throw _unsupported('remove');
   @override
   void removeWhere(bool Function(E element) test) =>
       throw _unsupported('removeWhere');
@@ -39,9 +39,9 @@ class FrozenPbList<E> extends PbListBase<E> {
   void retainWhere(bool Function(E element) test) =>
       throw _unsupported('retainWhere');
   @override
-  void sort([Comparator<E> compare]) => throw _unsupported('sort');
+  void sort([Comparator<E>? compare]) => throw _unsupported('sort');
   @override
-  void shuffle([math.Random random]) => throw _unsupported('shuffle');
+  void shuffle([math.Random? random]) => throw _unsupported('shuffle');
   @override
   void clear() => throw _unsupported('clear');
   @override
@@ -58,12 +58,12 @@ class FrozenPbList<E> extends PbListBase<E> {
   void replaceRange(int start, int end, Iterable<E> iterable) =>
       throw _unsupported('replaceRange');
   @override
-  void fillRange(int start, int end, [E fillValue]) =>
+  void fillRange(int start, int end, [E? fillValue]) =>
       throw _unsupported('fillRange');
 }
 
 class PbList<E> extends PbListBase<E> {
-  PbList({check = _checkNotNull}) : super._noList(check: check);
+  PbList({CheckFunc<E> check = _checkNotNull}) : super._noList(check: check);
 
   PbList.from(List from) : super._from(from);
 
@@ -99,11 +99,11 @@ class PbList<E> extends PbListBase<E> {
   /// Sorts this list according to the order specified by the [compare]
   /// function.
   @override
-  void sort([int Function(E a, E b) compare]) => _wrappedList.sort(compare);
+  void sort([int Function(E a, E b)? compare]) => _wrappedList.sort(compare);
 
   /// Shuffles the elements of this list randomly.
   @override
-  void shuffle([math.Random random]) => _wrappedList.shuffle(random);
+  void shuffle([math.Random? random]) => _wrappedList.shuffle(random);
 
   /// Removes all objects from this list; the length of the list becomes zero.
   @override
@@ -138,7 +138,7 @@ class PbList<E> extends PbListBase<E> {
 
   /// Removes the first occurrence of [value] from this list.
   @override
-  bool remove(Object value) => _wrappedList.remove(value);
+  bool remove(Object? value) => _wrappedList.remove(value);
 
   /// Removes the object at position [index] from this list.
   @override
@@ -176,7 +176,7 @@ class PbList<E> extends PbListBase<E> {
   /// Sets the objects in the range [start] inclusive to [end] exclusive to the
   /// given [fillValue].
   @override
-  void fillRange(int start, int end, [E fillValue]) {
+  void fillRange(int start, int end, [E? fillValue]) {
     check(fillValue);
     _wrappedList.fillRange(start, end, fillValue);
   }
@@ -198,7 +198,7 @@ abstract class PbListBase<E> extends ListBase<E> {
   PbListBase._(this._wrappedList, {this.check = _checkNotNull});
 
   PbListBase._noList({this.check = _checkNotNull}) : _wrappedList = <E>[] {
-    assert(check != null);
+    ArgumentError.checkNotNull(check, 'check');
   }
 
   PbListBase._from(List from)
@@ -234,7 +234,7 @@ abstract class PbListBase<E> extends ListBase<E> {
 
   /// Returns true if the collection contains an element equal to [element].
   @override
-  bool contains(Object element) => _wrappedList.contains(element);
+  bool contains(Object? element) => _wrappedList.contains(element);
 
   /// Applies the function [f] to each element of this list in iteration order.
   @override
@@ -316,12 +316,12 @@ abstract class PbListBase<E> extends ListBase<E> {
 
   /// Returns the first element that satisfies the given predicate [test].
   @override
-  E firstWhere(bool Function(E element) test, {E Function() orElse}) =>
+  E firstWhere(bool Function(E element) test, {E Function()? orElse}) =>
       _wrappedList.firstWhere(test, orElse: orElse);
 
   /// Returns the last element that satisfies the given predicate [test].
   @override
-  E lastWhere(bool Function(E element) test, {E Function() orElse}) =>
+  E lastWhere(bool Function(E element) test, {E Function()? orElse}) =>
       _wrappedList.lastWhere(test, orElse: orElse);
 
   /// Returns the single element that satisfies [test].
@@ -349,19 +349,19 @@ abstract class PbListBase<E> extends ListBase<E> {
   // TODO(jakobr): E instead of Object once dart-lang/sdk#31311 is fixed.
   /// Returns the first index of [element] in this list.
   @override
-  int indexOf(Object element, [int start = 0]) =>
-      _wrappedList.indexOf(element, start);
+  int indexOf(Object? element, [int start = 0]) =>
+      _wrappedList.indexOf(element as E, start);
 
   // TODO(jakobr): E instead of Object once dart-lang/sdk#31311 is fixed.
   /// Returns the last index of [element] in this list.
   @override
-  int lastIndexOf(Object element, [int start]) =>
-      _wrappedList.lastIndexOf(element, start);
+  int lastIndexOf(Object? element, [int? start]) =>
+      _wrappedList.lastIndexOf(element as E, start);
 
   /// Returns a new list containing the objects from [start] inclusive to [end]
   /// exclusive.
   @override
-  List<E> sublist(int start, [int end]) => _wrappedList.sublist(start, end);
+  List<E> sublist(int start, [int? end]) => _wrappedList.sublist(start, end);
 
   /// Returns an [Iterable] that iterates over the objects in the range [start]
   /// inclusive to [end] exclusive.

--- a/protobuf/lib/src/protobuf/readonly_message.dart
+++ b/protobuf/lib/src/protobuf/readonly_message.dart
@@ -17,7 +17,7 @@ abstract class ReadonlyMessageMixin {
 
   void clearField(int tagNumber) => _readonly('clearField');
 
-  List<T> createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
+  List<T>? createRepeatedField<T>(int tagNumber, FieldInfo<T> fi) {
     _readonly('createRepeatedField');
     return null; // not reached
   }
@@ -47,7 +47,7 @@ abstract class ReadonlyMessageMixin {
   void setExtension(Extension extension, var value) =>
       _readonly('setExtension');
 
-  void setField(int tagNumber, var value, [int fieldType]) =>
+  void setField(int tagNumber, var value, [int? fieldType]) =>
       _readonly('setField');
 
   void _readonly(String methodName) {

--- a/protobuf/lib/src/protobuf/rpc_client.dart
+++ b/protobuf/lib/src/protobuf/rpc_client.dart
@@ -7,7 +7,7 @@ part of protobuf;
 /// Client side context.
 class ClientContext {
   /// The desired timeout of the RPC call.
-  final Duration timeout;
+  final Duration? timeout;
 
   ClientContext({this.timeout});
 }
@@ -28,7 +28,7 @@ abstract class RpcClient {
   /// appropriate. It should merge the reply into [emptyResponse] and
   /// return it.
   Future<T> invoke<T extends GeneratedMessage>(
-      ClientContext ctx,
+      ClientContext? ctx,
       String serviceName,
       String methodName,
       GeneratedMessage request,

--- a/protobuf/lib/src/protobuf/type_registry.dart
+++ b/protobuf/lib/src/protobuf/type_registry.dart
@@ -26,7 +26,7 @@ class TypeRegistry {
 
   const TypeRegistry.empty() : _mapping = const {};
 
-  BuilderInfo lookup(String qualifiedName) {
+  BuilderInfo? lookup(String qualifiedName) {
     return _mapping[qualifiedName];
   }
 }

--- a/protobuf/lib/src/protobuf/unknown_field_set.dart
+++ b/protobuf/lib/src/protobuf/unknown_field_set.dart
@@ -28,7 +28,7 @@ class UnknownFieldSet {
     _fields.clear();
   }
 
-  UnknownFieldSetField getField(int tagNumber) => _fields[tagNumber];
+  UnknownFieldSetField? getField(int tagNumber) => _fields[tagNumber];
 
   bool hasField(int tagNumber) => _fields.containsKey(tagNumber);
 
@@ -88,7 +88,7 @@ class UnknownFieldSet {
   void mergeFromUnknownFieldSet(UnknownFieldSet other) {
     _ensureWritable('mergeFromUnknownFieldSet');
     for (var key in other._fields.keys) {
-      mergeField(key, other._fields[key]);
+      mergeField(key, other._fields[key]!);
     }
   }
 
@@ -133,7 +133,7 @@ class UnknownFieldSet {
   bool operator ==(other) {
     if (other is! UnknownFieldSet) return false;
 
-    UnknownFieldSet o = other;
+    var o = other;
     return _areMapsEqual(o._fields, _fields);
   }
 
@@ -154,7 +154,7 @@ class UnknownFieldSet {
     var stringBuffer = StringBuffer();
 
     for (var tag in _sorted(_fields.keys)) {
-      var field = _fields[tag];
+      var field = _fields[tag]!;
       for (var value in field.values) {
         if (value is UnknownFieldSet) {
           stringBuffer
@@ -176,7 +176,7 @@ class UnknownFieldSet {
 
   void writeToCodedBufferWriter(CodedBufferWriter output) {
     for (var key in _fields.keys) {
-      _fields[key].writeTo(key, output);
+      _fields[key]!.writeTo(key, output);
     }
   }
 
@@ -222,7 +222,7 @@ class UnknownFieldSetField {
   bool operator ==(other) {
     if (other is! UnknownFieldSetField) return false;
 
-    UnknownFieldSetField o = other;
+    var o = other;
     if (lengthDelimited.length != o.lengthDelimited.length) return false;
     for (var i = 0; i < lengthDelimited.length; i++) {
       if (!_areListsEqual(o.lengthDelimited[i], lengthDelimited[i])) {

--- a/protobuf/mono_pkg.yaml
+++ b/protobuf/mono_pkg.yaml
@@ -1,21 +1,16 @@
 # See https://github.com/dart-lang/mono_repo for details
 
-# - format stage runs only on Linux and only using dev SDK
-# - analyze stage runs only on Linux with different flags for 2.10.5 and dev SDKs
-# - test stage runs for all oses and all sdks
-
 stages:
   - format_analyze:
     - group:
       - format
-      - analyze: --fatal-infos lib
-      - analyze: --fatal-infos test
+      - analyze: --fatal-infos
       dart: [dev]
     - group:
       - analyze: lib
       - analyze: test
-      dart: [2.10.5]
+      dart: [2.12.0]
   - run_tests:
     - group: [test]
-      dart: [2.10.5, dev]
+      dart: [2.12.0, dev]
       os: [linux, osx, windows]

--- a/protobuf/pubspec.yaml
+++ b/protobuf/pubspec.yaml
@@ -1,19 +1,19 @@
 name: protobuf
-version: 1.1.4
+version: 2.0.1-dev
 description: >-
   Runtime library for protocol buffers support.
   Use https://pub.dev/packages/protoc_plugin to generate dart code for your '.proto' files.
 homepage: https://github.com/dart-lang/protobuf
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
+  fixnum: ^1.0.0
+  collection: ^1.15.0
 
 dev_dependencies:
-  test: '>=1.2.0'
-  benchmark_harness: any
-  js: any
-  matcher: any
-  pedantic: ^1.9.2
+  test: ^1.16.0
+  benchmark_harness: ^2.0.0
+  js: ^0.6.3
+  pedantic: ^1.10.0

--- a/protobuf/test/codec_test.dart
+++ b/protobuf/test/codec_test.dart
@@ -23,11 +23,11 @@ void main() {
       };
 
   RoundtripTester<T> roundtripTester<T>(
-      {T Function(CodedBufferReader bytes) fromBytes,
-      List<int> Function(T value) toBytes}) {
+      {T Function(CodedBufferReader bytes)? fromBytes,
+      List<int> Function(T value)? toBytes}) {
     return (T value, List<int> bytes) {
-      expect(fromBytes(CodedBufferReader(bytes)), equals(value));
-      expect(toBytes(value), bytes);
+      expect(fromBytes!(CodedBufferReader(bytes)), equals(value));
+      expect(toBytes!(value), bytes);
     };
   }
 
@@ -130,8 +130,8 @@ void main() {
 
   // Compare two doubles, where NaNs and same-sign inifinities compare equal.
   // For normal values, use equals.
-  Matcher doubleEquals(expected) => expected.isNaN
-      ? predicate((x) => x.isNaN, 'NaN expected')
+  Matcher doubleEquals(double expected) => expected.isNaN
+      ? predicate<double>((x) => x.isNaN, 'NaN expected')
       : equals(expected);
 
   List<int> dataToBytes(ByteData byteData) => Uint8List.view(byteData.buffer);

--- a/protobuf/test/dummy_field_test.dart
+++ b/protobuf/test/dummy_field_test.dart
@@ -9,7 +9,7 @@ class Message extends GeneratedMessage {
   @override
   BuilderInfo get info_ => _i;
   static final _i = BuilderInfo('Message')
-    ..add(0, null, null, null, null, null, null);
+    ..add(0, 'dummy', null, null, null, null, null);
   @override
   Message createEmptyInstance() => Message();
 

--- a/protobuf/test/json_test.dart
+++ b/protobuf/test/json_test.dart
@@ -29,8 +29,10 @@ void main() {
     // "c" is not a legal enum value.
     expect(
         () => example..mergeFromProto3Json({'enm': 'c'}),
-        throwsA(allOf(isFormatException,
-            predicate((e) => e.message.contains('Unknown enum value')))));
+        throwsA(allOf(
+            isFormatException,
+            predicate(
+                (dynamic e) => e.message.contains('Unknown enum value')))));
     // `example` hasn't changed.
     expect(example.hasEnm, isTrue);
     expect(example.enm.name, equals('b'));
@@ -48,8 +50,10 @@ void main() {
     expect((example..mergeFromProto3Json({'enm': 2})).enm.name, 'b');
     expect(
         () => example..mergeFromProto3Json({'enm': 3}),
-        throwsA(allOf(isFormatException,
-            predicate((e) => e.message.contains('Unknown enum value')))));
+        throwsA(allOf(
+            isFormatException,
+            predicate(
+                (dynamic e) => e.message.contains('Unknown enum value')))));
     // `example` hasn't changed.
     expect(example.hasEnm, isTrue);
     expect(example.enm.name, equals('b'));

--- a/protobuf/test/message_test.dart
+++ b/protobuf/test/message_test.dart
@@ -20,9 +20,9 @@ class Rec extends MockMessage {
 }
 
 Matcher throwsError(Type expectedType, String expectedMessage) =>
-    throwsA(predicate((x) {
+    throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
-      expect(x.message, expectedMessage);
+      expect(x!.message, expectedMessage);
       return true;
     }));
 

--- a/protobuf/test/mock_util.dart
+++ b/protobuf/test/mock_util.dart
@@ -4,6 +4,7 @@
 
 library mock_util;
 
+import 'package:collection/collection.dart';
 import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:protobuf/protobuf.dart'
     show
@@ -24,8 +25,7 @@ BuilderInfo mockInfo(String className, CreateBuilderFunc create) {
     // 6 is reserved for extensions in other tests.
     ..e(7, 'enm', PbFieldType.OE,
         defaultOrMaker: mockEnumValues.first,
-        valueOf: (i) =>
-            mockEnumValues.firstWhere((e) => e.value == i, orElse: () => null),
+        valueOf: (i) => mockEnumValues.firstWhereOrNull((e) => e.value == i),
         enumValues: mockEnumValues);
 }
 
@@ -54,7 +54,7 @@ abstract class MockMessage extends GeneratedMessage {
 
   @override
   GeneratedMessage clone() {
-    var create = info_.byName['child'].subBuilder;
+    var create = info_.byName['child']!.subBuilder!;
     return create()..mergeFromMessage(this);
   }
 }

--- a/protobuf/test/readonly_message_test.dart
+++ b/protobuf/test/readonly_message_test.dart
@@ -17,9 +17,9 @@ import 'package:protobuf/protobuf.dart'
         defaultFrozenMessageModificationHandler;
 
 Matcher throwsError(Type expectedType, Matcher expectedMessage) =>
-    throwsA(predicate((x) {
+    throwsA(predicate((dynamic x) {
       expect(x.runtimeType, expectedType);
-      expect(x.message, expectedMessage);
+      expect(x!.message, expectedMessage);
       return true;
     }));
 
@@ -52,8 +52,8 @@ class Rec extends GeneratedMessage {
   @override
   Rec copyWith(void Function(Rec) updates) {
     final builder = toBuilder();
-    updates(builder);
-    return builder.freeze();
+    updates(builder as Rec);
+    return builder.freeze() as Rec;
   }
 }
 
@@ -83,7 +83,7 @@ void main() {
       var called = 0;
 
       frozenMessageModificationHandler =
-          (String messageName, [String methodName]) {
+          (String messageName, [String? methodName]) {
         expect(messageName, 'rec');
         expect(methodName, isNull);
         called++;
@@ -103,7 +103,7 @@ void main() {
       final initialHashCode = message.hashCode;
 
       frozenMessageModificationHandler =
-          (String messageName, [String methodName]) {};
+          (String messageName, [String? methodName]) {};
       message.setField(1, 456);
       final modifiedHashCode = message.hashCode;
       expect(initialHashCode == modifiedHashCode, isFalse);

--- a/protobuf/test/test_util.dart
+++ b/protobuf/test/test_util.dart
@@ -7,12 +7,12 @@ library test_util;
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 
-Int64 make64(int lo, [int hi]) {
+Int64 make64(int lo, [int? hi]) {
   hi ??= lo < 0 ? -1 : 0;
   return Int64.fromInts(hi, lo);
 }
 
-Matcher expect64(int lo, [int hi]) {
+Matcher expect64(int lo, [int? hi]) {
   final expected = make64(lo, hi);
   return predicate((Int64 actual) => actual == expected);
 }

--- a/protoc_plugin/CHANGELOG.md
+++ b/protoc_plugin/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 19.3.2-dev
+## 20.0.0
 
-* Add the test for fixed32 int that could be negative.
-* Add tests for the repeated and map enum value fields where the 
-  enum value is unknown.
+* Stable release generating null-safe code.
 
 ## 19.3.1
 

--- a/protoc_plugin/bin/protoc_plugin.dart
+++ b/protoc_plugin/bin/protoc_plugin.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 import 'package:protoc_plugin/protoc.dart';
 

--- a/protoc_plugin/bin/protoc_plugin_bazel.dart
+++ b/protoc_plugin/bin/protoc_plugin_bazel.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:io';
 import 'package:protoc_plugin/bazel.dart';
 import 'package:protoc_plugin/protoc.dart';

--- a/protoc_plugin/lib/base_type.dart
+++ b/protoc_plugin/lib/base_type.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Represents the base type of a particular field in a proto definition.

--- a/protoc_plugin/lib/bazel.dart
+++ b/protoc_plugin/lib/bazel.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 /// Bazel support for protoc_plugin.
 library protoc_bazel;
 

--- a/protoc_plugin/lib/client_generator.dart
+++ b/protoc_plugin/lib/client_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ClientApiGenerator {
@@ -42,10 +44,10 @@ class ClientApiGenerator {
     var outputType = service._getDartClassName(m.outputType, forMainFile: true);
     out.addBlock(
         '$_asyncImportPrefix.Future<$outputType> $methodName('
-            '$_protobufImportPrefix.ClientContext ctx, $inputType request) {',
+            '$_protobufImportPrefix.ClientContext? ctx, $inputType request) {',
         '}', () {
       out.println('var emptyResponse = $outputType();');
-      out.println('return _client.invoke<$outputType>(ctx, \'${className}\', '
+      out.println('return _client.invoke<$outputType>(ctx, \'$className\', '
           '\'${m.name}\', request, emptyResponse);');
     });
   }

--- a/protoc_plugin/lib/code_generator.dart
+++ b/protoc_plugin/lib/code_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 abstract class ProtobufContainer {

--- a/protoc_plugin/lib/enum_generator.dart
+++ b/protoc_plugin/lib/enum_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class EnumAlias {
@@ -102,7 +104,7 @@ class EnumGenerator extends ProtobufContainer {
 
   void generate(IndentingWriter out) {
     out.addAnnotatedBlock(
-        'class ${classname} extends $_protobufImportPrefix.ProtobufEnum {',
+        'class $classname extends $_protobufImportPrefix.ProtobufEnum {',
         '}\n', [
       NamedLocation(
           name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
@@ -115,14 +117,14 @@ class EnumGenerator extends ProtobufContainer {
         final conditionalValName = configurationDependent(
             'protobuf.omit_enum_names', quoted(val.name));
         out.printlnAnnotated(
-            'static const ${classname} $name = '
-            '${classname}._(${val.number}, $conditionalValName);',
+            'static const $classname $name = '
+            '$classname._(${val.number}, $conditionalValName);',
             [
               NamedLocation(
                   name: name,
                   fieldPathSegment: List.from(fieldPath)
                     ..addAll([_enumValueTag, _originalCanonicalIndices[i]]),
-                  start: 'static const ${classname} '.length)
+                  start: 'static const $classname '.length)
             ]);
       }
       if (_aliases.isNotEmpty) {
@@ -131,21 +133,21 @@ class EnumGenerator extends ProtobufContainer {
           var alias = _aliases[i];
           final name = dartNames[alias.value.name];
           out.printlnAnnotated(
-              'static const ${classname} $name ='
+              'static const $classname $name ='
               ' ${dartNames[alias.canonicalValue.name]};',
               [
                 NamedLocation(
                     name: name,
                     fieldPathSegment: List.from(fieldPath)
                       ..addAll([_enumValueTag, _originalAliasIndices[i]]),
-                    start: 'static const ${classname} '.length)
+                    start: 'static const $classname '.length)
               ]);
         }
       }
       out.println();
 
-      out.println('static const $_coreImportPrefix.List<${classname}> values ='
-          ' <${classname}> [');
+      out.println('static const $_coreImportPrefix.List<$classname> values ='
+          ' <$classname> [');
       for (var val in _canonicalValues) {
         final name = dartNames[val.name];
         out.println('  $name,');
@@ -156,12 +158,12 @@ class EnumGenerator extends ProtobufContainer {
       out.println(
           'static final $_coreImportPrefix.Map<$_coreImportPrefix.int, $classname> _byValue ='
           ' $_protobufImportPrefix.ProtobufEnum.initByValue(values);');
-      out.println('static ${classname} valueOf($_coreImportPrefix.int value) =>'
+      out.println('static $classname? valueOf($_coreImportPrefix.int value) =>'
           ' _byValue[value];');
       out.println();
 
       out.println(
-          'const ${classname}._($_coreImportPrefix.int v, $_coreImportPrefix.String n) '
+          'const $classname._($_coreImportPrefix.int v, $_coreImportPrefix.String n) '
           ': super(v, n);');
     });
   }

--- a/protoc_plugin/lib/extension_generator.dart
+++ b/protoc_plugin/lib/extension_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ExtensionGenerator {

--- a/protoc_plugin/lib/file_generator.dart
+++ b/protoc_plugin/lib/file_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 final _dartIdentifier = RegExp(r'^\w+$');
@@ -592,7 +594,7 @@ class FileGenerator extends ProtobufContainer {
 //  Generated code. Do not modify.
 //  source: ${descriptor.name}
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields$extraIgnoresString
 ''');
   }

--- a/protoc_plugin/lib/grpc_generator.dart
+++ b/protoc_plugin/lib/grpc_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class GrpcServiceGenerator {
@@ -94,7 +96,7 @@ class GrpcServiceGenerator {
     if (mg == null) {
       var location = _undefinedDeps[fqname];
       // TODO(nichite): Throw more actionable error.
-      throw 'FAILURE: Unknown type reference (${fqname}) for ${location}';
+      throw 'FAILURE: Unknown type reference ($fqname) for $location';
     }
     return mg.fileImportPrefix + '.' + mg.classname;
   }
@@ -112,9 +114,9 @@ class GrpcServiceGenerator {
       }
       out.println();
       out.println('$_clientClassname($_clientChannel channel,');
-      out.println('    {$_callOptions options,');
+      out.println('    {$_callOptions? options,');
       out.println(
-          '    $_coreImportPrefix.Iterable<$_interceptor> interceptors})');
+          '    $_coreImportPrefix.Iterable<$_interceptor>? interceptors})');
       out.println('    : super(channel, options: options,');
       out.println('      interceptors: interceptors);');
       for (final method in _methods) {
@@ -225,7 +227,7 @@ class _GrpcMethod {
   void generateClientStub(IndentingWriter out) {
     out.println();
     out.addBlock(
-        '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions} options}) {',
+        '$_clientReturnType $_dartName($_argumentType request, {${GrpcServiceGenerator._callOptions}? options}) {',
         '}', () {
       if (_clientStreaming && _serverStreaming) {
         out.println(

--- a/protoc_plugin/lib/indenting_writer.dart
+++ b/protoc_plugin/lib/indenting_writer.dart
@@ -12,7 +12,10 @@ class NamedLocation {
   final String name;
   final List<int> fieldPathSegment;
   final int start;
-  NamedLocation({this.name, this.fieldPathSegment, this.start});
+  NamedLocation(
+      {required this.name,
+      required this.fieldPathSegment,
+      required this.start});
 }
 
 /// A buffer for writing indented source code.
@@ -24,9 +27,9 @@ class IndentingWriter {
   // After writing any chunk, _previousOffset is the size of everything that was
   // written to the buffer before the latest call to print or addBlock.
   int _previousOffset = 0;
-  final String _sourceFile;
+  final String? _sourceFile;
 
-  IndentingWriter({String filename}) : _sourceFile = filename;
+  IndentingWriter({String? filename}) : _sourceFile = filename;
 
   /// Appends a string indented to the current level.
   /// (Indentation will be added after newline characters where needed.)
@@ -131,7 +134,7 @@ class IndentingWriter {
     }
     var annotation = GeneratedCodeInfo_Annotation()
       ..path.addAll(fieldPath)
-      ..sourceFile = _sourceFile
+      ..sourceFile = _sourceFile!
       ..begin = _previousOffset + start
       ..end = _previousOffset + start + name.length;
     sourceLocationInfo.annotation.add(annotation);

--- a/protoc_plugin/lib/linker.dart
+++ b/protoc_plugin/lib/linker.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Resolves all cross-references in a set of proto files.

--- a/protoc_plugin/lib/message_generator.dart
+++ b/protoc_plugin/lib/message_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Generates the Dart enum corresponding to a oneof declaration.
@@ -11,7 +13,7 @@ part of protoc;
 class OneofEnumGenerator {
   static void generate(
       IndentingWriter out, String classname, List<ProtobufField> fields) {
-    out.addBlock('enum ${classname} {', '}\n', () {
+    out.addBlock('enum $classname {', '}\n', () {
       for (var field in fields) {
         final name = oneofEnumMemberName(field.memberNames.fieldName);
         out.println('$name, ');
@@ -152,7 +154,7 @@ class MessageGenerator extends ProtobufContainer {
   /// Throws an exception if [resolve] hasn't been called yet.
   void checkResolved() {
     if (_fieldList == null) {
-      throw StateError("message not resolved: ${fullName}");
+      throw StateError("message not resolved: $fullName");
     }
   }
 
@@ -307,7 +309,7 @@ class MessageGenerator extends ProtobufContainer {
             'fromProto3Json: $_mixinImportPrefix.${mixin.name}.fromProto3JsonHelper'
         : '';
     out.addAnnotatedBlock(
-        'class ${classname} extends $_protobufImportPrefix.GeneratedMessage${mixinClause} {',
+        'class $classname extends $_protobufImportPrefix.GeneratedMessage$mixinClause {',
         '}', [
       NamedLocation(
           name: classname, fieldPathSegment: fieldPath, start: 'class '.length)
@@ -320,7 +322,7 @@ class MessageGenerator extends ProtobufContainer {
             final oneofMemberName =
                 oneofEnumMemberName(field.memberNames.fieldName);
             out.println(
-                '${field.number} : ${oneof.oneofEnumName}.${oneofMemberName},');
+                '${field.number} : ${oneof.oneofEnumName}.$oneofMemberName,');
           }
           out.println('0 : ${oneof.oneofEnumName}.notSet');
         });
@@ -337,7 +339,7 @@ class MessageGenerator extends ProtobufContainer {
         for (var oneof = 0; oneof < _oneofFields.length; oneof++) {
           var tags =
               _oneofFields[oneof].map((ProtobufField f) => f.number).toList();
-          out.println("..oo($oneof, ${tags})");
+          out.println("..oo($oneof, $tags)");
         }
 
         for (var field in _fieldList) {
@@ -358,7 +360,7 @@ class MessageGenerator extends ProtobufContainer {
 
       out.println();
 
-      out.printlnAnnotated('${classname}._() : super();', [
+      out.printlnAnnotated('$classname._() : super();', [
         NamedLocation(name: classname, fieldPathSegment: fieldPath, start: 0)
       ]);
       out.print('factory $classname(');
@@ -368,10 +370,10 @@ class MessageGenerator extends ProtobufContainer {
           _emitDeprecatedIf(field.isDeprecated, out);
           if (field.isRepeated && !field.isMapField) {
             out.println(
-                '  ${field.baseType.getRepeatedDartTypeIterable(fileGen)} ${field.memberNames.fieldName},');
+                '  ${field.baseType.getRepeatedDartTypeIterable(fileGen)}? ${field.memberNames.fieldName},');
           } else {
             out.println(
-                '  ${field.getDartType(fileGen)} ${field.memberNames.fieldName},');
+                '  ${field.getDartType(fileGen)}? ${field.memberNames.fieldName},');
           }
         }
         out.print('}');
@@ -400,42 +402,43 @@ class MessageGenerator extends ProtobufContainer {
         out.println(') => create();');
       }
       out.println(
-          'factory ${classname}.fromBuffer($_coreImportPrefix.List<$_coreImportPrefix.int> i,'
+          'factory $classname.fromBuffer($_coreImportPrefix.List<$_coreImportPrefix.int> i,'
           ' [$_protobufImportPrefix.ExtensionRegistry r = $_protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' => create()..mergeFromBuffer(i, r);');
-      out.println('factory ${classname}.fromJson($_coreImportPrefix.String i,'
+      out.println('factory $classname.fromJson($_coreImportPrefix.String i,'
           ' [$_protobufImportPrefix.ExtensionRegistry r = $_protobufImportPrefix.ExtensionRegistry.EMPTY])'
           ' => create()..mergeFromJson(i, r);');
       out.println('''@$_coreImportPrefix.Deprecated(
 'Using this can add significant overhead to your binary. '
 'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
 'Will be removed in next major version\')''');
-      out.println('${classname} clone() =>'
-          ' ${classname}()..mergeFromMessage(this);');
+      out.println('$classname clone() =>'
+          ' $classname()..mergeFromMessage(this);');
       out.println('''@$_coreImportPrefix.Deprecated(
 'Using this can add significant overhead to your binary. '
 'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
 'Will be removed in next major version\')''');
       out.println('$classname copyWith(void Function($classname) updates) =>'
-          ' super.copyWith((message) => updates(message as $classname)) as $classname;'
+          ' super.copyWith((message) => updates(message as $classname))'
+          ' as $classname;'
           ' // ignore: deprecated_member_use');
 
       out.println('$_protobufImportPrefix.BuilderInfo get info_ => _i;');
 
       // Factory functions which can be used as default value closures.
-      out.println("@${_coreImportPrefix}.pragma('dart2js:noInline')");
-      out.println('static ${classname} create() => ${classname}._();');
-      out.println('${classname} createEmptyInstance() => create();');
+      out.println("@$_coreImportPrefix.pragma('dart2js:noInline')");
+      out.println('static $classname create() => $classname._();');
+      out.println('$classname createEmptyInstance() => create();');
 
       out.println(
-          'static $_protobufImportPrefix.PbList<${classname}> createRepeated() =>'
-          ' $_protobufImportPrefix.PbList<${classname}>();');
-      out.println("@${_coreImportPrefix}.pragma('dart2js:noInline')");
-      out.println('static ${classname} getDefault() =>'
+          'static $_protobufImportPrefix.PbList<$classname> createRepeated() =>'
+          ' $_protobufImportPrefix.PbList<$classname>();');
+      out.println("@$_coreImportPrefix.pragma('dart2js:noInline')");
+      out.println('static $classname getDefault() =>'
           ' _defaultInstance ??='
-          ' $_protobufImportPrefix.GeneratedMessage.\$_defaultFor<${classname}>'
+          ' $_protobufImportPrefix.GeneratedMessage.\$_defaultFor<$classname>'
           '(create);');
-      out.println('static ${classname} _defaultInstance;');
+      out.println('static $classname? _defaultInstance;');
 
       generateFieldsAccessorsMutators(out);
       mixin?.injectHelpers(out);
@@ -500,7 +503,7 @@ class MessageGenerator extends ProtobufContainer {
   void generateOneofAccessors(IndentingWriter out, OneofNames oneof) {
     out.println();
     out.println("${oneof.oneofEnumName} ${oneof.whichOneofMethodName}() "
-        "=> ${oneof.byTagMapName}[\$_whichOneof(${oneof.index})];");
+        "=> ${oneof.byTagMapName}[\$_whichOneof(${oneof.index})]!;");
     out.println('void ${oneof.clearMethodName}() '
         '=> clearField(\$_whichOneof(${oneof.index}));');
   }
@@ -517,11 +520,11 @@ class MessageGenerator extends ProtobufContainer {
     final getterExpr = _getterExpression(fieldTypeString, field.index,
         defaultExpr, field.isRepeated, field.isMapField);
     out.printlnAnnotated(
-        '${fieldTypeString} get ${names.fieldName} => ${getterExpr};', [
+        '$fieldTypeString get ${names.fieldName} => $getterExpr;', [
       NamedLocation(
           name: names.fieldName,
           fieldPathSegment: memberFieldPath,
-          start: '${fieldTypeString} get '.length)
+          start: '$fieldTypeString get '.length)
     ]);
 
     if (field.isRepeated) {
@@ -597,13 +600,13 @@ class MessageGenerator extends ProtobufContainer {
         _emitDeprecatedIf(field.isDeprecated, out);
         _emitIndexAnnotation(field.number, out);
         out.printlnAnnotated(
-            '${fieldTypeString} ${names.ensureMethodName}() => '
+            '$fieldTypeString ${names.ensureMethodName}() => '
             '\$_ensure(${field.index});',
             <NamedLocation>[
               NamedLocation(
                   name: names.ensureMethodName,
                   fieldPathSegment: memberFieldPath,
-                  start: '${fieldTypeString} '.length)
+                  start: '$fieldTypeString '.length)
             ]);
       }
     }

--- a/protoc_plugin/lib/mixins.dart
+++ b/protoc_plugin/lib/mixins.dart
@@ -7,7 +7,7 @@
 import 'indenting_writer.dart';
 
 /// Finds [name] in the exported mixins.
-PbMixin findMixin(String name) {
+PbMixin? findMixin(String name) {
   const _exportedMixins = {
     'PbMapMixin': _pbMapMixin,
     'PbEventMixin': _pbEventMixin,
@@ -28,16 +28,16 @@ class PbMixin {
   final String importFrom;
 
   /// Another mixin to apply ahead of this one, or null for none.
-  final PbMixin parent;
+  final PbMixin? parent;
 
   /// Names that shouldn't be used by properties in the generated child class.
   /// May be null if the mixin doesn't reserve any new names.
-  final List<String> reservedNames;
+  final List<String>? reservedNames;
 
   /// Code to inject into the class using the mixin.
   ///
   /// Typically used for static helpers since you cannot mix in static members.
-  final List<String> injectedHelpers;
+  final List<String>? injectedHelpers;
 
   /// If `True` the mixin should have static methods for converting to and from
   /// proto3 Json.
@@ -45,7 +45,7 @@ class PbMixin {
 
   const PbMixin(
     this.name, {
-    this.importFrom,
+    required this.importFrom,
     this.parent,
     this.reservedNames,
     this.injectedHelpers,
@@ -64,18 +64,18 @@ class PbMixin {
   /// Returns all the reserved names, including from ancestor mixins.
   Iterable<String> findReservedNames() {
     var names = <String>{};
-    for (var m = this; m != null; m = m.parent) {
+    for (PbMixin? m = this; m != null; m = m.parent) {
       names.add(m.name);
       if (m.reservedNames != null) {
-        names.addAll(m.reservedNames);
+        names.addAll(m.reservedNames!);
       }
     }
     return names;
   }
 
   void injectHelpers(IndentingWriter out) {
-    if (injectedHelpers != null && injectedHelpers.isNotEmpty) {
-      out.println(injectedHelpers.join('\n'));
+    if (injectedHelpers != null && injectedHelpers!.isNotEmpty) {
+      out.println(injectedHelpers!.join('\n'));
     }
   }
 }

--- a/protoc_plugin/lib/names.dart
+++ b/protoc_plugin/lib/names.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'dart:math' as math;
 
 import 'package:protobuf/meta.dart';
@@ -205,7 +207,7 @@ String oneofEnumMemberName(String fieldName) => disambiguateName(
 String messageOrEnumClassName(String descriptorName, Set<String> usedNames,
     {String parent = ''}) {
   if (parent != '') {
-    descriptorName = '${parent}_${descriptorName}';
+    descriptorName = '${parent}_$descriptorName';
   }
   return disambiguateName(
       avoidInitialUnderscore(descriptorName), usedNames, defaultSuffixes());

--- a/protoc_plugin/lib/options.dart
+++ b/protoc_plugin/lib/options.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 typedef OnError = void Function(String details);

--- a/protoc_plugin/lib/output_config.dart
+++ b/protoc_plugin/lib/output_config.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 /// Configures where output of the protoc compiler should be placed and how to

--- a/protoc_plugin/lib/protobuf_field.dart
+++ b/protoc_plugin/lib/protobuf_field.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ProtobufField {

--- a/protoc_plugin/lib/protoc.dart
+++ b/protoc_plugin/lib/protoc.dart
@@ -1,3 +1,5 @@
+// @dart=2.11
+
 library protoc;
 
 import 'dart:convert';

--- a/protoc_plugin/lib/service_generator.dart
+++ b/protoc_plugin/lib/service_generator.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 class ServiceGenerator {
@@ -121,7 +123,7 @@ class ServiceGenerator {
     var mg = _deps[fqname];
     if (mg == null) {
       var location = _undefinedDeps[fqname];
-      throw 'FAILURE: Unknown type reference (${fqname}) for ${location}';
+      throw 'FAILURE: Unknown type reference ($fqname) for $location';
     }
     if (forMainFile && fileGen.protoFileUri == mg.fileGen.protoFileUri) {
       // If it's the same file, we import it without using "as".
@@ -176,9 +178,9 @@ class ServiceGenerator {
       out.addBlock("switch (method) {", "}", () {
         for (var m in _methodDescriptors) {
           var methodName = _methodName(m.name);
-          final type = _getDartClassName(m.inputType);
-          out.println(
-              "case '${m.name}': return this.$methodName(ctx, request as $type);");
+          var inputClass = _getDartClassName(m.inputType);
+          out.println("case '${m.name}': return this.$methodName"
+              "(ctx, request as $inputClass);");
         }
         out.println("default: "
             "throw $_coreImportPrefix.ArgumentError('Unknown method: \$method');");
@@ -216,7 +218,8 @@ class ServiceGenerator {
   /// The map includes an entry for every message type that might need
   /// to be read or written (assuming the type name resolved).
   void generateConstants(IndentingWriter out) {
-    out.print("const $jsonConstant = ");
+    out.print("const $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+        " $_coreImportPrefix.dynamic> $jsonConstant = ");
     writeJsonConst(out, _descriptor.writeToJsonMap());
     out.println(";");
     out.println();
@@ -227,8 +230,12 @@ class ServiceGenerator {
     }
 
     out.println('@$_coreImportPrefix.Deprecated'
-        '(\'Use ${binaryDescriptorName} instead\')');
-    out.addBlock("const $messageJsonConstant = const {", "};", () {
+        '(\'Use $binaryDescriptorName instead\')');
+    out.addBlock(
+        "const $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+            " $_coreImportPrefix.Map<$_coreImportPrefix.String,"
+            " $_coreImportPrefix.dynamic>> $messageJsonConstant = const {",
+        "};", () {
       for (var key in typeConstants.keys) {
         var typeConst = typeConstants[key];
         out.println("'$key': $typeConst,");

--- a/protoc_plugin/lib/src/dart_options.pb.dart
+++ b/protoc_plugin/lib/src/dart_options.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: dart_options.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -38,9 +38,9 @@ class DartMixin extends $pb.GeneratedMessage {
 
   DartMixin._() : super();
   factory DartMixin({
-    $core.String name,
-    $core.String importFrom,
-    $core.String parent,
+    $core.String? name,
+    $core.String? importFrom,
+    $core.String? parent,
   }) {
     final _result = create();
     if (name != null) {
@@ -78,7 +78,7 @@ class DartMixin extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DartMixin getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DartMixin>(create);
-  static DartMixin _defaultInstance;
+  static DartMixin? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -138,7 +138,7 @@ class Imports extends $pb.GeneratedMessage {
 
   Imports._() : super();
   factory Imports({
-    $core.Iterable<DartMixin> mixins,
+    $core.Iterable<DartMixin>? mixins,
   }) {
     final _result = create();
     if (mixins != null) {
@@ -170,7 +170,7 @@ class Imports extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Imports getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Imports>(create);
-  static Imports _defaultInstance;
+  static Imports? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<DartMixin> get mixins => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pb.dart
+++ b/protoc_plugin/lib/src/descriptor.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -34,7 +34,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
 
   FileDescriptorSet._() : super();
   factory FileDescriptorSet({
-    $core.Iterable<FileDescriptorProto> file,
+    $core.Iterable<FileDescriptorProto>? file,
   }) {
     final _result = create();
     if (file != null) {
@@ -67,7 +67,7 @@ class FileDescriptorSet extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorSet getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorSet>(create);
-  static FileDescriptorSet _defaultInstance;
+  static FileDescriptorSet? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<FileDescriptorProto> get file => $_getList(0);
@@ -158,18 +158,18 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
 
   FileDescriptorProto._() : super();
   factory FileDescriptorProto({
-    $core.String name,
-    $core.String package,
-    $core.Iterable<$core.String> dependency,
-    $core.Iterable<DescriptorProto> messageType,
-    $core.Iterable<EnumDescriptorProto> enumType,
-    $core.Iterable<ServiceDescriptorProto> service,
-    $core.Iterable<FieldDescriptorProto> extension,
-    FileOptions options,
-    SourceCodeInfo sourceCodeInfo,
-    $core.Iterable<$core.int> publicDependency,
-    $core.Iterable<$core.int> weakDependency,
-    $core.String syntax,
+    $core.String? name,
+    $core.String? package,
+    $core.Iterable<$core.String>? dependency,
+    $core.Iterable<DescriptorProto>? messageType,
+    $core.Iterable<EnumDescriptorProto>? enumType,
+    $core.Iterable<ServiceDescriptorProto>? service,
+    $core.Iterable<FieldDescriptorProto>? extension,
+    FileOptions? options,
+    SourceCodeInfo? sourceCodeInfo,
+    $core.Iterable<$core.int>? publicDependency,
+    $core.Iterable<$core.int>? weakDependency,
+    $core.String? syntax,
   }) {
     final _result = create();
     if (name != null) {
@@ -235,7 +235,7 @@ class FileDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileDescriptorProto>(create);
-  static FileDescriptorProto _defaultInstance;
+  static FileDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -354,9 +354,9 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
 
   DescriptorProto_ExtensionRange._() : super();
   factory DescriptorProto_ExtensionRange({
-    $core.int start,
-    $core.int end,
-    ExtensionRangeOptions options,
+    $core.int? start,
+    $core.int? end,
+    ExtensionRangeOptions? options,
   }) {
     final _result = create();
     if (start != null) {
@@ -399,7 +399,7 @@ class DescriptorProto_ExtensionRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ExtensionRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ExtensionRange>(create);
-  static DescriptorProto_ExtensionRange _defaultInstance;
+  static DescriptorProto_ExtensionRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -466,8 +466,8 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
 
   DescriptorProto_ReservedRange._() : super();
   factory DescriptorProto_ReservedRange({
-    $core.int start,
-    $core.int end,
+    $core.int? start,
+    $core.int? end,
   }) {
     final _result = create();
     if (start != null) {
@@ -507,7 +507,7 @@ class DescriptorProto_ReservedRange extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto_ReservedRange getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto_ReservedRange>(create);
-  static DescriptorProto_ReservedRange _defaultInstance;
+  static DescriptorProto_ReservedRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -612,16 +612,16 @@ class DescriptorProto extends $pb.GeneratedMessage {
 
   DescriptorProto._() : super();
   factory DescriptorProto({
-    $core.String name,
-    $core.Iterable<FieldDescriptorProto> field,
-    $core.Iterable<DescriptorProto> nestedType,
-    $core.Iterable<EnumDescriptorProto> enumType,
-    $core.Iterable<DescriptorProto_ExtensionRange> extensionRange,
-    $core.Iterable<FieldDescriptorProto> extension,
-    MessageOptions options,
-    $core.Iterable<OneofDescriptorProto> oneofDecl,
-    $core.Iterable<DescriptorProto_ReservedRange> reservedRange,
-    $core.Iterable<$core.String> reservedName,
+    $core.String? name,
+    $core.Iterable<FieldDescriptorProto>? field,
+    $core.Iterable<DescriptorProto>? nestedType,
+    $core.Iterable<EnumDescriptorProto>? enumType,
+    $core.Iterable<DescriptorProto_ExtensionRange>? extensionRange,
+    $core.Iterable<FieldDescriptorProto>? extension,
+    MessageOptions? options,
+    $core.Iterable<OneofDescriptorProto>? oneofDecl,
+    $core.Iterable<DescriptorProto_ReservedRange>? reservedRange,
+    $core.Iterable<$core.String>? reservedName,
   }) {
     final _result = create();
     if (name != null) {
@@ -681,7 +681,7 @@ class DescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static DescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<DescriptorProto>(create);
-  static DescriptorProto _defaultInstance;
+  static DescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -755,7 +755,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
 
   ExtensionRangeOptions._() : super();
   factory ExtensionRangeOptions({
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (uninterpretedOption != null) {
@@ -790,7 +790,7 @@ class ExtensionRangeOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ExtensionRangeOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ExtensionRangeOptions>(create);
-  static ExtensionRangeOptions _defaultInstance;
+  static ExtensionRangeOptions? _defaultInstance;
 
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
@@ -875,17 +875,17 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
 
   FieldDescriptorProto._() : super();
   factory FieldDescriptorProto({
-    $core.String name,
-    $core.String extendee,
-    $core.int number,
-    FieldDescriptorProto_Label label,
-    FieldDescriptorProto_Type type,
-    $core.String typeName,
-    $core.String defaultValue,
-    FieldOptions options,
-    $core.int oneofIndex,
-    $core.String jsonName,
-    $core.bool proto3Optional,
+    $core.String? name,
+    $core.String? extendee,
+    $core.int? number,
+    FieldDescriptorProto_Label? label,
+    FieldDescriptorProto_Type? type,
+    $core.String? typeName,
+    $core.String? defaultValue,
+    FieldOptions? options,
+    $core.int? oneofIndex,
+    $core.String? jsonName,
+    $core.bool? proto3Optional,
   }) {
     final _result = create();
     if (name != null) {
@@ -949,7 +949,7 @@ class FieldDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldDescriptorProto>(create);
-  static FieldDescriptorProto _defaultInstance;
+  static FieldDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1110,8 +1110,8 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
 
   OneofDescriptorProto._() : super();
   factory OneofDescriptorProto({
-    $core.String name,
-    OneofOptions options,
+    $core.String? name,
+    OneofOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -1148,7 +1148,7 @@ class OneofDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofDescriptorProto>(create);
-  static OneofDescriptorProto _defaultInstance;
+  static OneofDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1203,8 +1203,8 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
 
   EnumDescriptorProto_EnumReservedRange._() : super();
   factory EnumDescriptorProto_EnumReservedRange({
-    $core.int start,
-    $core.int end,
+    $core.int? start,
+    $core.int? end,
   }) {
     final _result = create();
     if (start != null) {
@@ -1246,7 +1246,7 @@ class EnumDescriptorProto_EnumReservedRange extends $pb.GeneratedMessage {
   static EnumDescriptorProto_EnumReservedRange getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
           EnumDescriptorProto_EnumReservedRange>(create);
-  static EnumDescriptorProto_EnumReservedRange _defaultInstance;
+  static EnumDescriptorProto_EnumReservedRange? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get start => $_getIZ(0);
@@ -1316,11 +1316,11 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
 
   EnumDescriptorProto._() : super();
   factory EnumDescriptorProto({
-    $core.String name,
-    $core.Iterable<EnumValueDescriptorProto> value,
-    EnumOptions options,
-    $core.Iterable<EnumDescriptorProto_EnumReservedRange> reservedRange,
-    $core.Iterable<$core.String> reservedName,
+    $core.String? name,
+    $core.Iterable<EnumValueDescriptorProto>? value,
+    EnumOptions? options,
+    $core.Iterable<EnumDescriptorProto_EnumReservedRange>? reservedRange,
+    $core.Iterable<$core.String>? reservedName,
   }) {
     final _result = create();
     if (name != null) {
@@ -1365,7 +1365,7 @@ class EnumDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumDescriptorProto>(create);
-  static EnumDescriptorProto _defaultInstance;
+  static EnumDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1434,9 +1434,9 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
 
   EnumValueDescriptorProto._() : super();
   factory EnumValueDescriptorProto({
-    $core.String name,
-    $core.int number,
-    EnumValueOptions options,
+    $core.String? name,
+    $core.int? number,
+    EnumValueOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -1477,7 +1477,7 @@ class EnumValueDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueDescriptorProto>(create);
-  static EnumValueDescriptorProto _defaultInstance;
+  static EnumValueDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1549,9 +1549,9 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
 
   ServiceDescriptorProto._() : super();
   factory ServiceDescriptorProto({
-    $core.String name,
-    $core.Iterable<MethodDescriptorProto> method,
-    ServiceOptions options,
+    $core.String? name,
+    $core.Iterable<MethodDescriptorProto>? method,
+    ServiceOptions? options,
   }) {
     final _result = create();
     if (name != null) {
@@ -1592,7 +1592,7 @@ class ServiceDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceDescriptorProto>(create);
-  static ServiceDescriptorProto _defaultInstance;
+  static ServiceDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1668,12 +1668,12 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
 
   MethodDescriptorProto._() : super();
   factory MethodDescriptorProto({
-    $core.String name,
-    $core.String inputType,
-    $core.String outputType,
-    MethodOptions options,
-    $core.bool clientStreaming,
-    $core.bool serverStreaming,
+    $core.String? name,
+    $core.String? inputType,
+    $core.String? outputType,
+    MethodOptions? options,
+    $core.bool? clientStreaming,
+    $core.bool? serverStreaming,
   }) {
     final _result = create();
     if (name != null) {
@@ -1723,7 +1723,7 @@ class MethodDescriptorProto extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodDescriptorProto getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodDescriptorProto>(create);
-  static MethodDescriptorProto _defaultInstance;
+  static MethodDescriptorProto? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -1927,28 +1927,28 @@ class FileOptions extends $pb.GeneratedMessage {
 
   FileOptions._() : super();
   factory FileOptions({
-    $core.String javaPackage,
-    $core.String javaOuterClassname,
-    FileOptions_OptimizeMode optimizeFor,
-    $core.bool javaMultipleFiles,
-    $core.String goPackage,
-    $core.bool ccGenericServices,
-    $core.bool javaGenericServices,
-    $core.bool pyGenericServices,
+    $core.String? javaPackage,
+    $core.String? javaOuterClassname,
+    FileOptions_OptimizeMode? optimizeFor,
+    $core.bool? javaMultipleFiles,
+    $core.String? goPackage,
+    $core.bool? ccGenericServices,
+    $core.bool? javaGenericServices,
+    $core.bool? pyGenericServices,
     @$core.Deprecated('This field is deprecated.')
-        $core.bool javaGenerateEqualsAndHash,
-    $core.bool deprecated,
-    $core.bool javaStringCheckUtf8,
-    $core.bool ccEnableArenas,
-    $core.String objcClassPrefix,
-    $core.String csharpNamespace,
-    $core.String swiftPrefix,
-    $core.String phpClassPrefix,
-    $core.String phpNamespace,
-    $core.bool phpGenericServices,
-    $core.String phpMetadataNamespace,
-    $core.String rubyPackage,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+        $core.bool? javaGenerateEqualsAndHash,
+    $core.bool? deprecated,
+    $core.bool? javaStringCheckUtf8,
+    $core.bool? ccEnableArenas,
+    $core.String? objcClassPrefix,
+    $core.String? csharpNamespace,
+    $core.String? swiftPrefix,
+    $core.String? phpClassPrefix,
+    $core.String? phpNamespace,
+    $core.bool? phpGenericServices,
+    $core.String? phpMetadataNamespace,
+    $core.String? rubyPackage,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (javaPackage != null) {
@@ -2041,7 +2041,7 @@ class FileOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FileOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FileOptions>(create);
-  static FileOptions _defaultInstance;
+  static FileOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get javaPackage => $_getSZ(0);
@@ -2332,11 +2332,11 @@ class MessageOptions extends $pb.GeneratedMessage {
 
   MessageOptions._() : super();
   factory MessageOptions({
-    $core.bool messageSetWireFormat,
-    $core.bool noStandardDescriptorAccessor,
-    $core.bool deprecated,
-    $core.bool mapEntry,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? messageSetWireFormat,
+    $core.bool? noStandardDescriptorAccessor,
+    $core.bool? deprecated,
+    $core.bool? mapEntry,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (messageSetWireFormat != null) {
@@ -2381,7 +2381,7 @@ class MessageOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MessageOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MessageOptions>(create);
-  static MessageOptions _defaultInstance;
+  static MessageOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get messageSetWireFormat => $_getBF(0);
@@ -2494,13 +2494,13 @@ class FieldOptions extends $pb.GeneratedMessage {
 
   FieldOptions._() : super();
   factory FieldOptions({
-    FieldOptions_CType ctype,
-    $core.bool packed,
-    $core.bool deprecated,
-    $core.bool lazy,
-    FieldOptions_JSType jstype,
-    $core.bool weak,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    FieldOptions_CType? ctype,
+    $core.bool? packed,
+    $core.bool? deprecated,
+    $core.bool? lazy,
+    FieldOptions_JSType? jstype,
+    $core.bool? weak,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (ctype != null) {
@@ -2551,7 +2551,7 @@ class FieldOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static FieldOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<FieldOptions>(create);
-  static FieldOptions _defaultInstance;
+  static FieldOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   FieldOptions_CType get ctype => $_getN(0);
@@ -2650,7 +2650,7 @@ class OneofOptions extends $pb.GeneratedMessage {
 
   OneofOptions._() : super();
   factory OneofOptions({
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (uninterpretedOption != null) {
@@ -2683,7 +2683,7 @@ class OneofOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static OneofOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<OneofOptions>(create);
-  static OneofOptions _defaultInstance;
+  static OneofOptions? _defaultInstance;
 
   @$pb.TagNumber(999)
   $core.List<UninterpretedOption> get uninterpretedOption => $_getList(0);
@@ -2720,9 +2720,9 @@ class EnumOptions extends $pb.GeneratedMessage {
 
   EnumOptions._() : super();
   factory EnumOptions({
-    $core.bool allowAlias,
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? allowAlias,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (allowAlias != null) {
@@ -2760,7 +2760,7 @@ class EnumOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumOptions>(create);
-  static EnumOptions _defaultInstance;
+  static EnumOptions? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.bool get allowAlias => $_getBF(0);
@@ -2816,8 +2816,8 @@ class EnumValueOptions extends $pb.GeneratedMessage {
 
   EnumValueOptions._() : super();
   factory EnumValueOptions({
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -2853,7 +2853,7 @@ class EnumValueOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static EnumValueOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<EnumValueOptions>(create);
-  static EnumValueOptions _defaultInstance;
+  static EnumValueOptions? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get deprecated => $_getBF(0);
@@ -2897,8 +2897,8 @@ class ServiceOptions extends $pb.GeneratedMessage {
 
   ServiceOptions._() : super();
   factory ServiceOptions({
-    $core.bool deprecated,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -2934,7 +2934,7 @@ class ServiceOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static ServiceOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<ServiceOptions>(create);
-  static ServiceOptions _defaultInstance;
+  static ServiceOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -2987,9 +2987,9 @@ class MethodOptions extends $pb.GeneratedMessage {
 
   MethodOptions._() : super();
   factory MethodOptions({
-    $core.bool deprecated,
-    MethodOptions_IdempotencyLevel idempotencyLevel,
-    $core.Iterable<UninterpretedOption> uninterpretedOption,
+    $core.bool? deprecated,
+    MethodOptions_IdempotencyLevel? idempotencyLevel,
+    $core.Iterable<UninterpretedOption>? uninterpretedOption,
   }) {
     final _result = create();
     if (deprecated != null) {
@@ -3028,7 +3028,7 @@ class MethodOptions extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static MethodOptions getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<MethodOptions>(create);
-  static MethodOptions _defaultInstance;
+  static MethodOptions? _defaultInstance;
 
   @$pb.TagNumber(33)
   $core.bool get deprecated => $_getBF(0);
@@ -3082,8 +3082,8 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
 
   UninterpretedOption_NamePart._() : super();
   factory UninterpretedOption_NamePart({
-    $core.String namePart,
-    $core.bool isExtension,
+    $core.String? namePart,
+    $core.bool? isExtension,
   }) {
     final _result = create();
     if (namePart != null) {
@@ -3123,7 +3123,7 @@ class UninterpretedOption_NamePart extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption_NamePart getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption_NamePart>(create);
-  static UninterpretedOption_NamePart _defaultInstance;
+  static UninterpretedOption_NamePart? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get namePart => $_getSZ(0);
@@ -3204,13 +3204,13 @@ class UninterpretedOption extends $pb.GeneratedMessage {
 
   UninterpretedOption._() : super();
   factory UninterpretedOption({
-    $core.Iterable<UninterpretedOption_NamePart> name,
-    $core.String identifierValue,
-    $fixnum.Int64 positiveIntValue,
-    $fixnum.Int64 negativeIntValue,
-    $core.double doubleValue,
-    $core.List<$core.int> stringValue,
-    $core.String aggregateValue,
+    $core.Iterable<UninterpretedOption_NamePart>? name,
+    $core.String? identifierValue,
+    $fixnum.Int64? positiveIntValue,
+    $fixnum.Int64? negativeIntValue,
+    $core.double? doubleValue,
+    $core.List<$core.int>? stringValue,
+    $core.String? aggregateValue,
   }) {
     final _result = create();
     if (name != null) {
@@ -3261,7 +3261,7 @@ class UninterpretedOption extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static UninterpretedOption getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<UninterpretedOption>(create);
-  static UninterpretedOption _defaultInstance;
+  static UninterpretedOption? _defaultInstance;
 
   @$pb.TagNumber(2)
   $core.List<UninterpretedOption_NamePart> get name => $_getList(0);
@@ -3380,11 +3380,11 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
 
   SourceCodeInfo_Location._() : super();
   factory SourceCodeInfo_Location({
-    $core.Iterable<$core.int> path,
-    $core.Iterable<$core.int> span,
-    $core.String leadingComments,
-    $core.String trailingComments,
-    $core.Iterable<$core.String> leadingDetachedComments,
+    $core.Iterable<$core.int>? path,
+    $core.Iterable<$core.int>? span,
+    $core.String? leadingComments,
+    $core.String? trailingComments,
+    $core.Iterable<$core.String>? leadingDetachedComments,
   }) {
     final _result = create();
     if (path != null) {
@@ -3431,7 +3431,7 @@ class SourceCodeInfo_Location extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo_Location getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo_Location>(create);
-  static SourceCodeInfo_Location _defaultInstance;
+  static SourceCodeInfo_Location? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -3488,7 +3488,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
 
   SourceCodeInfo._() : super();
   factory SourceCodeInfo({
-    $core.Iterable<SourceCodeInfo_Location> location,
+    $core.Iterable<SourceCodeInfo_Location>? location,
   }) {
     final _result = create();
     if (location != null) {
@@ -3521,7 +3521,7 @@ class SourceCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static SourceCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SourceCodeInfo>(create);
-  static SourceCodeInfo _defaultInstance;
+  static SourceCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<SourceCodeInfo_Location> get location => $_getList(0);
@@ -3564,10 +3564,10 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
 
   GeneratedCodeInfo_Annotation._() : super();
   factory GeneratedCodeInfo_Annotation({
-    $core.Iterable<$core.int> path,
-    $core.String sourceFile,
-    $core.int begin,
-    $core.int end,
+    $core.Iterable<$core.int>? path,
+    $core.String? sourceFile,
+    $core.int? begin,
+    $core.int? end,
   }) {
     final _result = create();
     if (path != null) {
@@ -3613,7 +3613,7 @@ class GeneratedCodeInfo_Annotation extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo_Annotation getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo_Annotation>(create);
-  static GeneratedCodeInfo_Annotation _defaultInstance;
+  static GeneratedCodeInfo_Annotation? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get path => $_getList(0);
@@ -3676,7 +3676,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
 
   GeneratedCodeInfo._() : super();
   factory GeneratedCodeInfo({
-    $core.Iterable<GeneratedCodeInfo_Annotation> annotation,
+    $core.Iterable<GeneratedCodeInfo_Annotation>? annotation,
   }) {
     final _result = create();
     if (annotation != null) {
@@ -3709,7 +3709,7 @@ class GeneratedCodeInfo extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static GeneratedCodeInfo getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<GeneratedCodeInfo>(create);
-  static GeneratedCodeInfo _defaultInstance;
+  static GeneratedCodeInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<GeneratedCodeInfo_Annotation> get annotation => $_getList(0);

--- a/protoc_plugin/lib/src/descriptor.pbenum.dart
+++ b/protoc_plugin/lib/src/descriptor.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: descriptor.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -143,7 +143,7 @@ class FieldDescriptorProto_Type extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Type> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Type valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Type? valueOf($core.int value) => _byValue[value];
 
   const FieldDescriptorProto_Type._($core.int v, $core.String n) : super(v, n);
 }
@@ -177,7 +177,8 @@ class FieldDescriptorProto_Label extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldDescriptorProto_Label> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldDescriptorProto_Label valueOf($core.int value) => _byValue[value];
+  static FieldDescriptorProto_Label? valueOf($core.int value) =>
+      _byValue[value];
 
   const FieldDescriptorProto_Label._($core.int v, $core.String n) : super(v, n);
 }
@@ -209,7 +210,7 @@ class FileOptions_OptimizeMode extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FileOptions_OptimizeMode> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FileOptions_OptimizeMode valueOf($core.int value) => _byValue[value];
+  static FileOptions_OptimizeMode? valueOf($core.int value) => _byValue[value];
 
   const FileOptions_OptimizeMode._($core.int v, $core.String n) : super(v, n);
 }
@@ -239,7 +240,7 @@ class FieldOptions_CType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_CType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_CType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_CType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_CType._($core.int v, $core.String n) : super(v, n);
 }
@@ -269,7 +270,7 @@ class FieldOptions_JSType extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, FieldOptions_JSType> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static FieldOptions_JSType valueOf($core.int value) => _byValue[value];
+  static FieldOptions_JSType? valueOf($core.int value) => _byValue[value];
 
   const FieldOptions_JSType._($core.int v, $core.String n) : super(v, n);
 }
@@ -303,7 +304,7 @@ class MethodOptions_IdempotencyLevel extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, MethodOptions_IdempotencyLevel> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static MethodOptions_IdempotencyLevel valueOf($core.int value) =>
+  static MethodOptions_IdempotencyLevel? valueOf($core.int value) =>
       _byValue[value];
 
   const MethodOptions_IdempotencyLevel._($core.int v, $core.String n)

--- a/protoc_plugin/lib/src/plugin.pb.dart
+++ b/protoc_plugin/lib/src/plugin.pb.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -51,10 +51,10 @@ class Version extends $pb.GeneratedMessage {
 
   Version._() : super();
   factory Version({
-    $core.int major,
-    $core.int minor,
-    $core.int patch,
-    $core.String suffix,
+    $core.int? major,
+    $core.int? minor,
+    $core.int? patch,
+    $core.String? suffix,
   }) {
     final _result = create();
     if (major != null) {
@@ -95,7 +95,7 @@ class Version extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static Version getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Version>(create);
-  static Version _defaultInstance;
+  static Version? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get major => $_getIZ(0);
@@ -182,10 +182,10 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
 
   CodeGeneratorRequest._() : super();
   factory CodeGeneratorRequest({
-    $core.Iterable<$core.String> fileToGenerate,
-    $core.String parameter,
-    Version compilerVersion,
-    $core.Iterable<$0.FileDescriptorProto> protoFile,
+    $core.Iterable<$core.String>? fileToGenerate,
+    $core.String? parameter,
+    Version? compilerVersion,
+    $core.Iterable<$0.FileDescriptorProto>? protoFile,
   }) {
     final _result = create();
     if (fileToGenerate != null) {
@@ -228,7 +228,7 @@ class CodeGeneratorRequest extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorRequest>(create);
-  static CodeGeneratorRequest _defaultInstance;
+  static CodeGeneratorRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.String> get fileToGenerate => $_getList(0);
@@ -298,10 +298,10 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
 
   CodeGeneratorResponse_File._() : super();
   factory CodeGeneratorResponse_File({
-    $core.String name,
-    $core.String insertionPoint,
-    $core.String content,
-    $0.GeneratedCodeInfo generatedCodeInfo,
+    $core.String? name,
+    $core.String? insertionPoint,
+    $core.String? content,
+    $0.GeneratedCodeInfo? generatedCodeInfo,
   }) {
     final _result = create();
     if (name != null) {
@@ -346,7 +346,7 @@ class CodeGeneratorResponse_File extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse_File getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse_File>(create);
-  static CodeGeneratorResponse_File _defaultInstance;
+  static CodeGeneratorResponse_File? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
@@ -432,9 +432,9 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
 
   CodeGeneratorResponse._() : super();
   factory CodeGeneratorResponse({
-    $core.String error,
-    $fixnum.Int64 supportedFeatures,
-    $core.Iterable<CodeGeneratorResponse_File> file,
+    $core.String? error,
+    $fixnum.Int64? supportedFeatures,
+    $core.Iterable<CodeGeneratorResponse_File>? file,
   }) {
     final _result = create();
     if (error != null) {
@@ -475,7 +475,7 @@ class CodeGeneratorResponse extends $pb.GeneratedMessage {
   @$core.pragma('dart2js:noInline')
   static CodeGeneratorResponse getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<CodeGeneratorResponse>(create);
-  static CodeGeneratorResponse _defaultInstance;
+  static CodeGeneratorResponse? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get error => $_getSZ(0);

--- a/protoc_plugin/lib/src/plugin.pbenum.dart
+++ b/protoc_plugin/lib/src/plugin.pbenum.dart
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: plugin.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -31,7 +31,7 @@ class CodeGeneratorResponse_Feature extends $pb.ProtobufEnum {
 
   static final $core.Map<$core.int, CodeGeneratorResponse_Feature> _byValue =
       $pb.ProtobufEnum.initByValue(values);
-  static CodeGeneratorResponse_Feature valueOf($core.int value) =>
+  static CodeGeneratorResponse_Feature? valueOf($core.int value) =>
       _byValue[value];
 
   const CodeGeneratorResponse_Feature._($core.int v, $core.String n)

--- a/protoc_plugin/lib/testing/mixins.dart
+++ b/protoc_plugin/lib/testing/mixins.dart
@@ -1,3 +1,5 @@
+// @dart=2.12
+
 abstract class Mixin1 {
   String get overriddenString => "mixin1";
 

--- a/protoc_plugin/lib/well_known_types.dart
+++ b/protoc_plugin/lib/well_known_types.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 part of protoc;
 
 PbMixin wellKnownMixinForFullName(String qualifiedName) =>

--- a/protoc_plugin/mono_pkg.yaml
+++ b/protoc_plugin/mono_pkg.yaml
@@ -2,19 +2,14 @@
 stages:
   - format_analyze:
     - group:
+      - format
       - command: ./../tool/setup.sh
       - command: make protos
-      - format
       - analyze: --fatal-infos
       dart: [dev]
-    - group:
-      - command: ./../tool/setup.sh
-      - command: make protos
-      - analyze
-      dart: [2.10.5]
   - run_tests:
     - group:
       - command: ./../tool/setup.sh
       - command: make protos
       - test
-      dart: [2.10.5, dev]
+      dart: [2.12.0, dev]

--- a/protoc_plugin/pubspec.yaml
+++ b/protoc_plugin/pubspec.yaml
@@ -1,20 +1,26 @@
 name: protoc_plugin
-version: 19.3.2-dev
+version: 20.0.1-dev
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/protobuf
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  fixnum: ^0.10.9
-  path: ^1.0.0
-  protobuf: '>=1.1.3 <2.0.0'
-  dart_style: ^1.0.6
+  fixnum: ^1.0.0
+  path: ^1.8.0
+  protobuf: ^2.0.0
+  dart_style: ^2.0.0
 
 dev_dependencies:
-  test: ^1.3.0
-  pedantic: ^1.9.2
+  test: ^1.16.0
+  pedantic: ^1.10.0
+  matcher: ^0.12.10
+  collection: ^1.15.0
 
 executables:
   protoc-gen-dart: protoc_plugin
+
+dependency_overrides:
+  protobuf:
+    path: ../protobuf

--- a/protoc_plugin/test/all_tests.dart
+++ b/protoc_plugin/test/all_tests.dart
@@ -3,10 +3,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc_plugin_all_tests;
 
-import 'bazel_test.dart' as bazel;
 import 'any_test.dart' as any;
+import 'bazel_test.dart' as bazel;
 import 'client_generator_test.dart' as client_generator;
 import 'const_generator_test.dart' as const_generator;
 import 'default_value_escape_test.dart' as default_value_escape;
@@ -18,8 +20,8 @@ import 'file_generator_test.dart' as file_generator;
 import 'generated_message_test.dart' as generated_message;
 import 'hash_code_test.dart' as hash_code;
 import 'high_tagnumber_test.dart' as high_tagnumber;
-import 'import_test.dart' as import_prefix;
 import 'import_public_test.dart' as import_public;
+import 'import_test.dart' as import_prefix;
 import 'indenting_writer_test.dart' as indenting_writer;
 import 'json_test.dart' as json;
 import 'leading_underscores_test.dart' as leading_underscores;
@@ -30,16 +32,17 @@ import 'message_generator_test.dart' as message_generator;
 import 'message_test.dart' as message;
 import 'mixin_test.dart' as mixin_test;
 import 'names_test.dart' as names;
-import 'oneof_test.dart' as oneof;
 import 'omit_enum_names_test.dart' as omit_enum_names;
 import 'omit_field_names_test.dart' as omit_field_names;
 import 'omit_message_names_test.dart' as omit_message_names;
+import 'oneof_test.dart' as oneof;
 import 'proto3_optional_test.dart' as proto3_optional;
 import 'protoc_options_test.dart' as protoc_options;
 import 'repeated_field_test.dart' as repeated_field;
 import 'reserved_names_test.dart' as reserved_names;
-import 'service_test.dart' as service;
+import 'send_protos_via_sendports_test.dart' as send_protos_via_sendports_test;
 import 'service_generator_test.dart' as service_generator;
+import 'service_test.dart' as service;
 import 'to_builder_test.dart' as to_builder;
 import 'unknown_field_set_test.dart' as unknown_field_set;
 import 'validate_fail_test.dart' as validate_fail;
@@ -67,18 +70,19 @@ void main() {
   map.main();
   map_field.main();
   merge.main();
-  message_generator.main();
   message.main();
+  message_generator.main();
   mixin_test.main();
   names.main();
-  oneof.main();
   omit_enum_names.main();
   omit_field_names.main();
   omit_message_names.main();
+  oneof.main();
   proto3_optional.main();
   protoc_options.main();
   repeated_field.main();
   reserved_names.main();
+  send_protos_via_sendports_test.main();
   service.main();
   service_generator.main();
   to_builder.main();

--- a/protoc_plugin/test/any_test.dart
+++ b/protoc_plugin/test/any_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/bazel_test.dart
+++ b/protoc_plugin/test/bazel_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library bazel_test;
 
 import 'package:protoc_plugin/bazel.dart';

--- a/protoc_plugin/test/client_generator_test.dart
+++ b/protoc_plugin/test/client_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library client_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/default_value_escape_test.dart
+++ b/protoc_plugin/test/default_value_escape_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 import '../out/protos/default_value_escape.pb.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/descriptor_test.dart
+++ b/protoc_plugin/test/descriptor_test.dart
@@ -2,12 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:protoc_plugin/src/descriptor.pb.dart';
+// @dart=2.11
+
 import 'package:protobuf/protobuf.dart';
-import '../out/protos/google/protobuf/unittest.pbjson.dart';
+import 'package:protoc_plugin/src/descriptor.pb.dart';
+import 'package:test/test.dart';
+
 import '../out/protos/custom_option.pb.dart';
 import '../out/protos/custom_option.pbjson.dart';
-import 'package:test/test.dart';
+import '../out/protos/google/protobuf/unittest.pbjson.dart';
 
 void main() {
   test('Can decode message descriptor', () {

--- a/protoc_plugin/test/enum_generator_test.dart
+++ b/protoc_plugin/test/enum_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library enum_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/extension_generator_test.dart
+++ b/protoc_plugin/test/extension_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library extension_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/extension_test.dart
+++ b/protoc_plugin/test/extension_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library extension_test;
 
 import 'package:protobuf/protobuf.dart';

--- a/protoc_plugin/test/file_generator_test.dart
+++ b/protoc_plugin/test/file_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library file_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/generated_message_test.dart
+++ b/protoc_plugin/test/generated_message_test.dart
@@ -3,25 +3,26 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library generated_message_test;
 
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
+import '../out/protos/duplicate_names_import.pb.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/google/protobuf/unittest_import.pb.dart';
 import '../out/protos/google/protobuf/unittest_optimize_for.pb.dart';
 import '../out/protos/multiple_files_test.pb.dart';
-import '../out/protos/reserved_names.pb.dart';
-import '../out/protos/reserved_names_extension.pb.dart';
-import '../out/protos/reserved_names_message.pb.dart';
-import '../out/protos/duplicate_names_import.pb.dart';
 import '../out/protos/package1.pb.dart' as p1;
 import '../out/protos/package2.pb.dart' as p2;
 import '../out/protos/package3.pb.dart' as p3;
-import '../out/protos/toplevel_import.pb.dart' as t;
+import '../out/protos/reserved_names.pb.dart';
+import '../out/protos/reserved_names_extension.pb.dart';
+import '../out/protos/reserved_names_message.pb.dart';
 import '../out/protos/toplevel.pb.dart';
-
+import '../out/protos/toplevel_import.pb.dart' as t;
 import 'test_util.dart';
 
 void main() {
@@ -860,7 +861,7 @@ void main() {
       ..optionalForeignMessage = (ForeignMessage()..c = 18)
       ..freeze();
     final value2 = value1.rebuild((v) {
-      v..optionalFloat = 50.1;
+      v.optionalFloat = 50.1;
     });
     expect(value2.isFrozen, true);
     expect(value2.optionalFloat, 50.1);
@@ -883,5 +884,89 @@ void main() {
     setAllExtensions(value1);
     final value2 = value1.deepCopy();
     assertAllExtensionsSet(value2);
+  });
+
+  test('named arguments in constructor', () {
+    final value = TestAllTypes(
+      optionalInt32: 101,
+      optionalInt64: make64(102),
+      optionalUint32: 103,
+      optionalUint64: make64(104),
+      optionalSint32: 105,
+      optionalSint64: make64(106),
+      optionalFixed32: 107,
+      optionalFixed64: make64(108),
+      optionalSfixed32: 109,
+      optionalSfixed64: make64(110),
+      optionalFloat: 111.0,
+      optionalDouble: 112.0,
+      optionalBool: true,
+      optionalString: '115',
+      optionalBytes: '116'.codeUnits,
+      optionalGroup: TestAllTypes_OptionalGroup(a: 117),
+      optionalNestedMessage: TestAllTypes_NestedMessage(bb: 118),
+      optionalForeignMessage: ForeignMessage(c: 119),
+      optionalImportMessage: ImportMessage(d: 120),
+      optionalNestedEnum: TestAllTypes_NestedEnum.BAZ,
+      optionalForeignEnum: ForeignEnum.FOREIGN_BAZ,
+      optionalImportEnum: ImportEnum.IMPORT_BAZ,
+      optionalStringPiece: '124',
+      optionalCord: '125',
+      repeatedInt32: [201, 301],
+      repeatedInt64: [make64(202), make64(302)],
+      repeatedUint32: [203, 303],
+      repeatedUint64: [make64(204), make64(304)],
+      repeatedSint32: [205, 305],
+      repeatedSint64: [make64(206), make64(306)],
+      repeatedFixed32: [207, 307],
+      repeatedFixed64: [make64(208), make64(308)],
+      repeatedSfixed32: [209, 309],
+      repeatedSfixed64: [make64(210), make64(310)],
+      repeatedFloat: [211.0, 311.0],
+      repeatedDouble: [212.0, 312.0],
+      repeatedBool: [true, false],
+      repeatedString: ['215', '315'],
+      repeatedBytes: ['216'.codeUnits, '316'.codeUnits],
+      repeatedGroup: [
+        TestAllTypes_RepeatedGroup(a: 217),
+        TestAllTypes_RepeatedGroup(a: 317)
+      ],
+      repeatedNestedMessage: [
+        TestAllTypes_NestedMessage(bb: 218),
+        TestAllTypes_NestedMessage(bb: 318)
+      ],
+      repeatedForeignMessage: [ForeignMessage(c: 219), ForeignMessage(c: 319)],
+      repeatedImportMessage: [ImportMessage(d: 220), ImportMessage(d: 320)],
+      repeatedNestedEnum: [
+        TestAllTypes_NestedEnum.BAR,
+        TestAllTypes_NestedEnum.BAZ
+      ],
+      repeatedForeignEnum: [ForeignEnum.FOREIGN_BAR, ForeignEnum.FOREIGN_BAZ],
+      repeatedImportEnum: [ImportEnum.IMPORT_BAR, ImportEnum.IMPORT_BAZ],
+      repeatedStringPiece: ['224', '324'],
+      repeatedCord: ['225', '325'],
+      defaultInt32: 401,
+      defaultInt64: make64(402),
+      defaultUint32: 403,
+      defaultUint64: make64(404),
+      defaultSint32: 405,
+      defaultSint64: make64(406),
+      defaultFixed32: 407,
+      defaultFixed64: make64(408),
+      defaultSfixed32: 409,
+      defaultSfixed64: make64(410),
+      defaultFloat: 411.0,
+      defaultDouble: 412.0,
+      defaultBool: false,
+      defaultString: '415',
+      defaultBytes: '416'.codeUnits,
+      defaultNestedEnum: TestAllTypes_NestedEnum.FOO,
+      defaultForeignEnum: ForeignEnum.FOREIGN_FOO,
+      defaultImportEnum: ImportEnum.IMPORT_FOO,
+      defaultStringPiece: '424',
+      defaultCord: '425',
+    );
+
+    assertAllFieldsSet(value);
   });
 }

--- a/protoc_plugin/test/golden_file.dart
+++ b/protoc_plugin/test/golden_file.dart
@@ -14,7 +14,7 @@ void expectMatchesGoldenFile(String actual, String goldenFilePath) {
   var goldenFile = File(goldenFilePath);
   if (goldenFile.existsSync()) {
     expect(actual, equals(goldenFile.readAsStringSync()),
-        reason: 'goldenFilePath: "${goldenFilePath}"');
+        reason: 'goldenFilePath: "$goldenFilePath"');
   } else {
     // This enables writing the updated file when the run in otherwise hermetic
     // settings.

--- a/protoc_plugin/test/goldens/client
+++ b/protoc_plugin/test/goldens/client
@@ -2,11 +2,11 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<SomeReply> aMethod($pb.ClientContext ctx, SomeRequest request) {
+  $async.Future<SomeReply> aMethod($pb.ClientContext? ctx, SomeRequest request) {
     var emptyResponse = SomeReply();
     return _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, emptyResponse);
   }
-  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext ctx, $0.EmptyMessage request) {
+  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext? ctx, $0.EmptyMessage request) {
     var emptyResponse = $0.AnotherReply();
     return _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
   }

--- a/protoc_plugin/test/goldens/enum
+++ b/protoc_plugin/test/goldens/enum
@@ -12,7 +12,7 @@ class PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/grpc_service.pb
+++ b/protoc_plugin/test/goldens/grpc_service.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -35,6 +35,6 @@ class Empty extends $pb.GeneratedMessage {
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
-  static Empty _defaultInstance;
+  static Empty? _defaultInstance;
 }
 

--- a/protoc_plugin/test/goldens/grpc_service.pbgrpc
+++ b/protoc_plugin/test/goldens/grpc_service.pbgrpc
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -32,31 +32,31 @@ class TestClient extends $grpc.Client {
       ($core.List<$core.int> value) => $0.Output.fromBuffer(value));
 
   TestClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions options,
-      $core.Iterable<$grpc.ClientInterceptor> interceptors})
+      {$grpc.CallOptions? options,
+      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
       : super(channel, options: options, interceptors: interceptors);
 
   $grpc.ResponseFuture<$0.Output> unary($0.Input request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$unary, request, options: options);
   }
 
   $grpc.ResponseFuture<$0.Output> clientStreaming(
       $async.Stream<$0.Input> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$clientStreaming, request, options: options)
         .single;
   }
 
   $grpc.ResponseStream<$0.Output> serverStreaming($0.Input request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(
         _$serverStreaming, $async.Stream.fromIterable([request]),
         options: options);
   }
 
   $grpc.ResponseStream<$0.Output> bidirectional($async.Stream<$0.Input> request,
-      {$grpc.CallOptions options}) {
+      {$grpc.CallOptions? options}) {
     return $createStreamingCall(_$bidirectional, request, options: options);
   }
 }

--- a/protoc_plugin/test/goldens/header_in_package.pb
+++ b/protoc_plugin/test/goldens/header_in_package.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/header_with_fixnum.pb
+++ b/protoc_plugin/test/goldens/header_with_fixnum.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/imports.pb
+++ b/protoc_plugin/test/goldens/imports.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -22,9 +22,9 @@ class M extends $pb.GeneratedMessage {
 
   M._() : super();
   factory M({
-    M m,
-    $1.M m1,
-    $2.M m2,
+    M? m,
+    $1.M? m1,
+    $2.M? m2,
   }) {
     final _result = create();
     if (m != null) {
@@ -57,7 +57,7 @@ class M extends $pb.GeneratedMessage {
   static $pb.PbList<M> createRepeated() => $pb.PbList<M>();
   @$core.pragma('dart2js:noInline')
   static M getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<M>(create);
-  static M _defaultInstance;
+  static M? _defaultInstance;
 
   @$pb.TagNumber(1)
   M get m => $_getN(0);

--- a/protoc_plugin/test/goldens/imports.pbjson
+++ b/protoc_plugin/test/goldens/imports.pbjson
@@ -2,6 +2,6 @@
 //  Generated code. Do not modify.
 //  source: test.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 

--- a/protoc_plugin/test/goldens/int64.pb
+++ b/protoc_plugin/test/goldens/int64.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -18,7 +18,7 @@ class Int64 extends $pb.GeneratedMessage {
 
   Int64._() : super();
   factory Int64({
-    $fixnum.Int64 value,
+    $fixnum.Int64? value,
   }) {
     final _result = create();
     if (value != null) {
@@ -45,7 +45,7 @@ class Int64 extends $pb.GeneratedMessage {
   static $pb.PbList<Int64> createRepeated() => $pb.PbList<Int64>();
   @$core.pragma('dart2js:noInline')
   static Int64 getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Int64>(create);
-  static Int64 _defaultInstance;
+  static Int64? _defaultInstance;
 
   @$pb.TagNumber(1)
   $fixnum.Int64 get value => $_getI64(0);

--- a/protoc_plugin/test/goldens/messageGenerator
+++ b/protoc_plugin/test/goldens/messageGenerator
@@ -8,11 +8,11 @@ class PhoneNumber extends $pb.GeneratedMessage {
 
   PhoneNumber._() : super();
   factory PhoneNumber({
-    $core.String number,
-    PhoneNumber_PhoneType type,
-    $core.String name,
+    $core.String? number,
+    PhoneNumber_PhoneType? type,
+    $core.String? name,
   @$core.Deprecated('This field is deprecated.')
-    $core.String deprecatedField,
+    $core.String? deprecatedField,
   }) {
     final _result = create();
     if (number != null) {
@@ -49,7 +49,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
-  static PhoneNumber _defaultInstance;
+  static PhoneNumber? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);

--- a/protoc_plugin/test/goldens/messageGenerator.meta
+++ b/protoc_plugin/test/goldens/messageGenerator.meta
@@ -18,8 +18,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2797
-  end: 2803
+  begin: 2802
+  end: 2808
 }
 annotation: {
   path: 4
@@ -27,8 +27,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2845
-  end: 2851
+  begin: 2850
+  end: 2856
 }
 annotation: {
   path: 4
@@ -36,8 +36,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2924
-  end: 2933
+  begin: 2929
+  end: 2938
 }
 annotation: {
   path: 4
@@ -45,8 +45,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: 
-  begin: 2976
-  end: 2987
+  begin: 2981
+  end: 2992
 }
 annotation: {
   path: 4
@@ -54,8 +54,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 3057
-  end: 3061
+  begin: 3062
+  end: 3066
 }
 annotation: {
   path: 4
@@ -63,8 +63,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 3102
-  end: 3106
+  begin: 3107
+  end: 3111
 }
 annotation: {
   path: 4
@@ -72,8 +72,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 3185
-  end: 3192
+  begin: 3190
+  end: 3197
 }
 annotation: {
   path: 4
@@ -81,8 +81,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: 
-  begin: 3235
-  end: 3244
+  begin: 3240
+  end: 3249
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 3305
-  end: 3309
+  begin: 3310
+  end: 3314
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 3356
-  end: 3360
+  begin: 3361
+  end: 3365
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 3433
-  end: 3440
+  begin: 3438
+  end: 3445
 }
 annotation: {
   path: 4
@@ -117,17 +117,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: 
-  begin: 3483
-  end: 3492
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 3
-  sourceFile: 
-  begin: 3602
-  end: 3617
+  begin: 3488
+  end: 3497
 }
 annotation: {
   path: 4
@@ -135,8 +126,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3708
-  end: 3723
+  begin: 3607
+  end: 3622
 }
 annotation: {
   path: 4
@@ -144,8 +135,8 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3845
-  end: 3863
+  begin: 3713
+  end: 3728
 }
 annotation: {
   path: 4
@@ -153,6 +144,15 @@ annotation: {
   path: 2
   path: 3
   sourceFile: 
-  begin: 3955
-  end: 3975
+  begin: 3850
+  end: 3868
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 3
+  sourceFile: 
+  begin: 3960
+  end: 3980
 }

--- a/protoc_plugin/test/goldens/messageGeneratorEnums
+++ b/protoc_plugin/test/goldens/messageGeneratorEnums
@@ -12,7 +12,7 @@ class PhoneNumber_PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneNumber_PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneNumber_PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneNumber_PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneNumber_PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/oneMessage.pb
+++ b/protoc_plugin/test/goldens/oneMessage.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
@@ -18,9 +18,9 @@ class PhoneNumber extends $pb.GeneratedMessage {
 
   PhoneNumber._() : super();
   factory PhoneNumber({
-    $core.String number,
-    $core.int type,
-    $core.String name,
+    $core.String? number,
+    $core.int? type,
+    $core.String? name,
   }) {
     final _result = create();
     if (number != null) {
@@ -53,7 +53,7 @@ class PhoneNumber extends $pb.GeneratedMessage {
   static $pb.PbList<PhoneNumber> createRepeated() => $pb.PbList<PhoneNumber>();
   @$core.pragma('dart2js:noInline')
   static PhoneNumber getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<PhoneNumber>(create);
-  static PhoneNumber _defaultInstance;
+  static PhoneNumber? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get number => $_getSZ(0);

--- a/protoc_plugin/test/goldens/oneMessage.pb.meta
+++ b/protoc_plugin/test/goldens/oneMessage.pb.meta
@@ -2,24 +2,15 @@ annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 373
-  end: 384
+  begin: 374
+  end: 385
 }
 annotation: {
   path: 4
   path: 0
   sourceFile: test
-  begin: 945
-  end: 956
-}
-annotation: {
-  path: 4
-  path: 0
-  path: 2
-  path: 0
-  sourceFile: test
-  begin: 2681
-  end: 2687
+  begin: 946
+  end: 957
 }
 annotation: {
   path: 4
@@ -27,8 +18,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2729
-  end: 2735
+  begin: 2686
+  end: 2692
 }
 annotation: {
   path: 4
@@ -36,8 +27,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2808
-  end: 2817
+  begin: 2734
+  end: 2740
 }
 annotation: {
   path: 4
@@ -45,17 +36,17 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 2860
-  end: 2871
+  begin: 2813
+  end: 2822
 }
 annotation: {
   path: 4
   path: 0
   path: 2
-  path: 1
+  path: 0
   sourceFile: test
-  begin: 2929
-  end: 2933
+  begin: 2865
+  end: 2876
 }
 annotation: {
   path: 4
@@ -63,8 +54,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 2975
-  end: 2979
+  begin: 2934
+  end: 2938
 }
 annotation: {
   path: 4
@@ -72,8 +63,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 3054
-  end: 3061
+  begin: 2980
+  end: 2984
 }
 annotation: {
   path: 4
@@ -81,8 +72,17 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 3104
-  end: 3113
+  begin: 3059
+  end: 3066
+}
+annotation: {
+  path: 4
+  path: 0
+  path: 2
+  path: 1
+  sourceFile: test
+  begin: 3109
+  end: 3118
 }
 annotation: {
   path: 4
@@ -90,8 +90,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3174
-  end: 3178
+  begin: 3179
+  end: 3183
 }
 annotation: {
   path: 4
@@ -99,8 +99,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3225
-  end: 3229
+  begin: 3230
+  end: 3234
 }
 annotation: {
   path: 4
@@ -108,8 +108,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3302
-  end: 3309
+  begin: 3307
+  end: 3314
 }
 annotation: {
   path: 4
@@ -117,6 +117,6 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 3352
-  end: 3361
+  begin: 3357
+  end: 3366
 }

--- a/protoc_plugin/test/goldens/oneMessage.pbjson
+++ b/protoc_plugin/test/goldens/oneMessage.pbjson
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/service.pb
+++ b/protoc_plugin/test/goldens/service.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:async' as $async;
@@ -36,14 +36,14 @@ class Empty extends $pb.GeneratedMessage {
   static $pb.PbList<Empty> createRepeated() => $pb.PbList<Empty>();
   @$core.pragma('dart2js:noInline')
   static Empty getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Empty>(create);
-  static Empty _defaultInstance;
+  static Empty? _defaultInstance;
 }
 
 class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  $async.Future<Empty> ping($pb.ClientContext ctx, Empty request) {
+  $async.Future<Empty> ping($pb.ClientContext? ctx, Empty request) {
     var emptyResponse = Empty();
     return _client.invoke<Empty>(ctx, 'Test', 'Ping', request, emptyResponse);
   }

--- a/protoc_plugin/test/goldens/service.pbserver
+++ b/protoc_plugin/test/goldens/service.pbserver
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 import 'dart:async' as $async;

--- a/protoc_plugin/test/goldens/serviceGenerator.pb.json
+++ b/protoc_plugin/test/goldens/serviceGenerator.pb.json
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: testpkg.proto
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 import 'dart:core' as $core;
@@ -24,7 +24,7 @@ const SomeReply$json = const {
 
 /// Descriptor for `SomeReply`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List someReplyDescriptor = $convert.base64Decode('CglTb21lUmVwbHk=');
-const TestServiceBase$json = const {
+const $core.Map<$core.String, $core.dynamic> TestServiceBase$json = const {
   '1': 'Test',
   '2': const [
     const {'1': 'AMethod', '2': '.testpkg.SomeRequest', '3': '.testpkg.SomeReply'},
@@ -33,7 +33,7 @@ const TestServiceBase$json = const {
 };
 
 @$core.Deprecated('Use testServiceDescriptor instead')
-const TestServiceBase$messageJson = const {
+const $core.Map<$core.String, $core.Map<$core.String, $core.dynamic>> TestServiceBase$messageJson = const {
   '.testpkg.SomeRequest': SomeRequest$json,
   '.testpkg.SomeReply': SomeReply$json,
   '.foo.bar.EmptyMessage': $1.EmptyMessage$json,

--- a/protoc_plugin/test/goldens/topLevelEnum.pb
+++ b/protoc_plugin/test/goldens/topLevelEnum.pb
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 // ignore_for_file: UNDEFINED_SHOWN_NAME
@@ -23,7 +23,7 @@ class PhoneType extends $pb.ProtobufEnum {
   ];
 
   static final $core.Map<$core.int, PhoneType> _byValue = $pb.ProtobufEnum.initByValue(values);
-  static PhoneType valueOf($core.int value) => _byValue[value];
+  static PhoneType? valueOf($core.int value) => _byValue[value];
 
   const PhoneType._($core.int v, $core.String n) : super(v, n);
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbenum.meta
@@ -2,8 +2,8 @@ annotation: {
   path: 5
   path: 0
   sourceFile: test
-  begin: 413
-  end: 422
+  begin: 414
+  end: 423
 }
 annotation: {
   path: 5
@@ -11,8 +11,8 @@ annotation: {
   path: 2
   path: 0
   sourceFile: test
-  begin: 475
-  end: 481
+  begin: 476
+  end: 482
 }
 annotation: {
   path: 5
@@ -20,8 +20,8 @@ annotation: {
   path: 2
   path: 1
   sourceFile: test
-  begin: 603
-  end: 607
+  begin: 604
+  end: 608
 }
 annotation: {
   path: 5
@@ -29,8 +29,8 @@ annotation: {
   path: 2
   path: 2
   sourceFile: test
-  begin: 727
-  end: 731
+  begin: 728
+  end: 732
 }
 annotation: {
   path: 5
@@ -38,6 +38,6 @@ annotation: {
   path: 2
   path: 3
   sourceFile: test
-  begin: 852
-  end: 860
+  begin: 853
+  end: 861
 }

--- a/protoc_plugin/test/goldens/topLevelEnum.pbjson
+++ b/protoc_plugin/test/goldens/topLevelEnum.pbjson
@@ -2,7 +2,7 @@
 //  Generated code. Do not modify.
 //  source: test
 //
-// @dart = 2.7
+// @dart = 2.12
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 import 'dart:core' as $core;

--- a/protoc_plugin/test/hash_code_test.dart
+++ b/protoc_plugin/test/hash_code_test.dart
@@ -3,8 +3,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library hash_code_tests;
-
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart';
 

--- a/protoc_plugin/test/high_tagnumber_test.dart
+++ b/protoc_plugin/test/high_tagnumber_test.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../out/protos/high_tagnumber.pb.dart';
-import '../out/protos/google/protobuf/empty.pb.dart';
-import 'package:test/test.dart';
 import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
+
+import '../out/protos/google/protobuf/empty.pb.dart';
+import '../out/protos/high_tagnumber.pb.dart';
 
 void main() {
   test('round trip 29 bit tag number, binary encoding', () {
@@ -19,7 +20,7 @@ void main() {
   test('unknown fields', () {
     final empty = Empty.fromBuffer((M()..a = 44).writeToBuffer());
     expect(empty.unknownFields.isEmpty, false);
-    expect(empty.unknownFields.getField(M().info_.tagNumber('a')).varints,
+    expect(empty.unknownFields.getField(M().info_.tagNumber('a')!)!.varints,
         [Int64(44)]);
     expect(M.fromBuffer(empty.writeToBuffer()).a, 44);
   });

--- a/protoc_plugin/test/import_public_test.dart
+++ b/protoc_plugin/test/import_public_test.dart
@@ -1,8 +1,8 @@
 #!/usr/bin/env dart
-
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'package:test/test.dart';
 
 import '../out/protos/import_public.pb.dart';

--- a/protoc_plugin/test/import_test.dart
+++ b/protoc_plugin/test/import_test.dart
@@ -2,15 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library import_test;
-
 import 'package:test/test.dart';
 
-import '../out/protos/import_clash.pb.dart' as pb;
 import '../out/protos/foo.pb.dart' as foo;
+import '../out/protos/import_clash.pb.dart' as pb;
 
 void main() {
   test('Import prefixes in generated files do not clash with fields', () {
-    pb.Clasher()..foo = foo.Foo();
+    pb.Clasher().foo = foo.Foo();
   });
 }

--- a/protoc_plugin/test/indenting_writer_test.dart
+++ b/protoc_plugin/test/indenting_writer_test.dart
@@ -3,8 +3,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library indenting_writer_test;
-
 import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:protoc_plugin/src/descriptor.pb.dart';
 import 'package:test/test.dart';

--- a/protoc_plugin/test/json_test.dart
+++ b/protoc_plugin/test/json_test.dart
@@ -6,12 +6,12 @@
 library json_test;
 
 import 'package:fixnum/fixnum.dart';
+import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
-import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/foo.pb.dart' as foo;
+import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/map_enum_value.pb.dart';
-
 import 'test_util.dart';
 
 void main() {
@@ -36,7 +36,8 @@ void main() {
   Matcher expectedJson(String from, String to) {
     var expectedJson = TEST_ALL_TYPES_JSON.replaceAll(from, to);
     return predicate(
-        (message) => message.writeToJson() == expectedJson, 'Incorrect output');
+        (GeneratedMessage message) => message.writeToJson() == expectedJson,
+        'Incorrect output');
   }
 
   test('testUnsignedOutput', () {

--- a/protoc_plugin/test/leading_underscores_test.dart
+++ b/protoc_plugin/test/leading_underscores_test.dart
@@ -3,8 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
 
 import '../out/protos/_leading_underscores.pb.dart';
 

--- a/protoc_plugin/test/map_field_test.dart
+++ b/protoc_plugin/test/map_field_test.dart
@@ -3,10 +3,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library map_field_test;
 
 import 'dart:convert';
 
+import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
 import '../out/protos/map_field.pb.dart';
@@ -329,5 +332,39 @@ void main() {
 
     testValues(TestMap.fromBuffer(testMap.writeToBuffer()));
     testValues(TestMap.fromJson(testMap.writeToJson()));
+  });
+
+  test('Calling getField on map fields using reflective API works.', () {
+    final testMap = TestMap();
+    final mapFieldInfo = testMap.info_.fieldInfo.values
+        .where((fieldInfo) =>
+            fieldInfo is MapFieldInfo && fieldInfo.name == 'int32ToBytesField')
+        .single;
+    final value = testMap.getField(mapFieldInfo.tagNumber);
+    expect(value is Map<int, List<int>>, true);
+  });
+
+  test('named optional arguments in cosntructor', () {
+    final testMap = TestMap(
+      int32ToInt32Field: {1: 11, 2: 22, 3: 33},
+      int32ToStringField: {1: '11', 2: '22', 3: '33'},
+      int32ToBytesField: {
+        1: utf8.encode('11'),
+        2: utf8.encode('22'),
+        3: utf8.encode('33')
+      },
+      int32ToEnumField: {
+        1: TestMap_EnumValue.DEFAULT,
+        2: TestMap_EnumValue.BAR,
+        3: TestMap_EnumValue.BAZ
+      },
+      int32ToMessageField: {
+        1: TestMap_MessageValue(value: 11),
+        2: TestMap_MessageValue(value: 22),
+        3: TestMap_MessageValue(value: 33)
+      },
+      stringToInt32Field: {'1': 11, '2': 22, '3': 33},
+    );
+    _expectMapValuesSet(testMap);
   });
 }

--- a/protoc_plugin/test/map_test.dart
+++ b/protoc_plugin/test/map_test.dart
@@ -5,19 +5,11 @@
 
 library map_test;
 
-import 'package:matcher/src/interfaces.dart';
 import 'package:test/test.dart'
-    show test, expect, predicate, same, throwsA, throwsArgumentError;
+    show test, expect, predicate, same, throwsA, throwsArgumentError, isA;
 
 import '../out/protos/map_api.pb.dart' as pb;
 import '../out/protos/map_api2.pb.dart' as pb2;
-
-Matcher throwsError(Type expectedType, String expectedMessage) =>
-    throwsA(predicate((x) {
-      expect(x.runtimeType, expectedType);
-      expect(x.message, expectedMessage);
-      return true;
-    }));
 
 void main() {
   test("message doesn't implement Map when turned off", () {
@@ -63,8 +55,8 @@ void main() {
     expect(() {
       rec["unknown"] = 123;
     },
-        throwsError(ArgumentError,
-            "field 'unknown' not found in protobuf_unittest.Rec"));
+        throwsA(isA<ArgumentError>().having((p0) => p0.message, 'message',
+            "field 'unknown' not found in protobuf_unittest.Rec")));
   });
 
   test('operator []= throws exception for repeated field', () {
@@ -120,8 +112,8 @@ void main() {
     expect(() {
       rec.remove("str");
     },
-        throwsError(UnsupportedError,
-            "remove() not supported by protobuf_unittest.Rec"));
+        throwsA(isA<UnsupportedError>().having((p0) => p0.message, 'message',
+            "remove() not supported by protobuf_unittest.Rec")));
     expect(rec.str, "hello");
   });
 

--- a/protoc_plugin/test/merge_test.dart
+++ b/protoc_plugin/test/merge_test.dart
@@ -3,8 +3,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library merge_test;
-
 import 'package:fixnum/fixnum.dart';
 import 'package:test/test.dart' show test, expect;
 

--- a/protoc_plugin/test/message_generator_test.dart
+++ b/protoc_plugin/test/message_generator_test.dart
@@ -3,16 +3,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library message_generator_test;
+// @dart=2.11
 
 import 'dart:collection';
+
 import 'package:collection/collection.dart';
 import 'package:protoc_plugin/indenting_writer.dart';
 import 'package:protoc_plugin/protoc.dart';
-import 'package:test/test.dart';
-
 import 'package:protoc_plugin/src/descriptor.pb.dart';
 import 'package:protoc_plugin/src/plugin.pb.dart';
+import 'package:test/test.dart';
 
 import 'golden_file.dart';
 

--- a/protoc_plugin/test/message_test.dart
+++ b/protoc_plugin/test/message_test.dart
@@ -10,10 +10,9 @@ library message_test;
 import 'package:protoc_plugin/src/descriptor.pb.dart' show DescriptorProto;
 import 'package:test/test.dart';
 
-import 'test_util.dart';
-
 import '../out/protos/google/protobuf/unittest.pb.dart';
 import '../out/protos/google/protobuf/unittest.pbjson.dart';
+import 'test_util.dart';
 
 void main() {
   var TEST_REQUIRED_UNINITIALIZED = TestRequired();

--- a/protoc_plugin/test/mirror_util.dart
+++ b/protoc_plugin/test/mirror_util.dart
@@ -9,8 +9,8 @@ import 'dart:mirrors';
 /// Returns the names of the public properties and methods on a class.
 /// (Also visits its superclasses, recursively.)
 Set<String> findMemberNames(String importName, Symbol classSymbol) {
-  var lib = currentMirrorSystem().libraries[Uri.parse(importName)];
-  var cls = lib.declarations[classSymbol] as ClassMirror;
+  var lib = currentMirrorSystem().libraries[Uri.parse(importName)]!;
+  var cls = lib.declarations[classSymbol] as ClassMirror?;
 
   var result = <String>{};
 

--- a/protoc_plugin/test/mixin_test.dart
+++ b/protoc_plugin/test/mixin_test.dart
@@ -1,11 +1,11 @@
+import 'package:protoc_plugin/testing/mixins.dart';
 import 'package:test/test.dart';
 
 import '../out/protos/mixins.pb.dart' as pb;
-import 'package:protoc_plugin/testing/mixins.dart';
 
 void main() {
   group('Proto with Mixin1', () {
-    pb.Mixin1PB proto;
+    late pb.Mixin1PB proto;
 
     setUp(() {
       proto = pb.Mixin1PB();
@@ -24,7 +24,7 @@ void main() {
   });
 
   group('Proto with Mixin2', () {
-    pb.Mixin2PB proto;
+    late pb.Mixin2PB proto;
 
     setUp(() {
       proto = pb.Mixin2PB();
@@ -39,7 +39,7 @@ void main() {
   });
 
   group('Proto without mixins', () {
-    pb.NoMixinPB proto;
+    late pb.NoMixinPB proto;
 
     setUp(() {
       proto = pb.NoMixinPB();
@@ -52,7 +52,7 @@ void main() {
   });
 
   group('Proto with Mixin3', () {
-    pb.Mixin3PB proto;
+    late pb.Mixin3PB proto;
 
     setUp(() {
       proto = pb.Mixin3PB();

--- a/protoc_plugin/test/names_test.dart
+++ b/protoc_plugin/test/names_test.dart
@@ -2,12 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library dart_name_test;
 
-import 'package:test/test.dart';
 import 'package:protoc_plugin/names.dart' as names;
-import 'package:protoc_plugin/src/descriptor.pb.dart';
 import 'package:protoc_plugin/src/dart_options.pb.dart';
+import 'package:protoc_plugin/src/descriptor.pb.dart';
+import 'package:test/test.dart';
 
 import '../out/protos/dart_name.pb.dart' as pb;
 import '../out/protos/json_name.pb.dart' as json_name;
@@ -85,8 +87,8 @@ void main() {
   });
 
   test('message classes renamed to avoid Function keyword', () {
-    pb.Function_()..fun = 'renamed';
-    pb.Function__()..fun1 = 'also renamed';
+    pb.Function_().fun = 'renamed';
+    pb.Function__().fun1 = 'also renamed';
   });
 
   test('disambiguateName', () {

--- a/protoc_plugin/test/omit_enum_names_test.dart
+++ b/protoc_plugin/test/omit_enum_names_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
 @pragma('dart2js:noInline')

--- a/protoc_plugin/test/omit_field_names_test.dart
+++ b/protoc_plugin/test/omit_field_names_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
 @pragma('dart2js:noInline')

--- a/protoc_plugin/test/omit_message_names_test.dart
+++ b/protoc_plugin/test/omit_message_names_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
+
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
 @pragma('dart2js:noInline')

--- a/protoc_plugin/test/oneof_test.dart
+++ b/protoc_plugin/test/oneof_test.dart
@@ -165,7 +165,7 @@ void main() {
     expectOneofNotSet(foo);
     var copy1 = foo.deepCopy().freeze().rebuild((_) {}) as Foo;
     expectOneofNotSet(copy1);
-    foo..first = 'oneof';
+    foo.first = 'oneof';
     expectFirstSet(foo);
     var copy2 = foo.deepCopy().freeze().rebuild((_) {}) as Foo;
     expectFirstSet(copy2);

--- a/protoc_plugin/test/proto3_json_test.dart
+++ b/protoc_plugin/test/proto3_json_test.dart
@@ -9,6 +9,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
+import '../out/protos/enum_name.pb.dart';
 import '../out/protos/google/protobuf/any.pb.dart';
 import '../out/protos/google/protobuf/duration.pb.dart';
 import '../out/protos/google/protobuf/empty.pb.dart';
@@ -16,14 +17,12 @@ import '../out/protos/google/protobuf/field_mask.pb.dart';
 import '../out/protos/google/protobuf/struct.pb.dart';
 import '../out/protos/google/protobuf/timestamp.pb.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
-
 import '../out/protos/google/protobuf/unittest_well_known_types.pb.dart';
 import '../out/protos/google/protobuf/wrappers.pb.dart';
-import '../out/protos/enum_name.pb.dart';
 import '../out/protos/map_field.pb.dart';
 import '../out/protos/oneof.pb.dart';
-import 'test_util.dart';
 import 'oneof_test.dart';
+import 'test_util.dart';
 
 final testAllTypesJson = {
   'optionalInt32': 101,
@@ -346,7 +345,7 @@ void main() {
     Matcher parseFailure(List<String> expectedPath) => throwsA(predicate((e) {
           if (e is FormatException) {
             final pathExpression =
-                RegExp(r'root(\["[^"]*"]*\])*').firstMatch(e.message)[0];
+                RegExp(r'root(\["[^"]*"]*\])*').firstMatch(e.message)![0]!;
             final actualPath = RegExp(r'\["([^"]*)"\]')
                 .allMatches(pathExpression)
                 .map((match) => match[1])
@@ -411,7 +410,7 @@ void main() {
       expect(
           TestAllTypes()..mergeFromProto3Json({'optionalNestedEnum': 1}),
           TestAllTypes()
-            ..optionalNestedEnum = TestAllTypes_NestedEnum.valueOf(1));
+            ..optionalNestedEnum = TestAllTypes_NestedEnum.valueOf(1)!);
       expect(TestAllTypes()..mergeFromProto3Json({'repeatedBool': null}),
           TestAllTypes());
       expect(() => TestAllTypes()..mergeFromProto3Json({'repeatedBool': 100}),

--- a/protoc_plugin/test/protoc_options_test.dart
+++ b/protoc_plugin/test/protoc_options_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library protoc_options_test;
 
 import 'package:protoc_plugin/src/plugin.pb.dart';

--- a/protoc_plugin/test/reserved_names_test.dart
+++ b/protoc_plugin/test/reserved_names_test.dart
@@ -6,23 +6,21 @@
 @TestOn("vm")
 library reserved_names_test;
 
-import 'package:test/test.dart';
+import 'dart:collection' show MapMixin;
+import 'dart:mirrors';
 
 import 'package:protobuf/meta.dart'
     show GeneratedMessage_reservedNames, ProtobufEnum_reservedNames;
-import 'package:protoc_plugin/mixins.dart' show findMixin;
-
-import 'mirror_util.dart' show findMemberNames;
-
 // Import the libraries we will access via the mirrors.
 // ignore_for_file: unused_import
 import 'package:protobuf/protobuf.dart' show GeneratedMessage, ProtobufEnum;
 import 'package:protobuf/src/protobuf/mixins/event_mixin.dart'
     show PbEventMixin;
 import 'package:protobuf/src/protobuf/mixins/map_mixin.dart' show PbMapMixin;
-import 'dart:collection' show MapMixin;
+import 'package:protoc_plugin/mixins.dart' show findMixin;
+import 'package:test/test.dart';
 
-import 'dart:mirrors';
+import 'mirror_util.dart' show findMemberNames;
 
 void main() {
   test('GeneratedMessage reserved names are up to date', () {
@@ -54,13 +52,13 @@ void main() {
     for (var name in mixinNames) {
       if (name == "ReadonlyMessageMixin" || name == "unknownFields") continue;
       if (!reservedNames.contains(name)) {
-        fail("name from ReadonlyMessageMixin is not reserved: ${name}");
+        fail("name from ReadonlyMessageMixin is not reserved: $name");
       }
     }
   });
 
   test('PbMapMixin reserved names are up to date', () {
-    var meta = findMixin("PbMapMixin");
+    var meta = findMixin("PbMapMixin")!;
     var actual = Set<String>.from(meta.findReservedNames());
 
     var expected = findMemberNames(meta.importFrom, #PbMapMixin)
@@ -74,7 +72,7 @@ void main() {
   });
 
   test('PbEventMixin reserved names are up to date', () {
-    var meta = findMixin("PbEventMixin");
+    var meta = findMixin("PbEventMixin")!;
     var actual = Set<String>.from(meta.findReservedNames());
 
     var expected = findMemberNames(meta.importFrom, #PbEventMixin)

--- a/protoc_plugin/test/send_protos_via_sendports_test.dart
+++ b/protoc_plugin/test/send_protos_via_sendports_test.dart
@@ -1,0 +1,59 @@
+#!/usr/bin/env dart
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:test/test.dart';
+
+import '../out/protos/foo.pb.dart';
+import '../out/protos/map_field.pb.dart' as map;
+
+Future<T> sendReceive<T>(T object) async {
+  final rp = ReceivePort();
+  rp.sendPort.send(object);
+  return (await rp.first) as T;
+}
+
+Future main() async {
+  test('Normal proto can be transferred via ports', () async {
+    final object = Outer()
+      ..inner = (Inner()..value = 'pip')
+      ..inners.add(Inner()..value = 'pop');
+
+    final clone = await sendReceive(object);
+
+    // Ensure the clone is actually containing the same data.
+    expect(clone, equals(object));
+    expect(clone.toString(), equals(object.toString()));
+    expect(clone.toDebugString(), equals(object.toDebugString()));
+    expect(clone.writeToBuffer(), equals(object.writeToBuffer()));
+
+    // Ensure the actual objects got transitively cloned, but the metadata in
+    // the `_info_` did not get cloned.
+    expect(!identical(object, clone), true);
+    expect(!identical(object.inner, clone.inner), true);
+    expect(identical(object.info_, clone.info_), true);
+  }, onPlatform: {'js': Skip('dart:isolate only works on Dart VM')});
+
+  test('Map-using proto can be transferred via ports', () async {
+    final object = map.TestMap()
+      ..int32ToMessageField[42] = (map.TestMap_MessageValue()
+        ..value = 1
+        ..secondValue = 2);
+
+    final clone = await sendReceive(object);
+
+    // Ensure the clone is actually containing the same data.
+    expect(clone, equals(object));
+    expect(clone.toString(), equals(object.toString()));
+    expect(clone.toDebugString(), equals(object.toDebugString()));
+    expect(clone.writeToBuffer(), equals(object.writeToBuffer()));
+
+    // Ensure the actual objects got transitively cloned, but the metadata in
+    // the `_info_` did not get cloned.
+    expect(!identical(object, clone), true);
+    expect(identical(object.info_, clone.info_), true);
+  }, onPlatform: {'js': Skip('dart:isolate only works on Dart VM')});
+}

--- a/protoc_plugin/test/service_generator_test.dart
+++ b/protoc_plugin/test/service_generator_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library service_generator_test;
 
 import 'package:protoc_plugin/indenting_writer.dart';

--- a/protoc_plugin/test/service_test.dart
+++ b/protoc_plugin/test/service_test.dart
@@ -59,7 +59,7 @@ class FakeJsonClient implements RpcClient {
 
   @override
   Future<T> invoke<T extends GeneratedMessage>(
-      ClientContext ctx,
+      ClientContext? ctx,
       String serviceName,
       String methodName,
       GeneratedMessage request,
@@ -109,7 +109,7 @@ void main() {
     ]);
 
     String readMessageName(fqname) {
-      var json = map[fqname];
+      var json = map[fqname]!;
       var descriptor = DescriptorProto()..mergeFromJsonMap(json);
       return descriptor.name;
     }

--- a/protoc_plugin/test/test_util.dart
+++ b/protoc_plugin/test/test_util.dart
@@ -13,12 +13,12 @@ import '../out/protos/google/protobuf/unittest_import.pb.dart';
 
 final Matcher throwsATypeError = throwsA(TypeMatcher<TypeError>());
 
-Int64 make64(int lo, [int hi]) {
+Int64 make64(int lo, [int? hi]) {
   hi ??= lo < 0 ? -1 : 0;
   return Int64.fromInts(hi, lo);
 }
 
-Matcher expect64(int lo, [int hi]) {
+Matcher expect64(int lo, [int? hi]) {
   final expected = make64(lo, hi);
   return predicate((Int64 actual) => actual == expected);
 }
@@ -1414,23 +1414,21 @@ void setAllExtensions(TestAllExtensions message) {
   message.setExtension(Unittest.optionalStringExtension, '115');
   message.setExtension(Unittest.optionalBytesExtension, '116'.codeUnits);
 
-  var msg;
-
-  msg = OptionalGroup_extension();
+  var msg = OptionalGroup_extension();
   msg.a = 117;
   message.setExtension(Unittest.optionalGroupExtension, msg);
 
-  msg = TestAllTypes_NestedMessage();
-  msg.bb = 118;
-  message.setExtension(Unittest.optionalNestedMessageExtension, msg);
+  var msg2 = TestAllTypes_NestedMessage();
+  msg2.bb = 118;
+  message.setExtension(Unittest.optionalNestedMessageExtension, msg2);
 
-  msg = ForeignMessage();
-  msg.c = 119;
-  message.setExtension(Unittest.optionalForeignMessageExtension, msg);
+  var msg3 = ForeignMessage();
+  msg3.c = 119;
+  message.setExtension(Unittest.optionalForeignMessageExtension, msg3);
 
-  msg = ImportMessage();
-  msg.d = 120;
-  message.setExtension(Unittest.optionalImportMessageExtension, msg);
+  var msg4 = ImportMessage();
+  msg4.d = 120;
+  message.setExtension(Unittest.optionalImportMessageExtension, msg4);
 
   message.setExtension(
       Unittest.optionalNestedEnumExtension, TestAllTypes_NestedEnum.BAZ);
@@ -1460,21 +1458,21 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '215');
   message.addExtension(Unittest.repeatedBytesExtension, '216'.codeUnits);
 
-  msg = RepeatedGroup_extension();
-  msg.a = 217;
-  message.addExtension(Unittest.repeatedGroupExtension, msg);
+  var msg5 = RepeatedGroup_extension();
+  msg5.a = 217;
+  message.addExtension(Unittest.repeatedGroupExtension, msg5);
 
-  msg = TestAllTypes_NestedMessage();
-  msg.bb = 218;
-  message.addExtension(Unittest.repeatedNestedMessageExtension, msg);
+  var msg6 = TestAllTypes_NestedMessage();
+  msg6.bb = 218;
+  message.addExtension(Unittest.repeatedNestedMessageExtension, msg6);
 
-  msg = ForeignMessage();
-  msg.c = 219;
-  message.addExtension(Unittest.repeatedForeignMessageExtension, msg);
+  var msg7 = ForeignMessage();
+  msg7.c = 219;
+  message.addExtension(Unittest.repeatedForeignMessageExtension, msg7);
 
-  msg = ImportMessage();
-  msg.d = 220;
-  message.addExtension(Unittest.repeatedImportMessageExtension, msg);
+  var msg8 = ImportMessage();
+  msg8.d = 220;
+  message.addExtension(Unittest.repeatedImportMessageExtension, msg8);
 
   message.addExtension(
       Unittest.repeatedNestedEnumExtension, TestAllTypes_NestedEnum.BAR);
@@ -1503,21 +1501,21 @@ void setAllExtensions(TestAllExtensions message) {
   message.addExtension(Unittest.repeatedStringExtension, '315');
   message.addExtension(Unittest.repeatedBytesExtension, '316'.codeUnits);
 
-  msg = RepeatedGroup_extension();
-  msg.a = 317;
-  message.addExtension(Unittest.repeatedGroupExtension, msg);
+  var msg9 = RepeatedGroup_extension();
+  msg9.a = 317;
+  message.addExtension(Unittest.repeatedGroupExtension, msg9);
 
-  msg = TestAllTypes_NestedMessage();
-  msg.bb = 318;
-  message.addExtension(Unittest.repeatedNestedMessageExtension, msg);
+  var msg10 = TestAllTypes_NestedMessage();
+  msg10.bb = 318;
+  message.addExtension(Unittest.repeatedNestedMessageExtension, msg10);
 
-  msg = ForeignMessage();
-  msg.c = 319;
-  message.addExtension(Unittest.repeatedForeignMessageExtension, msg);
+  var msg11 = ForeignMessage();
+  msg11.c = 319;
+  message.addExtension(Unittest.repeatedForeignMessageExtension, msg11);
 
-  msg = ImportMessage();
-  msg.d = 320;
-  message.addExtension(Unittest.repeatedImportMessageExtension, msg);
+  var msg12 = ImportMessage();
+  msg12.d = 320;
+  message.addExtension(Unittest.repeatedImportMessageExtension, msg12);
 
   message.addExtension(
       Unittest.repeatedNestedEnumExtension, TestAllTypes_NestedEnum.BAZ);

--- a/protoc_plugin/test/to_builder_test.dart
+++ b/protoc_plugin/test/to_builder_test.dart
@@ -4,9 +4,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+
+import 'package:fixnum/fixnum.dart' show Int64;
 import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
-import 'package:fixnum/fixnum.dart' show Int64;
+
 import '../out/protos/foo.pb.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
@@ -88,8 +90,8 @@ void main() {
   });
 
   group('map properties behave correctly', () {
-    OuterWithMap original;
-    OuterWithMap outerBuilder;
+    late OuterWithMap original;
+    late OuterWithMap outerBuilder;
     setUp(() {
       original = OuterWithMap()
         ..innerMap[1] = (Inner()..value = 'mapInner')
@@ -102,23 +104,23 @@ void main() {
     });
     test('the builder is mutable', () {
       outerBuilder.innerMap[1] = (Inner()..value = 'mob');
-      expect(outerBuilder.innerMap[1].value, 'mob');
+      expect(outerBuilder.innerMap[1]!.value, 'mob');
     });
   });
 
   group('frozen unknown fields', () {
-    Inner inner;
-    TestEmptyMessage emptyMessage;
-    int tagNumber;
-    UnknownFieldSet unknownFieldSet;
-    UnknownFieldSetField field;
+    late Inner inner;
+    late TestEmptyMessage emptyMessage;
+    late int tagNumber;
+    late UnknownFieldSet unknownFieldSet;
+    late UnknownFieldSetField field;
 
     setUp(() {
       inner = Inner()..value = 'bob';
       emptyMessage = TestEmptyMessage.fromBuffer(inner.writeToBuffer());
-      tagNumber = inner.getTagNumber('value');
+      tagNumber = inner.getTagNumber('value')!;
       unknownFieldSet = emptyMessage.unknownFields;
-      field = unknownFieldSet.getField(tagNumber);
+      field = unknownFieldSet.getField(tagNumber)!;
     });
 
     test('can read from a frozen unknown fieldset', () {
@@ -127,7 +129,7 @@ void main() {
 
       emptyMessage.freeze();
       unknownFieldSet = emptyMessage.unknownFields;
-      field = unknownFieldSet.getField(tagNumber);
+      field = unknownFieldSet.getField(tagNumber)!;
 
       expect(unknownFieldSet.hasField(tagNumber), isTrue);
       expect(field.lengthDelimited[0], utf8.encode(inner.value));
@@ -135,19 +137,19 @@ void main() {
 
     test('can add fields to a builder with unknown fields', () {
       emptyMessage.freeze();
-      final builder = emptyMessage.toBuilder();
+      var builder = emptyMessage.toBuilder() as TestEmptyMessage;
 
       builder.unknownFields
           .addField(2, UnknownFieldSetField()..fixed32s.add(42));
-      expect(builder.unknownFields.getField(2).fixed32s[0], 42);
+      expect(builder.unknownFields.getField(2)!.fixed32s[0], 42);
     });
 
     test('cannot mutate already added UnknownFieldSetField on builder', () {
       emptyMessage.freeze();
-      final builder = emptyMessage.toBuilder();
+      var builder = emptyMessage.toBuilder() as TestEmptyMessage;
 
       expect(
-          () => builder.unknownFields.getField(1).lengthDelimited[0] =
+          () => builder.unknownFields.getField(1)!.lengthDelimited[0] =
               utf8.encode('alice'),
           throwsA(TypeMatcher<UnsupportedError>()));
     });

--- a/protoc_plugin/test/unknown_field_set_test.dart
+++ b/protoc_plugin/test/unknown_field_set_test.dart
@@ -9,7 +9,6 @@ import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
 import '../out/protos/google/protobuf/unittest.pb.dart';
-
 import 'test_util.dart';
 
 void main() {
@@ -19,9 +18,9 @@ void main() {
   var unknownFields = emptyMessage.unknownFields;
 
   UnknownFieldSetField getField(String name) {
-    var tagNumber = testAllTypes.getTagNumber(name);
+    var tagNumber = testAllTypes.getTagNumber(name)!;
     assert(unknownFields.hasField(tagNumber));
-    return unknownFields.getField(tagNumber);
+    return unknownFields.getField(tagNumber)!;
   }
 
   // Asserts that the given field sets are not equal and have different
@@ -72,14 +71,13 @@ void main() {
   });
 
   test('testGroup', () {
-    var tagNumberA = TestAllTypes_OptionalGroup().getTagNumber('a');
-    expect(tagNumberA != null, isTrue);
+    var tagNumberA = TestAllTypes_OptionalGroup().getTagNumber('a')!;
 
     var optionalGroupField = getField('optionalgroup');
     expect(optionalGroupField.groups.length, 1);
     var group = optionalGroupField.groups[0];
     expect(group.hasField(tagNumberA), isTrue);
-    expect(group.getField(tagNumberA).varints[0],
+    expect(group.getField(tagNumberA)!.varints[0],
         expect64(testAllTypes.optionalGroup.a));
   });
 
@@ -146,7 +144,7 @@ void main() {
     assertAllFieldsSet(destination);
     expect(destination.unknownFields.asMap().length, 1);
 
-    var field = destination.unknownFields.getField(123456);
+    var field = destination.unknownFields.getField(123456)!;
     expect(field.varints.length, 1);
     expect(field.varints[0], expect64(654321));
   });
@@ -209,10 +207,8 @@ void main() {
   });
 
   test('testParseUnknownEnumValue', () {
-    var singularFieldNum = testAllTypes.getTagNumber('optionalNestedEnum');
-    var repeatedFieldNum = testAllTypes.getTagNumber('repeatedNestedEnum');
-    expect(singularFieldNum, isNotNull);
-    expect(repeatedFieldNum, isNotNull);
+    var singularFieldNum = testAllTypes.getTagNumber('optionalNestedEnum')!;
+    var repeatedFieldNum = testAllTypes.getTagNumber('repeatedNestedEnum')!;
 
     var fieldSet = UnknownFieldSet()
       ..addField(
@@ -236,11 +232,11 @@ void main() {
       expect(message.repeatedNestedEnum,
           [TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAZ]);
       final singularVarints =
-          message.unknownFields.getField(singularFieldNum).varints;
+          message.unknownFields.getField(singularFieldNum)!.varints;
       expect(singularVarints.length, 1);
       expect(singularVarints[0], expect64(5));
       final repeatedVarints =
-          message.unknownFields.getField(repeatedFieldNum).varints;
+          message.unknownFields.getField(repeatedFieldNum)!.varints;
       expect(repeatedVarints.length, 2);
       expect(repeatedVarints[0], expect64(4));
       expect(repeatedVarints[1], expect64(6));
@@ -254,11 +250,11 @@ void main() {
       expect(message.getExtension(Unittest.repeatedNestedEnumExtension),
           [TestAllTypes_NestedEnum.FOO, TestAllTypes_NestedEnum.BAZ]);
       final singularVarints =
-          message.unknownFields.getField(singularFieldNum).varints;
+          message.unknownFields.getField(singularFieldNum)!.varints;
       expect(singularVarints.length, 1);
       expect(singularVarints[0], expect64(5));
       final repeatedVarints =
-          message.unknownFields.getField(repeatedFieldNum).varints;
+          message.unknownFields.getField(repeatedFieldNum)!.varints;
       expect(repeatedVarints.length, 2);
       expect(repeatedVarints[0], expect64(4));
       expect(repeatedVarints[1], expect64(6));
@@ -274,7 +270,7 @@ void main() {
 
     var parsed = UnknownFieldSet()
       ..mergeFromCodedBufferReader(CodedBufferReader(writer.toBuffer()));
-    var field = parsed.getField(1);
+    var field = parsed.getField(1)!;
     expect(field.varints.length, 1);
     expect(field.varints[0], expect64(0x7FFFFFFF, 0xFFFFFFFFF));
   });

--- a/protoc_plugin/test/validate_fail_test.dart
+++ b/protoc_plugin/test/validate_fail_test.dart
@@ -3,6 +3,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.11
+
 library validate_fail_test;
 
 import 'package:fixnum/fixnum.dart';

--- a/protoc_plugin/test/wire_format_test.dart
+++ b/protoc_plugin/test/wire_format_test.dart
@@ -9,7 +9,6 @@ import 'package:protobuf/protobuf.dart';
 import 'package:test/test.dart';
 
 import '../out/protos/google/protobuf/unittest.pb.dart';
-
 import 'test_util.dart';
 
 void main() {

--- a/query_benchmark/bin/decode.dart
+++ b/query_benchmark/bin/decode.dart
@@ -7,7 +7,8 @@ import 'package:query_benchmark/benchmark.dart';
 import 'package:query_benchmark/readfile.dart';
 
 main() {
-  String path = const String.fromEnvironment('testfile') ?? 'testdata/500.pb';
+  final path =
+      const String.fromEnvironment('testfile', defaultValue: 'testdata/500.pb');
 
   List<int> encoded = readfile(path);
   print(

--- a/query_benchmark/bin/decode_json.dart
+++ b/query_benchmark/bin/decode_json.dart
@@ -7,7 +7,8 @@ import 'package:query_benchmark/benchmark.dart';
 import 'package:query_benchmark/readfile.dart';
 
 main() {
-  String path = const String.fromEnvironment('testfile') ?? 'testdata/500.pb';
+  final path =
+      const String.fromEnvironment('testfile', defaultValue: 'testdata/500.pb');
 
   List<int> encoded = readfile(path);
   f0.A0 a = f0.A0.fromBuffer(encoded);

--- a/query_benchmark/bin/encode.dart
+++ b/query_benchmark/bin/encode.dart
@@ -7,7 +7,9 @@ import 'package:query_benchmark/benchmark.dart';
 import 'package:query_benchmark/readfile.dart';
 
 main() {
-  String path = const String.fromEnvironment('testfile') ?? 'testdata/500.pb';
+  final path =
+      const String.fromEnvironment('testfile', defaultValue: 'testdata/500.pb');
+
   List<int> encoded = readfile(path);
   f0.A0 a = f0.A0.fromBuffer(encoded);
   print(

--- a/query_benchmark/bin/encode_json.dart
+++ b/query_benchmark/bin/encode_json.dart
@@ -7,7 +7,8 @@ import 'package:query_benchmark/benchmark.dart';
 import 'package:query_benchmark/readfile.dart';
 
 main() {
-  String path = const String.fromEnvironment('testfile') ?? 'testdata/500.pb';
+  final path =
+      const String.fromEnvironment('testfile', defaultValue: 'testdata/500.pb');
 
   List<int> encoded = readfile(path);
   f0.A0 a = f0.A0.fromBuffer(encoded);

--- a/query_benchmark/bin/set_nested_value.dart
+++ b/query_benchmark/bin/set_nested_value.dart
@@ -2,23 +2,25 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:query_benchmark/generated/f0.pb.dart' as f0;
-import 'package:query_benchmark/generated/f2.pb.dart' as f2;
-import 'package:query_benchmark/generated/f19.pb.dart' as f19;
+import 'package:protobuf/protobuf.dart';
 import 'package:query_benchmark/benchmark.dart';
+import 'package:query_benchmark/generated/f0.pb.dart' as f0;
+import 'package:query_benchmark/generated/f19.pb.dart' as f19;
+import 'package:query_benchmark/generated/f2.pb.dart' as f2;
 import 'package:query_benchmark/readfile.dart';
 
 main() {
-  String path = const String.fromEnvironment('testfile') ?? 'testdata/500.pb';
+  final path =
+      const String.fromEnvironment('testfile', defaultValue: 'testdata/500.pb');
 
   List<int> encoded = readfile(path);
   f0.A0 a = f0.A0.fromBuffer(encoded)..freeze();
   print(
     formatReport(
       title: 'protobuf_decode',
-      duration: measure(() => a.copyWith((f0.A0 a0Builder) {
-            a0Builder.a4.last = a0Builder.a4.last.copyWith((f2.A1 a1builder) {
-              a1builder.a378.copyWith(
+      duration: measure(() => a.rebuild((f0.A0 a0Builder) {
+            a0Builder.a4.last = a0Builder.a4.last.rebuild((f2.A1 a1builder) {
+              a1builder.a378.rebuild(
                   (f19.A220 a220builder) => a220builder.a234 = 'new_value');
             });
           })),

--- a/query_benchmark/lib/benchmark.dart
+++ b/query_benchmark/lib/benchmark.dart
@@ -17,6 +17,6 @@ Duration measure(void Function() f,
   return s.elapsed ~/ iterations;
 }
 
-String formatReport({String title, Duration duration}) {
+String formatReport({required String title, required Duration duration}) {
   return "RunTimeRaw($title): ${duration.inMicroseconds} us";
 }

--- a/query_benchmark/mono_pkg.yaml
+++ b/query_benchmark/mono_pkg.yaml
@@ -1,10 +1,11 @@
 # See https://github.com/dart-lang/mono_repo for details
 
+dart:
 stages:
   - format_analyze:
     - group:
+      - format
       - command: ./../tool/setup.sh
       - command: ./compile_protos.sh
-      - format
-      - analyze
-      dart: [dev]
+      - analyze: --fatal-infos
+      dart: dev

--- a/query_benchmark/pubspec.yaml
+++ b/query_benchmark/pubspec.yaml
@@ -6,7 +6,7 @@ name: query_benchmark
 description: Measuring encoding and decoding of a "real-world" protobuf.
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   protobuf:

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -68,28 +68,16 @@ for PKG in ${PKGS}; do
       echo -e "\033[1mPKG: ${PKG}; TASK: ${TASK}\033[22m"
       case ${TASK} in
       analyze_0)
-        echo 'dart analyze'
-        dart analyze || EXIT_CODE=$?
+        echo 'dart analyze --fatal-infos'
+        dart analyze --fatal-infos || EXIT_CODE=$?
         ;;
       analyze_1)
-        echo 'dart analyze --fatal-infos lib'
-        dart analyze --fatal-infos lib || EXIT_CODE=$?
-        ;;
-      analyze_2)
-        echo 'dart analyze --fatal-infos test'
-        dart analyze --fatal-infos test || EXIT_CODE=$?
-        ;;
-      analyze_3)
         echo 'dart analyze lib'
         dart analyze lib || EXIT_CODE=$?
         ;;
-      analyze_4)
+      analyze_2)
         echo 'dart analyze test'
         dart analyze test || EXIT_CODE=$?
-        ;;
-      analyze_5)
-        echo 'dart analyze --fatal-infos'
-        dart analyze --fatal-infos || EXIT_CODE=$?
         ;;
       command_0)
         echo './../tool/setup.sh'


### PR DESCRIPTION
- Null safe package:protobuf and null safe code generation (#435)
- Merge master into null_safety (#438)
- Set protoc_plugin version to 20.0.0-nullsafety.0 (#439)
- Regenerate bootstrap protos with previous version of protoc_plugin (#440)
- Allow dart protos to be sent through sendports (and therefore to other isolates) (#452)
- Restore possibility to use reflective API to create default field values using getField() (#453)
- Prepare query_benchmark/ for NNBD (#451)
- Let protoc_plugin depend on protobuf from null-safety and fix changelog. (#456)
- named optional arguments in constructors for messages (#441)
- Merge master into null safety (#463)
- Use null-safe bootstrap protos (#464)
- Generate null-safe .pbgrpc files (#466)
- Stable null safety release of protobuf (#473)
- Stable release of protoc_plugin for null safety (#474)
- Fix protoc_plugin publish errors and warnings (#475)
- Fix lints (#488)
- null safe cleanup (#525)
